### PR TITLE
compilation fix: use impl_enum_decodable! from rustfmt

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,8 +16,8 @@ use std::path::Path;
 
 macro_rules! impl_enum_decodable {
     ( $e:ident, $( $x:ident ),* ) => {
-        impl ::serde::Deserialize for $e {
-            fn decode<D: ::serde::Deserializer>(d: &mut D) -> Result<Self, D::Error> {
+        impl ::rustc_serialize::Decodable for $e {
+            fn decode<D: ::rustc_serialize::Decoder>(d: &mut D) -> Result<Self, D::Error> {
                 use std::ascii::AsciiExt;
                 let s = try!(d.read_str());
                 $(


### PR DESCRIPTION
I believe this was a copy-paste mistake. Currently .toml config parsing, along with decoding enums is just copied from https://github.com/rust-lang-nursery/rustfmt/blob/master/src/utils.rs#L194 and https://github.com/rust-lang-nursery/rustfmt/blob/master/src/config.rs#L16. Bringing the original change allows us to define config enums again, like that:
```
configuration_option_enum! { CompilationType:
    Binary,
    Library,
}
```
to be used like that in rls.toml:
```
compilation_type = "Binary"
```
I checked enum value parsing with this change and it seems to be working.