### PR TITLE
Fixed erasing of a document on reformatting if the document has parsing errors.

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -479,8 +479,6 @@ impl ActionHandler {
         match format_input(input, &config, Some(&mut buf)) {
             Ok((summary, ..)) => {
                 // format_input returns Ok even if there are any errors, i.e., parsing errors.
-                // If there are any errors the buffer is empty.
-                // An empty buffer removes the whole content of the document.
                 if summary.has_no_errors() {
                     // Note that we don't need to keep the VFS up to date, the client
                     // echos back the change to us.


### PR DESCRIPTION
Fixed #161.

This is workaround.
I would like to open a PR to the rustfmt's repository, but unfortunately I don't know how to fix the bug in rustfmt.

The bug in rustfmt is that `format_input` returns `Ok` instead of `Err`:
https://github.com/rust-lang-nursery/rustfmt/blob/master/src/lib.rs#L494