### PR TITLE
 Use json! macro to construct json string for testing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,13 @@ extern crate rustfmt;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+
+#[cfg(test)]
+#[macro_use]
 extern crate serde_json;
+#[cfg(not(test))]
+extern crate serde_json;
+
 extern crate toml;
 extern crate url;
 extern crate url_serde;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -49,8 +49,10 @@ fn test_goto_def() {
                                                         ("rootUri", "null".to_owned()),
                                                         ("trace", "\"off\"".to_owned())]),
                         Message::new("textDocument/definition",
-                                     vec![("textDocument", text_doc),
-                                          ("position", cache.mk_ls_position_str(src(&source_file_path, 22, "world")))])];
+                                     vec![
+                                        ("textDocument", text_doc),
+                                        ("position", serde_json::to_string(&cache.mk_ls_position(src(&source_file_path, 22, "world"))).expect("couldn't convert path to JSON"))
+                                     ])];
     let (server, results) = mock_server(messages);
     // Initialise and build.
     assert_eq!(ls_server::LsService::handle_message(server.clone()),
@@ -83,8 +85,10 @@ fn test_hover() {
                                                         ("rootUri", "null".to_owned()),
                                                         ("trace", "\"off\"".to_owned())]),
                         Message::new("textDocument/hover",
-                                     vec![("textDocument", text_doc),
-                                          ("position", cache.mk_ls_position_str(src(&source_file_path, 22, "world")))])];
+                                     vec![
+                                        ("textDocument", text_doc),
+                                        ("position", serde_json::to_string(&cache.mk_ls_position(src(&source_file_path, 22, "world"))).expect("couldn't convert path to JSON"))
+                                     ])];
     let (server, results) = mock_server(messages);
     // Initialise and build.
     assert_eq!(ls_server::LsService::handle_message(server.clone()),
@@ -353,11 +357,15 @@ fn test_completion() {
                                                         ("rootUri", "null".to_owned()),
                                                         ("trace", "\"off\"".to_owned())]),
                         Message::new("textDocument/completion",
-                                     vec![("textDocument", text_doc.to_owned()),
-                                          ("position", cache.mk_ls_position_str(src(&source_file_path, 22, "rld")))]),
+                                     vec![
+                                        ("textDocument", text_doc.to_owned()),
+                                        ("position",  serde_json::to_string(&cache.mk_ls_position(src(&source_file_path, 22, "rld"))).expect("couldn't convert path to JSON"))
+                                    ]),
                         Message::new("textDocument/completion",
-                                     vec![("textDocument", text_doc.to_owned()),
-                                          ("position", cache.mk_ls_position_str(src(&source_file_path, 25, "x)")))])];
+                                     vec![
+                                        ("textDocument", text_doc.to_owned()),
+                                        ("position", serde_json::to_string(&cache.mk_ls_position(src(&source_file_path, 25, "x)"))).expect("couldn't convert path to JSON"))
+                                     ])];
     let (server, results) = mock_server(messages);
     // Initialise and build.
     assert_eq!(ls_server::LsService::handle_message(server.clone()),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -41,8 +41,7 @@ fn test_goto_def() {
     let root_path = format!("{}", serde_json::to_string(&cache.abs_path(Path::new(".")))
                                       .expect("couldn't convert path to JSON"));
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
-    let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
-                                                 .expect("couldn't convert path to JSON"));
+    let text_doc = serde_json::to_string(&TextDocumentIdentifier::new(url)).expect("couldn't convert path to JSON");
     let messages = vec![Message::new("initialize", vec![("processId", "0".to_owned()),
                                                         ("capabilities", "{ \"experimental\": null }".to_owned()),
                                                         ("rootPath", root_path),
@@ -77,8 +76,7 @@ fn test_hover() {
                                       .expect("couldn't convert path to JSON"));
 
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
-    let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
-                                                 .expect("couldn't convert path to JSON"));
+    let text_doc = serde_json::to_string(&TextDocumentIdentifier::new(url)).expect("couldn't convert path to JSON");
     let messages = vec![Message::new("initialize", vec![("processId", "0".to_owned()),
                                                         ("capabilities", "{ \"experimental\": null }".to_owned()),
                                                         ("rootPath", root_path),
@@ -349,8 +347,7 @@ fn test_completion() {
     let root_path = format!("{}", serde_json::to_string(&cache.abs_path(Path::new(".")))
                                       .expect("couldn't convert path to JSON"));
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
-    let text_doc = format!("{{\"uri\":{}}}", serde_json::to_string(&url.as_str().to_owned())
-                                                 .expect("couldn't convert path to JSON"));
+    let text_doc = serde_json::to_string(&TextDocumentIdentifier::new(url)).expect("couldn't convert path to JSON");
     let messages = vec![Message::new("initialize", vec![("processId", "0".to_owned()),
                                                         ("capabilities", "{ \"experimental\": null }".to_owned()),
                                                         ("rootPath", root_path),

--- a/src/test/types.rs
+++ b/src/test/types.rs
@@ -14,6 +14,8 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::io::{BufRead, BufReader};
 
+use ls_types;
+
 #[derive(Clone, Copy, Debug)]
 pub struct Src<'a, 'b> {
     pub file_name: &'a Path,
@@ -46,10 +48,16 @@ impl Cache {
         }
     }
 
-    pub fn mk_ls_position(&mut self, src: Src) -> String {
+    pub fn mk_ls_position_str(&mut self, src: Src) -> String {
         let line = self.get_line(src);
         let col = line.find(src.name).expect(&format!("Line does not contain name {}", src.name));
         format!("{{\"line\":{},\"character\":{}}}", src.line - 1, char_of_byte_index(&line, col))
+    }
+
+    pub fn mk_ls_position(&mut self, src: Src) -> ls_types::Position {
+        let line = self.get_line(src);
+        let col = line.find(src.name).expect(&format!("Line does not contain name {}", src.name));
+        ls_types::Position::new( (src.line - 1) as u64,  char_of_byte_index(&line, col) as u64)
     }
 
     pub fn abs_path(&self, file_name: &Path) -> PathBuf {

--- a/src/test/types.rs
+++ b/src/test/types.rs
@@ -48,12 +48,6 @@ impl Cache {
         }
     }
 
-    pub fn mk_ls_position_str(&mut self, src: Src) -> String {
-        let line = self.get_line(src);
-        let col = line.find(src.name).expect(&format!("Line does not contain name {}", src.name));
-        format!("{{\"line\":{},\"character\":{}}}", src.line - 1, char_of_byte_index(&line, col))
-    }
-
     pub fn mk_ls_position(&mut self, src: Src) -> ls_types::Position {
         let line = self.get_line(src);
         let col = line.find(src.name).expect(&format!("Line does not contain name {}", src.name));


### PR DESCRIPTION
- This fix https://github.com/rust-lang-nursery/rls/issues/303
- This is not a part of https://github.com/rust-lang-nursery/rls/issues/305
- This does not touch a part of constructing expected results because they compares partial strings with an actual results.