### PR TITLE
Update language server types, making ClientCapabilities.experimental optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "cargo 0.20.0 (git+https://github.com/rust-lang/cargo)",
  "derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "languageserver-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "languageserver-types 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-analysis 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "languageserver-types"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1148,7 +1148,7 @@ dependencies = [
 "checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum languageserver-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8de566291d854d66c503833cb785db8cc0eae23dc5962fef6edb78a966f98fd2"
+"checksum languageserver-types 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea607ef903b101632266f62bb4b544f0ab209c564b2dd1d2e61b12d110f05f2f"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "babb8281da88cba992fa1f4ddec7d63ed96280a1a53ec9b919fd37b53d71e502"
 "checksum libgit2-sys 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a3aaa20337a0e79fb75180b6a1970c1f7cff9a413f570d6b999b38a5d5d54e81"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ build = "build.rs"
 cargo = { git = "https://github.com/rust-lang/cargo" }
 derive-new = "0.3"
 env_logger = "0.4"
-languageserver-types = "0.8.0"
+languageserver-types = "0.9.0"
 log = "0.3"
 racer = "2.0.6"
 rls-analysis = "0.2.1"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -18,7 +18,6 @@ use vfs::Vfs;
 use server::{self, ServerMessage, Request, Notification, Method, LsService, ParseError, ResponseData};
 
 use ls_types::{ClientCapabilities, TextDocumentPositionParams, TextDocumentIdentifier, TraceOption, Position, InitializeParams};
-use serde_json::Value;
 use std::time::Duration;
 use std::io::{stdin, stdout, Write};
 use std::path::Path;
@@ -121,7 +120,7 @@ fn initialize(root_path: String) -> ServerMessage {
         capabilities: ClientCapabilities {
             workspace: None,
             text_document: None,
-            experimental: Value::Null,
+            experimental: None,
         },
         trace: TraceOption::Off,
     };

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -78,7 +78,7 @@ fn test_hover() {
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
     let text_doc = serde_json::to_string(&TextDocumentIdentifier::new(url)).expect("couldn't convert path to JSON");
     let messages = vec![Message::new("initialize", vec![("processId", "0".to_owned()),
-                                                        ("capabilities", "{ \"experimental\": null }".to_owned()),
+                                                        ("capabilities", "{}".to_owned()),
                                                         ("rootPath", root_path),
                                                         ("rootUri", "null".to_owned()),
                                                         ("trace", "\"off\"".to_owned())]),
@@ -116,9 +116,7 @@ fn test_find_all_refs() {
             "id": 0,
             "params": {
                 "processId": 0,
-                "capabilities": {
-                    "experimental": null
-                },
+                "capabilities": {},
                 "rootPath": root_path,
                 "rootUri": null,
                 "trace": "off"
@@ -169,9 +167,7 @@ fn test_find_all_refs_no_cfg_test() {
             "id": 0,
             "params": {
                 "processId": 0,
-                "capabilities": {
-                    "experimental": null
-                },
+                "capabilities": {},
                 "rootPath": root_path,
                 "rootUri": null,
                 "trace": "off"
@@ -217,9 +213,7 @@ fn test_borrow_error() {
             "id": 0,
             "params": {
                 "processId": 0,
-                "capabilities": {
-                    "experimental": null
-                },
+                "capabilities": {},
                 "rootPath": root_path,
                 "rootUri": null,
                 "trace": "off"
@@ -254,9 +248,7 @@ fn test_highlight() {
             "id": 0,
             "params": {
                 "processId": 0,
-                "capabilities": {
-                    "experimental": null
-                },
+                "capabilities": {},
                 "rootPath": root_path,
                 "rootUri": null,
                 "trace": "off"
@@ -303,9 +295,7 @@ fn test_rename() {
             "id": 0,
             "params": {
                 "processId": 0,
-                "capabilities": {
-                    "experimental": null
-                },
+                "capabilities": {},
                 "rootPath": root_path,
                 "rootUri": null,
                 "trace": "off"
@@ -349,7 +339,7 @@ fn test_completion() {
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
     let text_doc = serde_json::to_string(&TextDocumentIdentifier::new(url)).expect("couldn't convert path to JSON");
     let messages = vec![Message::new("initialize", vec![("processId", "0".to_owned()),
-                                                        ("capabilities", "{ \"experimental\": null }".to_owned()),
+                                                        ("capabilities", "{}".to_owned()),
                                                         ("rootPath", root_path),
                                                         ("rootUri", "null".to_owned()),
                                                         ("trace", "\"off\"".to_owned())]),


### PR DESCRIPTION
Fixes #312.

- Update "languageserver-types" to 0.9.0;
- Modify initialization params to use `None` in experimental field of ClientCapabilities;
- Change tests to consider an empty object in "capabilities" instead of { "experimental": null }.