### PR TITLE
Alternative attempt to support rangeLength field in LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "rls-analysis 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-vfs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-vfs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt 0.8.3 (git+https://github.com/rust-lang-nursery/rustfmt)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "rls-vfs"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "racer 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1226,7 +1226,7 @@ dependencies = [
 "checksum rls-analysis 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0d536f6f27157033214baad389e4cb5f66453485c18830d58c786a54b0524449"
 "checksum rls-data 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af1dfff00189fd7b78edb9af131b0de703676c04fa8126aed77fd2c586775a4d"
 "checksum rls-span 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8656f7b850ac85fb204ef94318c641bbb15a32766e12f9a589a23e4c0fbc38db"
-"checksum rls-vfs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41986501392bf9b41dc2712e0fc2c6c3fddc0d9e5baef5488637ec65fe2ae827"
+"checksum rls-vfs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "840ccded6b43794d0693d53cac50267e3d35f64fde0b8698cb63e4154581e3fd"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustfmt 0.8.3 (git+https://github.com/rust-lang-nursery/rustfmt)" = "<none>"
 "checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ racer = "2.0.6"
 rls-analysis = "0.1"
 rls-data = "0.1"
 rls-span = { version = "0.1", features = ["serialize-serde"] }
-rls-vfs = { version = "0.1", features = ["racer-impls"] }
+rls-vfs = { version = "0.2", features = ["racer-impls"] }
 rustfmt = { git = "https://github.com/rust-lang-nursery/rustfmt" }
 serde = "0.9"
 serde_json = "0.9"

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -178,6 +178,7 @@ impl ActionHandler {
                 let range = ls_util::range_to_rls(range);
                 Change::ReplaceText {
                     span: Span::from_range(range, fname.clone()),
+                    len: i.range_length,
                     text: i.text.clone()
                 }
             } else {


### PR DESCRIPTION
This is another attempt to fix the issue #280. 

Since the pull request #281 ran into problems due to the fact that `rls-span` and `rls-data` crates are actually used as API for interaction with Rust compiler, and have an embedded version of themselves inside it, changing them doesn't seem a good idea anymore.

Hence this alternative less invasive approach, which touches only `rls` and `rls-vfs` crates. Since it keeps using `rls-span 0.1` and `rls-data 0.1`, it works and passes all tests locally, including fresh compilers, and so I expect Travis to confirm.

I've reverted all changes in `rls-analysis` and `rls-vfs` that were made in preparation of #281, as they're conflicting with this attempt, and further edited `rls-vfs` to support this new way, which basically consists of adding `len` field to ReplaceText event of `rls` <-> `rls-vfs` interface.  

I will send PRs with those changes to the nrc repos, once Travis checks this build. Meanwhile, I've pointed `Cargo.toml` to my fixed repos, and you can see what's in them here.

https://github.com/nrc/rls-vfs/compare/master...albel727:master
https://github.com/nrc/rls-analysis/compare/master...albel727:master

Luckily, changes to `rls-span` and `rls-data` need not be reverted immediately, as they're depended upon not as git repos, but through crates.io. Let's leave the decision of what to do with them to nrc.