### PR TITLE
simplified build request init logic

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -127,17 +127,13 @@ impl BuildQueue {
 
     pub fn request_build(&self, build_dir: &Path, priority: BuildPriority) -> BuildResult {
         // println!("request_build, {:?} {:?}", build_dir, priority);
+
         // If there is a change in the project directory, then we can forget any
         // pending build and start straight with this new build.
         {
             let mut prev_build_dir = self.build_dir.lock().unwrap();
 
-            let reset = match *prev_build_dir {
-                Some(ref dir) if dir == build_dir => false,
-                _ => true
-            };
-
-            if reset {
+            if prev_build_dir.as_ref().map_or(true, |dir| dir != build_dir) {
                 *prev_build_dir = Some(build_dir.to_owned());
                 self.cancel_pending();
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -130,15 +130,14 @@ impl BuildQueue {
         // If there is a change in the project directory, then we can forget any
         // pending build and start straight with this new build.
         {
-            let mut reset = false;
             let mut prev_build_dir = self.build_dir.lock().unwrap();
-            if let Some(ref prev_build_dir) = *prev_build_dir {
-                if prev_build_dir != build_dir {
-                    reset = true;
-                }
-            }
 
-            if reset || prev_build_dir.is_none() {
+            let reset = match *prev_build_dir {
+                Some(ref dir) if dir == build_dir => false,
+                _ => true
+            };
+
+            if reset {
                 *prev_build_dir = Some(build_dir.to_owned());
                 self.cancel_pending();
 


### PR DESCRIPTION
I tried to better convey that build request will be (re)initialized when current build dir is none or different that the one for which build has been requested.
Tried to introduce single match on `prev_build_dir`, but due to assignment inside I couldn't due to few issues, mostly with borrowing. If someone knows how to do it better, then please guide me :+1: Originally it was simply `if prev_build_dir.is_none() || prev_build_dir.as_ref().unwrap() != build_dir` instead of changing `reset`, but since eventually we check `reset` value twice here (initialize conditionally + check) anyway, I'm not sure that's better than checking, in one line, `is_none()`+`unwrap()` twice.