### PR TITLE
Remove needless guide to set 'RLS_ROOT' from contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -83,16 +83,7 @@ For Linux, this path is called LD_LIBRARY_PATH.
 export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
 ```
 
-### Step 4: Set your RLS_ROOT
-
-Next, we'll set the RLS_ROOT environment variable to point to where we built
-the RLS:
-
-```
-export RLS_ROOT=/Source/rls
-```
-
-### Step 5: Download standard library metadata
+### Step 4: Download standard library metadata
 
 Finally, we need to get the metadata for the standard library.  This lets
 us get additional docs and types for all of `std`.  The command is currently only


### PR DESCRIPTION
Now, this paragraph is needless for this repository.

This envvar is used by [rls_vscode][rls_vscode], but it have the same guide in [its repository][rls_vscode_guide].

[rls_vscode]: https://github.com/jonathandturner/rls_vscod://github.com/editor-rs/vscode-rust
[rls_vscode_guide]: https://github.com/jonathandturner/rls_vscode/blob/a5eb35e5745375ac1068593c938907b827c16a95/README.md#via-source