### PR TITLE
Revert "First step moving over to lsp 3.0"

### DIFF
--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -138,7 +138,7 @@ pub struct NotificationMessage<T>
 impl <T> NotificationMessage<T> where T: Debug + Serialize {
     pub fn new(method: String, params: T) -> Self {
         NotificationMessage {
-            jsonrpc: "3.0",
+            jsonrpc: "2.0",
             method: method,
             params: params
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -427,7 +427,7 @@ pub trait Output {
     fn response(&self, output: String);
 
     fn parse_error(&self) {
-        self.response(r#"{"jsonrpc": "3.0", "error": {"code": -32700, "message": "Parse error"}, "id": null}"#.to_owned());
+        self.response(r#"{"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}, "id": null}"#.to_owned());
     }
 
     fn failure(&self, id: usize, message: &str) {
@@ -448,7 +448,7 @@ pub trait Output {
         }
 
         let rf = ResponseFailure {
-            jsonrpc: "3.0",
+            jsonrpc: "2.0",
             id: id,
             error: ResponseError {
                 code: METHOD_NOT_FOUND,
@@ -465,7 +465,7 @@ pub trait Output {
         //     id: usize,
         //     result: String,
         // }
-        let output = format!("{{\"jsonrpc\":\"3.0\",\"id\":{},\"result\":{}}}", id, data);
+        let output = format!("{{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{}}}", id, data);
 
         self.response(output);
     }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -164,7 +164,7 @@ fn test_find_all_refs() {
     let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
                                                  .expect("couldn't convert path to JSON"));
     let messages = vec![format!(r#"{{
-        "jsonrpc": "3.0",
+        "jsonrpc": "2.0",
         "method": "initialize",
         "id": 0,
         "params": {{
@@ -173,7 +173,7 @@ fn test_find_all_refs() {
             "rootPath": {}
         }}
     }}"#, root_path), format!(r#"{{
-        "jsonrpc": "3.0",
+        "jsonrpc": "2.0",
         "method": "textDocument/references",
         "id": 42,
         "params": {{
@@ -216,7 +216,7 @@ fn test_find_all_refs_no_cfg_test() {
     let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
                                                  .expect("couldn't convert path to JSON"));
     let messages = vec![format!(r#"{{
-        "jsonrpc": "3.0",
+        "jsonrpc": "2.0",
         "method": "initialize",
         "id": 0,
         "params": {{
@@ -225,7 +225,7 @@ fn test_find_all_refs_no_cfg_test() {
             "rootPath": {}
         }}
     }}"#, root_path), format!(r#"{{
-        "jsonrpc": "3.0",
+        "jsonrpc": "2.0",
         "method": "textDocument/references",
         "id": 42,
         "params": {{
@@ -262,7 +262,7 @@ fn test_borrow_error() {
     let root_path = format!("{}", serde_json::to_string(&cache.abs_path(Path::new(".")))
                                       .expect("couldn't convert path to JSON"));
     let messages = vec![format!(r#"{{
-        "jsonrpc": "3.0",
+        "jsonrpc": "2.0",
         "method": "initialize",
         "id": 0,
         "params": {{
@@ -298,7 +298,7 @@ fn test_highlight() {
     let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
                                                  .expect("couldn't convert path to JSON"));
     let messages = vec![format!(r#"{{
-        "jsonrpc": "3.0",
+        "jsonrpc": "2.0",
         "method": "initialize",
         "id": 0,
         "params": {{
@@ -307,7 +307,7 @@ fn test_highlight() {
             "rootPath": {}
         }}
     }}"#, root_path), format!(r#"{{
-        "jsonrpc": "3.0",
+        "jsonrpc": "2.0",
         "method": "textDocument/documentHighlight",
         "id": 42,
         "params": {{
@@ -346,7 +346,7 @@ fn test_rename() {
     let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
                                                  .expect("couldn't convert path to JSON"));
     let messages = vec![format!(r#"{{
-        "jsonrpc": "3.0",
+        "jsonrpc": "2.0",
         "method": "initialize",
         "id": 0,
         "params": {{
@@ -355,7 +355,7 @@ fn test_rename() {
             "rootPath": {}
         }}
     }}"#, root_path), format!(r#"{{
-        "jsonrpc": "3.0",
+        "jsonrpc": "2.0",
         "method": "textDocument/rename",
         "id": 42,
         "params": {{
@@ -581,7 +581,7 @@ fn expect_messages(results: LsResultList, expected: &[&ExpectedMessage]) {
     assert_eq!(results.len(), expected.len());
     for (found, expected) in results.iter().zip(expected.iter()) {
         let values: serde_json::Value = serde_json::from_str(found).unwrap();
-        assert!(values.get("jsonrpc").expect("Missing jsonrpc field").as_str().unwrap() == "3.0", "Bad jsonrpc field");
+        assert!(values.get("jsonrpc").expect("Missing jsonrpc field").as_str().unwrap() == "2.0", "Bad jsonrpc field");
         if let Some(id) = expected.id {
             assert_eq!(values.get("id").expect("Missing id field").as_u64().unwrap(), id, "Unexpected id");
         }


### PR DESCRIPTION
This changed the jsonrpc version which is unrelated to the language server protocol version. There is no language server protocol version field.

Also check https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#example and http://www.jsonrpc.org/specification#response_object for the correct value of jsonrpc.