### PR TITLE
Added responding to a shutdown request.

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -84,7 +84,9 @@ serializable_enum!(ResponseData,
     TextEdit([TextEdit; 1]),
     Locations(Vec<Location>),
     Highlights(Vec<DocumentHighlight>),
-    HoverSuccess(Hover)
+    HoverSuccess(Hover),
+    // Empty tuple is represented as null in JSON
+    Null(())
 );
 
 // Generates the Method enum and parse_message function.
@@ -300,6 +302,10 @@ impl LsService {
                         Method::Shutdown => {
                             trace!("shutting down...");
                             this.shut_down.store(true, Ordering::SeqCst);
+
+                            // We must respond, otherwise we wouldn't get a request to exit.
+                            let out = &*this.output;
+                            out.success(id, ResponseData::Null(()));
                         }
                         Method::Hover(params) => {
                             trace!("command(hover): {:?}", params);

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,6 +24,9 @@ use std::thread;
 use std::path::PathBuf;
 
 
+#[derive(Debug, Serialize)]
+pub struct Ack {}
+
 #[derive(Debug, new)]
 struct ParseError {
     kind: ErrorKind,
@@ -85,8 +88,7 @@ serializable_enum!(ResponseData,
     Locations(Vec<Location>),
     Highlights(Vec<DocumentHighlight>),
     HoverSuccess(Hover),
-    // Empty tuple is represented as null in JSON
-    Null(())
+    Ack(Ack)
 );
 
 // Generates the Method enum and parse_message function.
@@ -303,9 +305,8 @@ impl LsService {
                             trace!("shutting down...");
                             this.shut_down.store(true, Ordering::SeqCst);
 
-                            // We must respond, otherwise we wouldn't get a request to exit.
                             let out = &*this.output;
-                            out.success(id, ResponseData::Null(()));
+                            out.success(id, ResponseData::Ack(Ack {}));
                         }
                         Method::Hover(params) => {
                             trace!("command(hover): {:?}", params);


### PR DESCRIPTION
The protocol specifies that the server must respond to the shutdown request in order to receive the exit request.

I need it to implement restarting in my extension.

Let me know if you have better solution.

Fixes #176