### PR TITLE
Allow config file to be named .rls.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ squiggles to see the text of the error.
 ## Configuration
 
 The RLS can be configured on a per-project basis by adding a file called
-`rls.toml` to the project root (i.e., next to Cargo.toml). Entries in this file
-will affect how the RLS operates and how it builds your project.
+`.rls.toml` or `rls.toml` to the project root (i.e., next to Cargo.toml).
+Entries in this file will affect how the RLS operates and how it builds your
+project.
 
 Currently we accept the following options:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -166,15 +166,23 @@ macro_rules! create_config {
                 )+
             }
 
-            /// Attempt to read a confid from rls.toml in path, failing that use defaults.
+            /// Attempt to read a config from .rls.toml, then rls.toml in path, failing that use
+            /// defaults.
             pub fn from_path(path: &Path) -> Config {
-                let config_path = path.to_owned().join("rls.toml");
-                let config_file = File::open(config_path);
-                let mut toml = String::new();
-                if let Ok(mut f) = config_file {
-                    f.read_to_string(&mut toml).unwrap();
+                const CONFIG_FILE_NAMES: [&str; 2] = [".rls.toml", "rls.toml"];
+
+                for config_file_name in &CONFIG_FILE_NAMES {
+                    let config_path = path.to_owned().join(config_file_name);
+                    let config_file = File::open(config_path);
+
+                    if let Ok(mut f) = config_file {
+                        let mut toml = String::new();
+                        f.read_to_string(&mut toml).unwrap();
+                        return Config::from_toml(&toml);
+                    }
                 }
-                Config::from_toml(&toml)
+
+                Config::default()
             }
         }
 


### PR DESCRIPTION
.rls.toml will be preferred over rls.toml, mirroring rustfmt's behaviour

resolves #295