### PR TITLE
Dump pkg version & build date & commit hash if run with `--version` flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "rls"
 version = "0.1.0"
 authors = ["Jonathan Turner <jturner@mozilla.com>"]
 
+build = "build.rs"
+
 [dependencies]
 cargo = { git = "https://github.com/rust-lang/cargo" }
 derive-new = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -12,21 +12,10 @@
 // [rustup]: https://github.com/rust-lang-nursery/rustup.rs/tree/a1c6be19add9c99f8d8868ec384aa76057fe7f70
 
 use std::env;
-use std::error::Error;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
-
-struct Ignore;
-
-impl<E> From<E> for Ignore
-    where E: Error
-{
-    fn from(_: E) -> Ignore {
-        Ignore
-    }
-}
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -41,24 +30,26 @@ fn main() {
 // (git not installed or if this is not a git repository) just return an empty string.
 fn commit_info() -> String {
     match (commit_hash(), commit_date()) {
-        (Ok(hash), Ok(date)) => format!(" ({} {})", hash.trim_right(), date),
+        (Some(hash), Some(date)) => format!(" ({} {})", hash.trim_right(), date),
         _ => String::new(),
     }
 }
 
-fn commit_hash() -> Result<String, Ignore> {
-    Ok(try!(String::from_utf8(try!(Command::new("git")
-                                       .args(&["rev-parse", "--short", "HEAD"])
-                                       .output())
-                                  .stdout)))
+fn commit_hash() -> Option<String> {
+    Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|r| String::from_utf8(r.stdout).ok())
 }
 
-fn commit_date() -> Result<String, Ignore> {
-    Ok(try!(String::from_utf8(try!(Command::new("git")
-                                       .args(&["log",
-                                               "-1",
-                                               "--date=short",
-                                               "--pretty=format:%cd"])
-                                       .output())
-                                  .stdout)))
+fn commit_date() -> Option<String> {
+    Command::new("git")
+        .args(&["log",
+                "-1",
+                "--date=short",
+                "--pretty=format:%cd"])
+        .output()
+        .ok()
+        .and_then(|r| String::from_utf8(r.stdout).ok())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,64 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// The original code is [rustup.rs][rustup]
+// [rustup]: https://github.com/rust-lang-nursery/rustup.rs/tree/a1c6be19add9c99f8d8868ec384aa76057fe7f70
+
+use std::env;
+use std::error::Error;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+struct Ignore;
+
+impl<E> From<E> for Ignore
+    where E: Error
+{
+    fn from(_: E) -> Ignore {
+        Ignore
+    }
+}
+
+fn main() {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    File::create(out_dir.join("commit-info.txt"))
+        .unwrap()
+        .write_all(commit_info().as_bytes())
+        .unwrap();
+}
+
+// Try to get hash and date of the last commit on a best effort basis. If anything goes wrong
+// (git not installed or if this is not a git repository) just return an empty string.
+fn commit_info() -> String {
+    match (commit_hash(), commit_date()) {
+        (Ok(hash), Ok(date)) => format!(" ({} {})", hash.trim_right(), date),
+        _ => String::new(),
+    }
+}
+
+fn commit_hash() -> Result<String, Ignore> {
+    Ok(try!(String::from_utf8(try!(Command::new("git")
+                                       .args(&["rev-parse", "--short", "HEAD"])
+                                       .output())
+                                  .stdout)))
+}
+
+fn commit_date() -> Result<String, Ignore> {
+    Ok(try!(String::from_utf8(try!(Command::new("git")
+                                       .args(&["log",
+                                               "-1",
+                                               "--date=short",
+                                               "--pretty=format:%cd"])
+                                       .output())
+                                  .stdout)))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,21 +51,19 @@ type Span = span::Span<span::ZeroIndexed>;
 pub fn main() {
     env_logger::init().unwrap();
 
-    let args: Vec<String> = ::std::env::args().collect();
-    if args[1] == "--version" || args[1] == "-V" {
-        println!("rls {}", version());
+    if let Some(first_arg) = ::std::env::args().skip(1).next() {
+        match first_arg.as_str() {
+            "--version" | "-V" => println!("rls {}", version()),
+            _ => cmd::run(),
+        }
         return;
     }
 
-    if args.len() > 1 {
-        cmd::run();
-    } else {
-        let analysis = Arc::new(analysis::AnalysisHost::new(analysis::Target::Debug));
-        let vfs = Arc::new(vfs::Vfs::new());
-        let build_queue = Arc::new(build::BuildQueue::new(vfs.clone()));
+    let analysis = Arc::new(analysis::AnalysisHost::new(analysis::Target::Debug));
+    let vfs = Arc::new(vfs::Vfs::new());
+    let build_queue = Arc::new(build::BuildQueue::new(vfs.clone()));
 
-        server::run_server(analysis, vfs, build_queue);
-    }
+    server::run_server(analysis, vfs, build_queue);
 }
 
 fn version() -> &'static str {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,8 +51,13 @@ type Span = span::Span<span::ZeroIndexed>;
 pub fn main() {
     env_logger::init().unwrap();
 
-    let arg_count = ::std::env::args().count();
-    if arg_count > 1 {
+    let args: Vec<String> = ::std::env::args().collect();
+    if args[1] == "--version" || args[1] == "-V" {
+        println!("rls {}", version());
+        return;
+    }
+
+    if args.len() > 1 {
         cmd::run();
     } else {
         let analysis = Arc::new(analysis::AnalysisHost::new(analysis::Target::Debug));
@@ -61,4 +66,8 @@ pub fn main() {
 
         server::run_server(analysis, vfs, build_queue);
     }
+}
+
+fn version() -> &'static str {
+    concat!(env!("CARGO_PKG_VERSION"), include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt")))
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,6 +1,0 @@
-use getopts::{Options, Matches};
-
-pub fn create_cmd_option() -> Options {
-    let mut opt = Options::new();
-    opt
-}

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,6 @@
+use getopts::{Options, Matches};
+
+pub fn create_cmd_option() -> Options {
+    let mut opt = Options::new();
+    opt
+}


### PR DESCRIPTION
- The output format is `rls <version> (<commit hash> <build date>)`.
- This embed approach is based on [rustup.rs][rustup]'s code.
  - rustup.rs is licensed under same licenses (Apache 2.0/MIT),
    so I think there is no license problem.

[rustup]: https://github.com/rust-lang-nursery/rustup.rs/tree/a1c6be19add9c99f8d8868ec384aa76057fe7f70

## Related Issues

- https://github.com/rust-lang-nursery/rls/issues/304