### PR TITLE
Upgrade Serde to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,20 +5,20 @@ dependencies = [
  "cargo 0.20.0 (git+https://github.com/rust-lang/cargo)",
  "derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "languageserver-types 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "languageserver-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-analysis 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-span 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-vfs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-analysis 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-data 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-vfs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt 0.8.3 (git+https://github.com/rust-lang-nursery/rustfmt)",
- "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url_serde 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -356,15 +356,15 @@ dependencies = [
 
 [[package]]
 name = "languageserver-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url_serde 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -633,42 +633,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rls-analysis"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-span 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-data 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rls-data"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rls-span 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rls-span"
-version = "0.1.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rls-vfs"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "racer 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-span 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -725,31 +725,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.9.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "serde"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "serde_codegen_internals"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_derive"
-version = "0.9.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "serde_derive"
@@ -776,17 +753,6 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_json"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1011,14 +977,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "toml"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1087,10 +1045,10 @@ dependencies = [
 
 [[package]]
 name = "url_serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1190,7 +1148,7 @@ dependencies = [
 "checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum languageserver-types 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d540adcb0542aa58175ebfe39cadf01a437b7635147cca61f092ffcf10e48b03"
+"checksum languageserver-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8de566291d854d66c503833cb785db8cc0eae23dc5962fef6edb78a966f98fd2"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "babb8281da88cba992fa1f4ddec7d63ed96280a1a53ec9b919fd37b53d71e502"
 "checksum libgit2-sys 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a3aaa20337a0e79fb75180b6a1970c1f7cff9a413f570d6b999b38a5d5d54e81"
@@ -1223,23 +1181,19 @@ dependencies = [
 "checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
-"checksum rls-analysis 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0d536f6f27157033214baad389e4cb5f66453485c18830d58c786a54b0524449"
-"checksum rls-data 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af1dfff00189fd7b78edb9af131b0de703676c04fa8126aed77fd2c586775a4d"
-"checksum rls-span 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8656f7b850ac85fb204ef94318c641bbb15a32766e12f9a589a23e4c0fbc38db"
-"checksum rls-vfs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "840ccded6b43794d0693d53cac50267e3d35f64fde0b8698cb63e4154581e3fd"
+"checksum rls-analysis 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a62d88c341375c6f3f8b2e18b9b364896e7d3e7aa916907de717d0267e116506"
+"checksum rls-data 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fc4277ce3c57f456b11fe3145b181a844a25201bab5cbaa1978457e6e2f27d47"
+"checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
+"checksum rls-vfs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "986eada111517bcb5a7a75205b3f2b70c82e7766653cca61a23f5afce79bdb94"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustfmt 0.8.3 (git+https://github.com/rust-lang-nursery/rustfmt)" = "<none>"
 "checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3b46a59dd63931010fdb1d88538513f3279090d88b5c22ef4fe8440cfffcc6e3"
-"checksum serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"
-"checksum serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "978fd866f4d4872084a81ccc35e275158351d3b9fe620074e7d7504b816b74ba"
 "checksum serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6c06b68790963518008b8ae0152d48be4bbbe77015d2c717f6282eea1824be9a"
 "checksum serde_derive_internals 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "021c338d22c7e30f957a6ab7e388cb6098499dda9fd4ba1661ee074ca7a180d1"
 "checksum serde_ignored 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c10e798e4405d7dcec3658989e35ee6706f730a9ed7c1184d5ebd84317e82f46"
-"checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
 "checksum serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1c62115693d0a9ed8c32d1c760f0fdbe7d4b05cb13c135b9b54137ac0d59fccb"
 "checksum shell-escape 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dd5cc96481d54583947bfe88bf30c23d53f883c6cd0145368b69989d97b84ef8"
 "checksum strings 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "54f86446ab480b4f60782188f4f78886465c5793aee248cbb48b7fdc0d022420"
@@ -1264,7 +1218,6 @@ dependencies = [
 "checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
 "checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
-"checksum toml 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bd86ad9ebee246fdedd610e0f6d0587b754a3d81438db930a244d0480ed7878f"
 "checksum toml 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3063405db158de3dce8efad5fc89cf1baffb9501a3647dc9505ba109694ce31f"
 "checksum typed-arena 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e2f9dc90da4f9d66ffc9ad3ead2c7d57582a26f4a3292d2ce7011bd29965100"
 "checksum unicode-bidi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a078ebdd62c0e71a709c3d53d2af693fe09fe93fbff8344aebe289b78f9032"
@@ -1276,7 +1229,7 @@ dependencies = [
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5ba8a749fb4479b043733416c244fa9d1d3af3d7c23804944651c8a448cb87e"
-"checksum url_serde 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64ddbc0a67ae30778179166934129e0aeb92c5b7051d8e0b519e3bce73aff106"
+"checksum url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74e7d099f1ee52f823d4bdd60c93c3602043c728f5db3b97bdb548467f7bddea"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,17 @@ authors = ["Jonathan Turner <jturner@mozilla.com>"]
 cargo = { git = "https://github.com/rust-lang/cargo" }
 derive-new = "0.3"
 env_logger = "0.4"
-languageserver-types = "0.7.0"
+languageserver-types = "0.8.0"
 log = "0.3"
 racer = "2.0.6"
-rls-analysis = "0.1"
-rls-data = "0.1"
-rls-span = { version = "0.1", features = ["serialize-serde"] }
-rls-vfs = { version = "0.2", features = ["racer-impls"] }
+rls-analysis = "0.2.1"
+rls-data = "0.3.1"
+rls-span = { version = "0.4", features = ["serialize-serde"] }
+rls-vfs = { version = "0.3", features = ["racer-impls"] }
 rustfmt = { git = "https://github.com/rust-lang-nursery/rustfmt" }
-serde = "0.9"
-serde_json = "0.9"
-serde_derive = "0.9"
-toml = "0.3"
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
+toml = "0.4"
 url = "1.1.0"
-url_serde = "0.1.0"
+url_serde = "0.2.0"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -17,7 +17,7 @@ use build::BuildQueue;
 use vfs::Vfs;
 use server::{self, ServerMessage, Request, Notification, Method, LsService, ParseError, ResponseData};
 
-use ls_types::{TextDocumentPositionParams, TextDocumentIdentifier, Position, InitializeParams};
+use ls_types::{ClientCapabilities, TextDocumentPositionParams, TextDocumentIdentifier, TraceOption, Position, InitializeParams};
 use serde_json::Value;
 use std::time::Duration;
 use std::io::{stdin, stdout, Write};
@@ -115,9 +115,15 @@ fn exit() -> ServerMessage {
 fn initialize(root_path: String) -> ServerMessage {
     let params = InitializeParams {
         process_id: None,
-        root_path: Some(root_path),
+        root_path: Some(root_path), // FIXME(#299): This property is deprecated. Instead Use `root_uri`.
+        root_uri: None,
         initialization_options: None,
-        capabilities: Value::Null,
+        capabilities: ClientCapabilities {
+            workspace: None,
+            text_document: None,
+            experimental: Value::Null,
+        },
+        trace: TraceOption::Off,
     };
     let request = Request {
         id: next_id(),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -43,8 +43,10 @@ fn test_goto_def() {
     let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
                                                  .expect("couldn't convert path to JSON"));
     let messages = vec![Message::new("initialize", vec![("processId", "0".to_owned()),
-                                                        ("capabilities", "null".to_owned()),
-                                                        ("rootPath", root_path)]),
+                                                        ("capabilities", "{ \"experimental\": null }".to_owned()),
+                                                        ("rootPath", root_path),
+                                                        ("rootUri", "null".to_owned()),
+                                                        ("trace", "\"off\"".to_owned())]),
                         Message::new("textDocument/definition",
                                      vec![("textDocument", text_doc),
                                           ("position", cache.mk_ls_position(src(&source_file_path, 22, "world")))])];
@@ -75,8 +77,10 @@ fn test_hover() {
     let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
                                                  .expect("couldn't convert path to JSON"));
     let messages = vec![Message::new("initialize", vec![("processId", "0".to_owned()),
-                                                        ("capabilities", "null".to_owned()),
-                                                        ("rootPath", root_path)]),
+                                                        ("capabilities", "{ \"experimental\": null }".to_owned()),
+                                                        ("rootPath", root_path),
+                                                        ("rootUri", "null".to_owned()),
+                                                        ("trace", "\"off\"".to_owned())]),
                         Message::new("textDocument/hover",
                                      vec![("textDocument", text_doc),
                                           ("position", cache.mk_ls_position(src(&source_file_path, 22, "world")))])];
@@ -109,9 +113,13 @@ fn test_find_all_refs() {
         "method": "initialize",
         "id": 0,
         "params": {{
-            "processId": "0",
-            "capabilities": null,
-            "rootPath": {}
+            "processId": 0,
+            "capabilities": {{
+                "experimental": null
+            }},
+            "rootPath": {},
+            "rootUri": null,
+            "trace": "off"
         }}
     }}"#, root_path), format!(r#"{{
         "jsonrpc": "2.0",
@@ -157,9 +165,13 @@ fn test_find_all_refs_no_cfg_test() {
         "method": "initialize",
         "id": 0,
         "params": {{
-            "processId": "0",
-            "capabilities": null,
-            "rootPath": {}
+            "processId": 0,
+            "capabilities": {{
+                "experimental": null
+            }},
+            "rootPath": {},
+            "rootUri": null,
+            "trace": "off"
         }}
     }}"#, root_path), format!(r#"{{
         "jsonrpc": "2.0",
@@ -199,9 +211,13 @@ fn test_borrow_error() {
         "method": "initialize",
         "id": 0,
         "params": {{
-            "processId": "0",
-            "capabilities": null,
-            "rootPath": {}
+            "processId": 0,
+            "capabilities": {{
+                "experimental": null
+            }},
+            "rootPath": {},
+            "rootUri": null,
+            "trace": "off"
         }}
     }}"#, root_path)];
 
@@ -231,9 +247,13 @@ fn test_highlight() {
         "method": "initialize",
         "id": 0,
         "params": {{
-            "processId": "0",
-            "capabilities": null,
-            "rootPath": {}
+            "processId": 0,
+            "capabilities": {{
+                "experimental": null
+            }},
+            "rootPath": {},
+            "rootUri": null,
+            "trace": "off"
         }}
     }}"#, root_path), format!(r#"{{
         "jsonrpc": "2.0",
@@ -275,9 +295,13 @@ fn test_rename() {
         "method": "initialize",
         "id": 0,
         "params": {{
-            "processId": "0",
-            "capabilities": null,
-            "rootPath": {}
+            "processId": 0,
+            "capabilities": {{
+                "experimental": null
+            }},
+            "rootPath": {},
+            "rootUri": null,
+            "trace": "off"
         }}
     }}"#, root_path), format!(r#"{{
         "jsonrpc": "2.0",
@@ -317,8 +341,10 @@ fn test_completion() {
     let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
                                                  .expect("couldn't convert path to JSON"));
     let messages = vec![Message::new("initialize", vec![("processId", "0".to_owned()),
-                                                        ("capabilities", "null".to_owned()),
-                                                        ("rootPath", root_path)]),
+                                                        ("capabilities", "{ \"experimental\": null }".to_owned()),
+                                                        ("rootPath", root_path),
+                                                        ("rootUri", "null".to_owned()),
+                                                        ("trace", "\"off\"".to_owned())]),
                         Message::new("textDocument/completion",
                                      vec![("textDocument", text_doc.to_owned()),
                                           ("position", cache.mk_ls_position(src(&source_file_path, 22, "rld")))]),

--- a/src/test/types.rs
+++ b/src/test/types.rs
@@ -49,7 +49,7 @@ impl Cache {
     pub fn mk_ls_position(&mut self, src: Src) -> String {
         let line = self.get_line(src);
         let col = line.find(src.name).expect(&format!("Line does not contain name {}", src.name));
-        format!("{{\"line\":\"{}\",\"character\":\"{}\"}}", src.line - 1, char_of_byte_index(&line, col))
+        format!("{{\"line\":{},\"character\":{}}}", src.line - 1, char_of_byte_index(&line, col))
     }
 
     pub fn abs_path(&self, file_name: &Path) -> PathBuf {


### PR DESCRIPTION
This change includes to upgrade [languageserver-types](https://github.com/gluon-lang/languageserver-types).
It also contains to bump up the Language Server Potocol which our used to v3.


## Related Issues

- Fix https://github.com/rust-lang-nursery/rls/issues/271
- Future work: https://github.com/rust-lang-nursery/rls/issues/299