### PR TITLE
Drop rustc-serialize dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,6 @@ dependencies = [
  "rls-data 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-vfs 0.1.0 (git+https://github.com/nrc/rls-vfs)",
- "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt 0.8.3 (git+https://github.com/rust-lang-nursery/rustfmt)",
  "serde 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ rls-analysis = { git = "https://github.com/nrc/rls-analysis" }
 rls-data = "0.1"
 rls-span = { version = "0.1", features = ["serialize-serde"] }
 rls-vfs = { git = "https://github.com/nrc/rls-vfs", features = ["racer-impls"] }
-rustc-serialize = "0.3"
 rustfmt = { git = "https://github.com/rust-lang-nursery/rustfmt" }
 serde = "0.9"
 serde_json = "0.9"

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,7 +92,7 @@ impl ConfigType for String {
 
 macro_rules! create_config {
     ($($i:ident: $ty:ty, $def:expr, $unstable:expr, $( $dstring:expr ),+ );+ $(;)*) => (
-        #[derive(RustcDecodable, Clone)]
+        #[derive(Clone)]
         pub struct Config {
             $(pub $i: $ty),+
         }
@@ -102,7 +102,7 @@ macro_rules! create_config {
         // specity all properties of `Config`.
         // We first parse into `ParsedConfig`, then create a default `Config`
         // and overwrite the properties with corresponding values from `ParsedConfig`
-        #[derive(RustcDecodable, Clone, Deserialize)]
+        #[derive(Clone, Deserialize)]
         pub struct ParsedConfig {
             $(pub $i: Option<$ty>),+
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,6 @@ extern crate rls_analysis as analysis;
 extern crate rls_vfs as vfs;
 extern crate rls_span as span;
 extern crate rls_data as data;
-extern crate rustc_serialize;
 extern crate rustfmt;
 extern crate serde;
 #[macro_use]


### PR DESCRIPTION
- Fix https://github.com/rust-lang-nursery/rls/issues/270
- We don't have a code which converts configuration file to `Config` directly. We always load configuration file into `ParsedConfig` and create `Config` from it.
  - So I think we can remove this simply.