### PR TITLE
fix for #233

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -406,8 +406,8 @@ impl MessageReader for StdioMsgReader {
             return None;
         }
 
-        if res[0] == "Content-length:" {
-            info!("Header is missing 'Content-length'");
+        if res[0].to_lowercase() != "content-length:" {
+            info!("Header is missing 'content-length'");
             return None;
         }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -548,6 +548,11 @@ impl ls_server::Output for RecordOutput {
 
 // Initialise the environment for a test.
 fn init_env(project_dir: &str) {
+    match env::var("RUST_TEST_THREADS") {
+        Ok(ref var) if var == "1" => (),
+        _ => panic!("Please run tests with `RUST_TEST_THREADS=1 cargo test`"),
+    }; 
+
     let mut cwd = env::current_dir().expect(FAIL_MSG);
     cwd.push("test_data");
     cwd.push(project_dir);


### PR DESCRIPTION
I had a more elaborate fix but implementing tests for it was non-trivial due to how the message parsing directly calls out to stdin; there's no way for me to pass some other reader during testing.

I want to note that the current `read_message` implementation is not to spec: in particular it is only expecting a single header. The specification does not limit the possible number of headers, and at least the `content-type` header could be reasonably expected from some clients. 

In the course of playing around with the tests I ran into issues because I hadn't seen the guideline to pass `RUST_TEST_THREADS=1`; I added a check in the tests that will fail if that is not set. If there's some reason this is a bad idea, let me know. :) 

This closes #233.