### PR TITLE
Use RustLSP library.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,12 +6,12 @@ dependencies = [
  "derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "languageserver-types 0.5.0 (git+https://github.com/gluon-lang/languageserver-types)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.0 (git+https://github.com/phildawes/racer)",
  "rls-analysis 0.1.0 (git+https://github.com/nrc/rls-analysis)",
  "rls-span 0.1.0 (git+https://github.com/nrc/rls-span)",
  "rls-vfs 0.1.0 (git+https://github.com/nrc/rls-vfs)",
+ "rust_lsp 0.6.0 (git+https://github.com/RustDT/RustLSP)",
  "rustfmt 0.6.3 (git+https://github.com/rust-lang-nursery/rustfmt)",
  "serde 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -231,6 +231,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,8 +355,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "languageserver-types"
-version = "0.5.0"
-source = "git+https://github.com/gluon-lang/languageserver-types#7c747c9a5d9ec9879b111e7ca583da650d0d86c1"
+version = "0.6.1"
+source = "git+https://github.com/gluon-lang/languageserver-types#a8d3600f54b2932c140783c76ef23cadd22a64eb"
 dependencies = [
  "enum_primitive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -630,6 +638,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_lsp"
+version = "0.6.0"
+source = "git+https://github.com/RustDT/RustLSP#5080c14f33e3a6d9d7aede0fb4de963d53db7e27"
+dependencies = [
+ "languageserver-types 0.6.1 (git+https://github.com/gluon-lang/languageserver-types)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustdt-json_rpc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustdt_util 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +662,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rustdt-json_rpc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustdt_util 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustdt_util"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustfmt"
@@ -1051,6 +1089,7 @@ dependencies = [
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
 "checksum fs2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "640001e1bd865c7c32806292822445af576a6866175b5225aa2087ca5e3de551"
+"checksum futures 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "177a82a61dd7e528022ce97f24e54b499dd2fee4d4646a0f283c5fb500dbfe20"
 "checksum gcc 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "872db9e59486ef2b14f8e8c10e9ef02de2bccef6363d7f34835dedb386b3d950"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
@@ -1065,7 +1104,7 @@ dependencies = [
 "checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum languageserver-types 0.5.0 (git+https://github.com/gluon-lang/languageserver-types)" = "<none>"
+"checksum languageserver-types 0.6.1 (git+https://github.com/gluon-lang/languageserver-types)" = "<none>"
 "checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
 "checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
 "checksum libgit2-sys 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "502e50bcdcfa98df366bdd54935bff856f4cf11f725daa608092c0288205887a"
@@ -1098,8 +1137,11 @@ dependencies = [
 "checksum rls-analysis 0.1.0 (git+https://github.com/nrc/rls-analysis)" = "<none>"
 "checksum rls-span 0.1.0 (git+https://github.com/nrc/rls-span)" = "<none>"
 "checksum rls-vfs 0.1.0 (git+https://github.com/nrc/rls-vfs)" = "<none>"
+"checksum rust_lsp 0.6.0 (git+https://github.com/RustDT/RustLSP)" = "<none>"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum rustdt-json_rpc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4c31d27be068eab063ca422ce1ac6b6060dd16cbb233425cc33eff4b43008cbc"
+"checksum rustdt_util 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7cfffa8a89d8758be2dd5605c5fc62bce055af2491ebf3ce953d4d31512c59fd"
 "checksum rustfmt 0.6.3 (git+https://github.com/rust-lang-nursery/rustfmt)" = "<none>"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae2ff60ecdb19c255841c066cbfa5f8c2a4ada1eb3ae47c77ab6667128da71f5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Jonathan Turner <jturner@mozilla.com>"]
 cargo = { path = "../cargo" }
 derive-new = "0.3"
 env_logger = "0.3"
-languageserver-types = { version = "0.5.0", git = "https://github.com/gluon-lang/languageserver-types" }
+rust_lsp = { version = "0.6.0", git = "https://github.com/RustDT/RustLSP" }
 log = "0.3"
 racer = { git = "https://github.com/phildawes/racer" }
 rls-span = { git = "https://github.com/nrc/rls-span" }

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -8,13 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Debug;
 use std::path::PathBuf;
 use std::error::Error;
 
 use analysis::raw;
 use hyper::Url;
-use serde::Serialize;
 use span;
 
 pub use ls_types::*;
@@ -112,24 +110,3 @@ pub fn source_kind_from_def_kind(k: raw::DefKind) -> SymbolKind {
     }
 }
 
-/* -----------------  JSON-RPC protocol types ----------------- */
-
-/// An event-like (no response needed) notification message.
-#[derive(Debug, Serialize)]
-pub struct NotificationMessage<T>
-    where T: Debug + Serialize
-{
-    jsonrpc: &'static str,
-    pub method: String,
-    pub params: T,
-}
-
-impl <T> NotificationMessage<T> where T: Debug + Serialize {
-    pub fn new(method: String, params: T) -> Self {
-        NotificationMessage {
-            jsonrpc: "2.0",
-            method: method,
-            params: params
-        }
-    }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,8 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 
-extern crate languageserver_types as ls_types;
+use rust_lsp::ls_types;
+extern crate rust_lsp;
 
 use std::sync::Arc;
 


### PR DESCRIPTION
A more extensive and principled way to handle the LSP protocol. Adds
*interface* support for all LSP requests.

Fixes:
* 'completionItem/resolve' should return CompletionItem not a vector
* Concurrent handling of requests. Requests must be handled in order,
otherwise, for example, text document changes could be applied out of
order. Only read-only requests can conceptually be executed in parallel
(since that would have the same result as if they were processed in
order). See here for more info:
Microsoft/language-server-protocol#12

TODO for RustLSP:
 * Cancel support
 * Support sending requests to client from server 
(only notifications can be sent currently). This is required for one LSP
request: 'window/showMessageRequest'. 
 * Perhaps integrate with https://github.com/ethcore/jsonrpc-core and
share part of the JSON-RPC implementation?