### PR TITLE
Provide CompletionItem.kind for Racer completions

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -240,10 +240,7 @@ impl ActionHandler {
             let location = pos_to_racer_location(params.position);
             let results = racer::complete_from_file(file_path, location, &session);
 
-            results.map(|comp| CompletionItem::new_simple(
-                comp.matchstr.clone(),
-                comp.contextstr.clone(),
-            )).collect()
+            results.map(|comp| completion_item_from_racer_match(comp)).collect()
         }).unwrap_or_else(|_| vec![]);
 
         out.success(id, ResponseData::CompletionItems(result));

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -16,6 +16,7 @@ use analysis::raw;
 use hyper::Url;
 use serde::Serialize;
 use span;
+use racer;
 
 pub use ls_types::*;
 
@@ -120,6 +121,39 @@ pub fn source_kind_from_def_kind(k: raw::DefKind) -> SymbolKind {
         raw::DefKind::Const |
         raw::DefKind::Field => SymbolKind::Variable,
     }
+}
+
+pub fn completion_kind_from_match_type(m : racer::MatchType) -> CompletionItemKind {
+    match m {
+        racer::MatchType::Crate |
+        racer::MatchType::Module => CompletionItemKind::Module,
+        racer::MatchType::Struct => CompletionItemKind::Class,
+        racer::MatchType::Enum => CompletionItemKind::Enum,
+        racer::MatchType::StructField |
+        racer::MatchType::EnumVariant => CompletionItemKind::Field,
+        racer::MatchType::Macro |
+        racer::MatchType::Function |
+        racer::MatchType::FnArg |
+        racer::MatchType::Impl => CompletionItemKind::Function,
+        racer::MatchType::Type |
+        racer::MatchType::Trait |
+        racer::MatchType::TraitImpl => CompletionItemKind::Interface,
+        racer::MatchType::Let |
+        racer::MatchType::IfLet |
+        racer::MatchType::WhileLet |
+        racer::MatchType::For |
+        racer::MatchType::MatchArm |
+        racer::MatchType::Const |
+        racer::MatchType::Static => CompletionItemKind::Variable,
+        racer::MatchType::Builtin => CompletionItemKind::Keyword,
+    }
+}
+
+pub fn completion_item_from_racer_match(m : racer::Match) -> CompletionItem {
+    let mut item = CompletionItem::new_simple(m.matchstr.clone(), m.contextstr.clone());
+    item.kind = Some(completion_kind_from_match_type(m.mtype));
+
+    item
 }
 
 /* -----------------  JSON-RPC protocol types ----------------- */

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -398,8 +398,11 @@ fn test_completion() {
                                                         ("capabilities", "null".to_owned()),
                                                         ("rootPath", root_path)]),
                         Message::new("textDocument/completion",
-                                     vec![("textDocument", text_doc),
-                                          ("position", cache.mk_ls_position(src(&source_file_path, 22, "rld")))])];
+                                     vec![("textDocument", text_doc.to_owned()),
+                                          ("position", cache.mk_ls_position(src(&source_file_path, 22, "rld")))]),
+                        Message::new("textDocument/completion",
+                                     vec![("textDocument", text_doc.to_owned()),
+                                          ("position", cache.mk_ls_position(src(&source_file_path, 25, "x)")))])];
     let (server, results) = mock_server(messages);
     // Initialise and build.
     assert_eq!(ls_server::LsService::handle_message(server.clone()),
@@ -410,7 +413,11 @@ fn test_completion() {
 
     assert_eq!(ls_server::LsService::handle_message(server.clone()),
                ls_server::ServerStateChange::Continue);
-    expect_messages(results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains("[{\"label\":\"world\",\"detail\":\"let world = \\\"world\\\";\"}]")]);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains("[{\"label\":\"world\",\"kind\":6,\"detail\":\"let world = \\\"world\\\";\"}]")]);
+
+    assert_eq!(ls_server::LsService::handle_message(server.clone()),
+               ls_server::ServerStateChange::Continue);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains("[{\"label\":\"x\",\"kind\":5,\"detail\":\"u64\"}]")]);
 }
 
 #[test]


### PR DESCRIPTION
This implements https://github.com/rust-lang-nursery/rls/issues/74 (Provide CompletionItem.kind from Language Server Protocol).

Right now we have a generic wrench icon applied to every completion:
![no-completion-item-kind](https://cloud.githubusercontent.com/assets/3093213/24573117/757af0f0-167f-11e7-97dc-05f8ea7af9be.jpg)

After mapping from MatchType in Match from Racer completion results to an appropriate CompleteItemKind we get:
![completion-item-kind](https://cloud.githubusercontent.com/assets/3093213/24573118/77a2ecde-167f-11e7-9414-5e31eafe03a4.jpg)

Not sure if the mapping is implemented in the right place - I only got inspired by already existing mapping function `source_kind_from_def_kind` in `lsp_data.rs`. This is obviously just an idea how we could do that.
We could even introduce mapping for `CompletionItemKind::Constructor` later on, for example for functions that return an owned version of Self, when we'll be able to retrieve a proper function signature. Until then we could possibly provide heuristics for functions called `new` or `from` if needed.