### PR TITLE
Add primary label/secondary labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,8 @@ dependencies = [
  "serde_derive 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url_serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ serde = "0.9"
 serde_json = "0.9"
 serde_derive = "0.9"
 toml = "0.1"
+url = "1.1.0"
+url_serde = "0.1.0"
 
 [dependencies.hyper]
 version = "0.9"

--- a/src/actions/compiler_message_parsing.rs
+++ b/src/actions/compiler_message_parsing.rs
@@ -10,9 +10,10 @@
 
 use std::path::PathBuf;
 
-use ls_types::{Diagnostic, DiagnosticSeverity, NumberOrString};
+use ls_types::{DiagnosticSeverity, NumberOrString};
 use serde_json;
 use span::compiler::DiagnosticSpan;
+use actions::{RustDiagnostic, LabelledRange};
 
 use lsp_data::ls_util;
 
@@ -33,7 +34,7 @@ struct CompilerMessage {
 #[derive(Debug)]
 pub struct FileDiagnostic {
     pub file_path: PathBuf,
-    pub diagnostic: Diagnostic,
+    pub diagnostic: RustDiagnostic,
 }
 
 #[derive(Debug)]
@@ -55,12 +56,29 @@ pub fn parse(message: &str) -> Result<FileDiagnostic, ParseError> {
         return Err(ParseError::NoSpans);
     }
 
-    let span = message.spans[0].rls_span().zero_indexed();
-
     let message_text = compose_message(&message);
+    let span = message.spans[0].rls_span().zero_indexed();
+    let range = ls_util::rls_to_range(span.range);
 
-    let diagnostic = Diagnostic {
-        range: ls_util::rls_to_range(span.range),
+    // build up the secondary spans
+    let mut secondary = vec![];
+    for span in message.spans.iter().skip(1) {
+        let secondary_range = ls_util::rls_to_range(span.rls_span().zero_indexed().range);
+
+        secondary.push(LabelledRange {
+            start: secondary_range.start,
+            end: secondary_range.end,
+            label: span.label.clone(),
+        });
+    }
+
+    let diagnostic = RustDiagnostic {
+        range: LabelledRange {
+            start: range.start,
+            end: range.end,
+            label: message.spans[0].label.clone(),
+        },
+        secondary: secondary,
         severity: Some(if message.level == "error" {
             DiagnosticSeverity::Error
         } else {

--- a/src/actions/compiler_message_parsing.rs
+++ b/src/actions/compiler_message_parsing.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use ls_types::{DiagnosticSeverity, NumberOrString};
 use serde_json;
 use span::compiler::DiagnosticSpan;
-use actions::{RustDiagnostic, LabelledRange};
+use actions::lsp_extensions::{RustDiagnostic, LabelledRange};
 
 use lsp_data::ls_util;
 

--- a/src/actions/lsp_extensions.rs
+++ b/src/actions/lsp_extensions.rs
@@ -1,0 +1,61 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use url_serde;
+use lsp_data::*;
+use url::Url;
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+pub struct PublishRustDiagnosticsParams {
+    /// The URI for which diagnostic information is reported.
+    #[serde(deserialize_with = "url_serde::deserialize", serialize_with = "url_serde::serialize")]
+    pub uri: Url,
+
+    /// An array of diagnostic information items.
+    pub diagnostics: Vec<RustDiagnostic>,
+}
+
+/// A range in a text document expressed as (zero-based) start and end positions.
+/// A range is comparable to a selection in an editor. Therefore the end position is exclusive.
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+pub struct LabelledRange {
+    /// The range's start position.
+    pub start: Position,
+    /// The range's end position.
+    pub end: Position,
+    /// The optional label.
+    pub label: Option<String>,
+}
+
+/// Represents a diagnostic, such as a compiler error or warning.
+/// Diagnostic objects are only valid in the scope of a resource.
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+pub struct RustDiagnostic {
+    /// The primary range at which the message applies.
+    pub range: LabelledRange,
+
+    /// The secondary ranges that apply to the message
+    pub secondary: Vec<LabelledRange>,
+
+    /// The diagnostic's severity. Can be omitted. If omitted it is up to the
+    /// client to interpret diagnostics as error, warning, info or hint.
+    pub severity: Option<DiagnosticSeverity>,
+
+    /// The diagnostic's code. Can be omitted.
+    pub code: Option<NumberOrString>,
+
+    /// A human-readable string describing the source of this
+    /// diagnostic, e.g. 'typescript' or 'super lint'.
+    pub source: Option<String>,
+
+    /// The diagnostic's message.
+    pub message: String,
+}
+

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 mod compiler_message_parsing;
+mod lsp_extensions;
 
 use analysis::{AnalysisHost};
 use hyper::Url;
@@ -23,7 +24,6 @@ use Span;
 use build::*;
 use lsp_data::*;
 use server::{ResponseData, Output};
-use url_serde;
 
 use std::collections::HashMap;
 use std::panic;
@@ -32,65 +32,10 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use self::lsp_extensions::{PublishRustDiagnosticsParams, RustDiagnostic};
 use self::compiler_message_parsing::{FileDiagnostic, ParseError};
 
 type BuildResults = HashMap<PathBuf, Vec<RustDiagnostic>>;
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-pub struct PublishRustDiagnosticsParams {
-    /// The URI for which diagnostic information is reported.
-    #[serde(deserialize_with = "url_serde::deserialize", serialize_with = "url_serde::serialize")]
-    pub uri: Url,
-
-    /// An array of diagnostic information items.
-    pub diagnostics: Vec<RustDiagnostic>,
-}
-
-impl PublishRustDiagnosticsParams {
-    pub fn new(uri: Url, diagnostics: Vec<RustDiagnostic>) -> PublishRustDiagnosticsParams {
-        PublishRustDiagnosticsParams {
-            uri: uri,
-            diagnostics: diagnostics,
-        }
-    }
-}
-
-/// A range in a text document expressed as (zero-based) start and end positions.
-/// A range is comparable to a selection in an editor. Therefore the end position is exclusive.
-#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
-pub struct LabelledRange {
-    /// The range's start position.
-    pub start: Position,
-    /// The range's end position.
-    pub end: Position,
-    /// The optional LabelledRange.
-    pub label: Option<String>,
-}
-
-/// Represents a diagnostic, such as a compiler error or warning.
-/// Diagnostic objects are only valid in the scope of a resource.
-#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
-pub struct RustDiagnostic {
-    /// The primary range at which the message applies.
-    pub range: LabelledRange,
-
-    /// The secondary ranges that apply to the message
-    pub secondary: Vec<LabelledRange>,
-
-    /// The diagnostic's severity. Can be omitted. If omitted it is up to the
-    /// client to interpret diagnostics as error, warning, info or hint.
-    pub severity: Option<DiagnosticSeverity>,
-
-    /// The diagnostic's code. Can be omitted.
-    pub code: Option<NumberOrString>,
-    //    code?: number | string;
-    /// A human-readable string describing the source of this
-    /// diagnostic, e.g. 'typescript' or 'super lint'.
-    pub source: Option<String>,
-
-    /// The diagnostic's message.
-    pub message: String,
-}
 
 pub struct ActionHandler {
     analysis: Arc<AnalysisHost>,
@@ -158,10 +103,10 @@ impl ActionHandler {
             .map(|(path, diagnostics)| {
                 let method = "textDocument/publishDiagnostics".to_string();
 
-                let params = PublishRustDiagnosticsParams::new(
-                    Url::from_file_path(project_path.join(path)).unwrap(),
-                    diagnostics.clone(),
-                );
+                let params = PublishRustDiagnosticsParams {
+                    uri: Url::from_file_path(project_path.join(path)).unwrap(),
+                    diagnostics: diagnostics.clone(),
+                };
 
                 NotificationMessage::new(method, params)
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,8 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate toml;
+extern crate url;
+extern crate url_serde;
 
 use std::sync::Arc;
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -257,15 +257,10 @@ fn test_borrow_error() {
     let _cr = TestCleanup::new();
 
     init_env("borrow_error");
-    let mut cache = types::Cache::new(Path::new("."));
-
-    let source_file_path = Path::new("src").join("main.rs");
+    let cache = types::Cache::new(Path::new("."));
 
     let root_path = format!("{}", serde_json::to_string(&cache.abs_path(Path::new(".")))
                                       .expect("couldn't convert path to JSON"));
-    let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
-    let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
-                                                 .expect("couldn't convert path to JSON"));
     let messages = vec![format!(r#"{{
         "jsonrpc": "2.0",
         "method": "initialize",

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -252,6 +252,42 @@ fn test_find_all_refs_no_cfg_test() {
 }
 
 #[test]
+fn test_borrow_error() {
+    let _ = env_logger::init();
+    let _cr = TestCleanup::new();
+
+    init_env("borrow_error");
+    let mut cache = types::Cache::new(Path::new("."));
+
+    let source_file_path = Path::new("src").join("main.rs");
+
+    let root_path = format!("{}", serde_json::to_string(&cache.abs_path(Path::new(".")))
+                                      .expect("couldn't convert path to JSON"));
+    let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
+    let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
+                                                 .expect("couldn't convert path to JSON"));
+    let messages = vec![format!(r#"{{
+        "jsonrpc": "2.0",
+        "method": "initialize",
+        "id": 0,
+        "params": {{
+            "processId": "0",
+            "capabilities": null,
+            "rootPath": {}
+        }}
+    }}"#, root_path)];
+
+    let (server, results) = mock_raw_server(messages);
+    // Initialise and build.
+    assert_eq!(ls_server::LsService::handle_message(server.clone()),
+               ls_server::ServerStateChange::Continue);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
+                                       ExpectedMessage::new(None).expect_contains("\"secondary\":[{\"start\":{\"line\":3,\"character\":17},\"end\":{\"line\":3,\"character\":18},\"label\":\"second mutable borrow occurs here\"}"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
+}
+
+#[test]
 fn test_highlight() {
     let _ = env_logger::init();
     let _cr = TestCleanup::new();

--- a/test_data/borrow_error/Cargo.lock
+++ b/test_data/borrow_error/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "borrow_error"
+version = "0.1.0"
+

--- a/test_data/borrow_error/Cargo.toml
+++ b/test_data/borrow_error/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "borrow_error"
+version = "0.1.0"
+authors = ["Jonathan Turner <jturner@mozilla.com>"]
+
+[dependencies]

--- a/test_data/borrow_error/src/main.rs
+++ b/test_data/borrow_error/src/main.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let mut x = 3;
+    let y = &mut x;
+    let z = &mut x;
+}


### PR DESCRIPTION
This PR specialises Diagnostic for the RLS, enabling us to pass along an optional label on the primary range.  It also adds a new field for the secondary labels.

Adds intentionally failing test case to check for new behaviour.  This has also been tested and works with our existing vscode plugin, unchanged.