### PR TITLE
Use ServerMessages in tests

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -107,7 +107,7 @@ fn def(file_name: &str, row: &str, col: &str) -> ServerMessage {
     };
     let request = Request {
         id: next_id(),
-        method: Method::GotoDef(params),
+        method: Method::GotoDefinition(params),
     };
     ServerMessage::Request(request)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(rustc_private)]
+#![feature(concat_idents)]
 
 extern crate cargo;
 #[macro_use]

--- a/src/server.rs
+++ b/src/server.rs
@@ -620,22 +620,22 @@ mod test {
     fn server_message_get_method_name() {
         let test_url = Url::from_str("http://testurl").expect("Couldn't parse test URI");
 
-        let request_shut = ServerMessage::Request(Request { id: 1, method: Method::Shutdown });
+        let request_shut = ServerMessage::request(1, Method::Shutdown);
         assert_eq!(request_shut.get_method_name(), "shutdown");
 
-        let request_init = ServerMessage::simple_test_initialize(1, None);
+        let request_init = ServerMessage::initialize(1, None);
         assert_eq!(request_init.get_method_name(), "initialize");
 
-        let request_hover = ServerMessage::Request(Request { id: 1, method: Method::Hover(TextDocumentPositionParams {
+        let request_hover = ServerMessage::request(1, Method::Hover(TextDocumentPositionParams {
             text_document: TextDocumentIdentifier { uri: test_url.clone() },
             position: Position { line: 0, character: 0 },
-        })});
+        }));
         assert_eq!(request_hover.get_method_name(), "textDocument/hover");
 
 
-        let request_resolve = ServerMessage::Request(Request {id: 1, method: Method::ResolveCompletionItem(
+        let request_resolve = ServerMessage::request(1, Method::ResolveCompletionItem(
             CompletionItem::new_simple("label".to_owned(), "detail".to_owned())
-        )});
+        ));
         assert_eq!(request_resolve.get_method_name(), "completionItem/resolve");
 
         let notif_exit = ServerMessage::Notification(Notification::Exit);
@@ -655,7 +655,7 @@ mod test {
 
     #[test]
     fn server_message_to_str() {
-        let request = ServerMessage::Request(Request { id: 1, method: Method::Shutdown });
+        let request = ServerMessage::request(1, Method::Shutdown);
         let request_json: serde_json::Value = serde_json::from_str(&request.to_message_str()).unwrap();
         let expected_json = json!({
             "jsonrpc": "2.0",
@@ -667,10 +667,10 @@ mod test {
         println!("{0}", request_json);
 
         let test_url = Url::from_str("http://testurl").expect("Couldn't parse test URI");
-        let request = ServerMessage::Request(Request { id: 2, method: Method::Hover(TextDocumentPositionParams {
+        let request = ServerMessage::request(2, Method::Hover(TextDocumentPositionParams {
             text_document: TextDocumentIdentifier { uri: test_url.clone() },
             position: Position { line: 0, character: 0 },
-        })});
+        }));
         let request_json: serde_json::Value = serde_json::from_str(&request.to_message_str()).unwrap();
         assert_eq!(request_json.get("jsonrpc").unwrap().as_str().unwrap(), "2.0");
         assert_eq!(request_json.get("id").unwrap().as_i64().unwrap(), 2);

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -33,7 +33,7 @@ use std::path::{Path, PathBuf};
 const TEST_TIMEOUT_IN_SEC: u64 = 10;
 
 impl ServerMessage {
-    pub fn simple_test_initialize(id: usize, root_path: Option<String>) -> ServerMessage {
+    pub fn initialize(id: usize, root_path: Option<String>) -> ServerMessage {
         ServerMessage::Request(Request {
             id: id,
             method: Method::Initialize(InitializeParams {
@@ -50,6 +50,10 @@ impl ServerMessage {
             })
         })
     }
+
+    pub fn request(id: usize, method: Method) -> ServerMessage {
+        ServerMessage::Request(Request { id: id, method: method })
+    }
 }
 
 #[test]
@@ -62,11 +66,11 @@ fn test_goto_def() {
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
 
     let messages = vec![
-        ServerMessage::simple_test_initialize(0,root_path.as_os_str().to_str().map(|x| x.to_owned())),
-        ServerMessage::Request(Request { id: 11, method: Method::GotoDefinition(TextDocumentPositionParams {
+        ServerMessage::initialize(0,root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::request(11, Method::GotoDefinition(TextDocumentPositionParams {
             text_document: TextDocumentIdentifier::new(url),
             position: cache.mk_ls_position(src(&source_file_path, 22, "world"))
-        })}),
+        })),
     ];
 
     let (server, results) = mock_server(messages);
@@ -93,11 +97,11 @@ fn test_hover() {
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
 
     let messages = vec![
-        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
-        ServerMessage::Request(Request { id: 11, method: Method::Hover(TextDocumentPositionParams {
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::request(11, Method::Hover(TextDocumentPositionParams {
             text_document: TextDocumentIdentifier::new(url),
             position: cache.mk_ls_position(src(&source_file_path, 22, "world"))
-        })}),
+        })),
     ];
 
     let (server, results) = mock_server(messages);
@@ -123,12 +127,12 @@ fn test_find_all_refs() {
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
 
     let messages : Vec<String> = vec![
-        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
-        ServerMessage::Request(Request { id: 42, method: Method::References(ReferenceParams {
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::request(42, Method::References(ReferenceParams {
             text_document: TextDocumentIdentifier::new(url),
             position: cache.mk_ls_position(src(&source_file_path, 10, "Bar")),
             context: ReferenceContext { include_declaration: true }
-        })}),
+        })),
     ].iter().map(ServerMessage::to_message_str).collect();
 
     let (server, results) = mock_raw_server(messages);
@@ -156,12 +160,12 @@ fn test_find_all_refs_no_cfg_test() {
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
 
     let messages : Vec<String> = vec![
-        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
-        ServerMessage::Request(Request { id: 42, method: Method::References(ReferenceParams {
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::request(42, Method::References(ReferenceParams {
             text_document: TextDocumentIdentifier::new(url),
             position: cache.mk_ls_position(src(&source_file_path, 10, "Bar")),
             context: ReferenceContext { include_declaration: true }
-        })}),
+        })),
     ].iter().map(ServerMessage::to_message_str).collect();
 
     let (server, results) = mock_raw_server(messages);
@@ -184,7 +188,7 @@ fn test_borrow_error() {
 
     let root_path = cache.abs_path(Path::new("."));
     let messages : Vec<String> = vec![
-        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned()))
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned()))
     ].iter().map(ServerMessage::to_message_str).collect();
 
     let (server, results) = mock_raw_server(messages);
@@ -207,11 +211,11 @@ fn test_highlight() {
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
 
     let messages : Vec<String> = vec![
-        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
-        ServerMessage::Request(Request { id: 42, method: Method::DocumentHighlight(TextDocumentPositionParams {
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::request(42, Method::DocumentHighlight(TextDocumentPositionParams {
             text_document: TextDocumentIdentifier::new(url),
             position: cache.mk_ls_position(src(&source_file_path, 22, "world"))
-        })}),
+        })),
     ].iter().map(ServerMessage::to_message_str).collect();
 
     let (server, results) = mock_raw_server(messages);
@@ -238,12 +242,12 @@ fn test_rename() {
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
     let text_doc = TextDocumentIdentifier::new(url);
     let messages : Vec<String> = vec![
-        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
-        ServerMessage::Request(Request { id: 42, method: Method::Rename(RenameParams {
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::request(42, Method::Rename(RenameParams {
             text_document: text_doc,
             position: cache.mk_ls_position(src(&source_file_path, 22, "world")),
             new_name: "foo".to_owned()
-        })}),
+        })),
     ].iter().map(ServerMessage::to_message_str).collect();
 
     let (server, results) = mock_raw_server(messages);
@@ -272,15 +276,15 @@ fn test_completion() {
     let text_doc = TextDocumentIdentifier::new(url);
 
     let messages = vec![
-        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
-        ServerMessage::Request(Request { id: 11, method: Method::Completion(TextDocumentPositionParams {
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::request(11, Method::Completion(TextDocumentPositionParams {
             text_document: text_doc.clone(),
             position: cache.mk_ls_position(src(&source_file_path, 22, "rld"))
-        })}),
-        ServerMessage::Request(Request { id: 22, method: Method::Completion(TextDocumentPositionParams {
+        })),
+        ServerMessage::request(22, Method::Completion(TextDocumentPositionParams {
             text_document: text_doc.clone(),
             position: cache.mk_ls_position(src(&source_file_path, 25, "x)"))
-        })}),
+        })),
     ];
 
     let (server, results) = mock_server(messages);

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -20,17 +20,37 @@ use env_logger;
 
 use analysis;
 use build;
-use server as ls_server;
+use server::{self as ls_server, ServerMessage, Request, Method};
 use vfs;
 
 use self::types::src;
 
 use url::Url;
-use ls_types::TextDocumentIdentifier;
+use ls_types::*;
 use serde_json;
 use std::path::{Path, PathBuf};
 
 const TEST_TIMEOUT_IN_SEC: u64 = 10;
+
+impl ServerMessage {
+    pub fn simple_test_initialize(id: usize, root_path: Option<String>) -> ServerMessage {
+        ServerMessage::Request(Request {
+            id: id,
+            method: Method::Initialize(InitializeParams {
+                process_id: None,
+                root_path: root_path,
+                root_uri: None,
+                initialization_options: None,
+                capabilities: ClientCapabilities {
+                    workspace: None,
+                    text_document: None,
+                    experimental: None,
+                },
+                trace: TraceOption::Off,
+            })
+        })
+    }
+}
 
 #[test]
 fn test_goto_def() {
@@ -38,32 +58,29 @@ fn test_goto_def() {
 
     let source_file_path = Path::new("src").join("main.rs");
 
-    let root_path = format!("{}", serde_json::to_string(&cache.abs_path(Path::new(".")))
-                                      .expect("couldn't convert path to JSON"));
+    let root_path = cache.abs_path(Path::new("."));
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
-    let text_doc = serde_json::to_string(&TextDocumentIdentifier::new(url)).expect("couldn't convert path to JSON");
-    let messages = vec![Message::new("initialize", vec![("processId", "0".to_owned()),
-                                                        ("capabilities", "{ \"experimental\": null }".to_owned()),
-                                                        ("rootPath", root_path),
-                                                        ("rootUri", "null".to_owned()),
-                                                        ("trace", "\"off\"".to_owned())]),
-                        Message::new("textDocument/definition",
-                                     vec![
-                                        ("textDocument", text_doc),
-                                        ("position", serde_json::to_string(&cache.mk_ls_position(src(&source_file_path, 22, "world"))).expect("couldn't convert path to JSON"))
-                                     ])];
+
+    let messages = vec![
+        ServerMessage::simple_test_initialize(0,root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::Request(Request { id: 11, method: Method::GotoDefinition(TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier::new(url),
+            position: cache.mk_ls_position(src(&source_file_path, 22, "world"))
+        })}),
+    ];
+
     let (server, results) = mock_server(messages);
     // Initialise and build.
     assert_eq!(ls_server::LsService::handle_message(server.clone()),
                ls_server::ServerStateChange::Continue);
-    expect_messages(results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains("capabilities"),
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
 
     assert_eq!(ls_server::LsService::handle_message(server.clone()),
                ls_server::ServerStateChange::Continue);
     // TODO structural checking of result, rather than looking for a string - src(&source_file_path, 12, "world")
-    expect_messages(results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains("\"start\":{\"line\":20,\"character\":8}")]);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(11)).expect_contains(r#""start":{"line":20,"character":8}"#)]);
 }
 
 #[test]
@@ -72,32 +89,28 @@ fn test_hover() {
 
     let source_file_path = Path::new("src").join("main.rs");
 
-    let root_path = format!("{}", serde_json::to_string(&cache.abs_path(Path::new(".")))
-                                      .expect("couldn't convert path to JSON"));
-
+    let root_path = cache.abs_path(Path::new("."));
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
-    let text_doc = serde_json::to_string(&TextDocumentIdentifier::new(url)).expect("couldn't convert path to JSON");
-    let messages = vec![Message::new("initialize", vec![("processId", "0".to_owned()),
-                                                        ("capabilities", "{}".to_owned()),
-                                                        ("rootPath", root_path),
-                                                        ("rootUri", "null".to_owned()),
-                                                        ("trace", "\"off\"".to_owned())]),
-                        Message::new("textDocument/hover",
-                                     vec![
-                                        ("textDocument", text_doc),
-                                        ("position", serde_json::to_string(&cache.mk_ls_position(src(&source_file_path, 22, "world"))).expect("couldn't convert path to JSON"))
-                                     ])];
+
+    let messages = vec![
+        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::Request(Request { id: 11, method: Method::Hover(TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier::new(url),
+            position: cache.mk_ls_position(src(&source_file_path, 22, "world"))
+        })}),
+    ];
+
     let (server, results) = mock_server(messages);
     // Initialise and build.
     assert_eq!(ls_server::LsService::handle_message(server.clone()),
                ls_server::ServerStateChange::Continue);
-    expect_messages(results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains("capabilities"),
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
 
     assert_eq!(ls_server::LsService::handle_message(server.clone()),
                ls_server::ServerStateChange::Continue);
-    expect_messages(results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains("[{\"language\":\"rust\",\"value\":\"&str\"}]")]);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(11)).expect_contains(r#"[{"language":"rust","value":"&str"}]"#)]);
 }
 
 #[test]
@@ -108,33 +121,15 @@ fn test_find_all_refs() {
 
     let root_path = cache.abs_path(Path::new("."));
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
-    let text_doc = TextDocumentIdentifier::new(url);
-    let messages = vec![
-        json!({
-            "jsonrpc": "2.0",
-            "method": "initialize",
-            "id": 0,
-            "params": {
-                "processId": 0,
-                "capabilities": {},
-                "rootPath": root_path,
-                "rootUri": null,
-                "trace": "off"
-            }
-        }).to_string(),
-        json!({
-            "jsonrpc": "2.0",
-            "method": "textDocument/references",
-            "id": 42,
-            "params": {
-                "textDocument": text_doc,
-                "position": cache.mk_ls_position(src(&source_file_path, 10, "Bar")),
-                "context": {
-                    "includeDeclaration": true
-                }
-            }
-        }).to_string()
-    ];
+
+    let messages : Vec<String> = vec![
+        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::Request(Request { id: 42, method: Method::References(ReferenceParams {
+            text_document: TextDocumentIdentifier::new(url),
+            position: cache.mk_ls_position(src(&source_file_path, 10, "Bar")),
+            context: ReferenceContext { include_declaration: true }
+        })}),
+    ].iter().map(ServerMessage::to_message_str).collect();
 
     let (server, results) = mock_raw_server(messages);
     // Initialise and build.
@@ -159,33 +154,15 @@ fn test_find_all_refs_no_cfg_test() {
 
     let root_path = cache.abs_path(Path::new("."));
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
-    let text_doc = TextDocumentIdentifier::new(url);
-    let messages = vec![
-        json!({
-            "jsonrpc": "2.0",
-            "method": "initialize",
-            "id": 0,
-            "params": {
-                "processId": 0,
-                "capabilities": {},
-                "rootPath": root_path,
-                "rootUri": null,
-                "trace": "off"
-            }
-        }).to_string(),
-        json!({
-            "jsonrpc": "2.0",
-            "method": "textDocument/references",
-            "id": 42,
-            "params": {
-                "textDocument": text_doc,
-                "position": cache.mk_ls_position(src(&source_file_path, 10, "Bar")),
-                "context": {
-                    "includeDeclaration": true
-                }
-            }
-        }).to_string()
-    ];
+
+    let messages : Vec<String> = vec![
+        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::Request(Request { id: 42, method: Method::References(ReferenceParams {
+            text_document: TextDocumentIdentifier::new(url),
+            position: cache.mk_ls_position(src(&source_file_path, 10, "Bar")),
+            context: ReferenceContext { include_declaration: true }
+        })}),
+    ].iter().map(ServerMessage::to_message_str).collect();
 
     let (server, results) = mock_raw_server(messages);
     // Initialise and build.
@@ -206,20 +183,9 @@ fn test_borrow_error() {
     let (cache, _tc) = init_env("borrow_error");
 
     let root_path = cache.abs_path(Path::new("."));
-    let messages = vec![
-        json!({
-            "jsonrpc": "2.0",
-            "method": "initialize",
-            "id": 0,
-            "params": {
-                "processId": 0,
-                "capabilities": {},
-                "rootPath": root_path,
-                "rootUri": null,
-                "trace": "off"
-            }
-        }).to_string()
-    ];
+    let messages : Vec<String> = vec![
+        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned()))
+    ].iter().map(ServerMessage::to_message_str).collect();
 
     let (server, results) = mock_raw_server(messages);
     // Initialise and build.
@@ -227,7 +193,7 @@ fn test_borrow_error() {
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
-                                       ExpectedMessage::new(None).expect_contains("\"secondaryRanges\":[{\"start\":{\"line\":2,\"character\":17},\"end\":{\"line\":2,\"character\":18},\"label\":\"first mutable borrow occurs here\"}"),
+                                       ExpectedMessage::new(None).expect_contains(r#"secondaryRanges":[{"start":{"line":2,"character":17},"end":{"line":2,"character":18},"label":"first mutable borrow occurs here"}"#),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
 }
 
@@ -239,31 +205,14 @@ fn test_highlight() {
 
     let root_path = cache.abs_path(Path::new("."));
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
-    let text_doc = TextDocumentIdentifier::new(url);
 
-    let messages = vec![
-        json!({
-            "jsonrpc": "2.0",
-            "method": "initialize",
-            "id": 0,
-            "params": {
-                "processId": 0,
-                "capabilities": {},
-                "rootPath": root_path,
-                "rootUri": null,
-                "trace": "off"
-            }
-        }).to_string(),
-        json!({
-            "jsonrpc": "2.0",
-            "method": "textDocument/documentHighlight",
-            "id": 42,
-            "params": {
-                "textDocument": text_doc,
-                "position": cache.mk_ls_position(src(&source_file_path, 22, "world"))
-            }
-        }).to_string()
-    ];
+    let messages : Vec<String> = vec![
+        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::Request(Request { id: 42, method: Method::DocumentHighlight(TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier::new(url),
+            position: cache.mk_ls_position(src(&source_file_path, 22, "world"))
+        })}),
+    ].iter().map(ServerMessage::to_message_str).collect();
 
     let (server, results) = mock_raw_server(messages);
     // Initialise and build.
@@ -288,30 +237,14 @@ fn test_rename() {
     let root_path = cache.abs_path(Path::new("."));
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
     let text_doc = TextDocumentIdentifier::new(url);
-    let messages = vec![
-        json!({
-            "jsonrpc": "2.0",
-            "method": "initialize",
-            "id": 0,
-            "params": {
-                "processId": 0,
-                "capabilities": {},
-                "rootPath": root_path,
-                "rootUri": null,
-                "trace": "off"
-            }
-        }).to_string(),
-        json!({
-            "jsonrpc": "2.0",
-            "method": "textDocument/rename",
-            "id": 42,
-            "params": {
-                "textDocument": text_doc,
-                "position": cache.mk_ls_position(src(&source_file_path, 22, "world")),
-                "newName": "foo"
-            }
-        }).to_string()
-    ];
+    let messages : Vec<String> = vec![
+        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::Request(Request { id: 42, method: Method::Rename(RenameParams {
+            text_document: text_doc,
+            position: cache.mk_ls_position(src(&source_file_path, 22, "world")),
+            new_name: "foo".to_owned()
+        })}),
+    ].iter().map(ServerMessage::to_message_str).collect();
 
     let (server, results) = mock_raw_server(messages);
     // Initialise and build.
@@ -334,40 +267,37 @@ fn test_completion() {
 
     let source_file_path = Path::new("src").join("main.rs");
 
-    let root_path = format!("{}", serde_json::to_string(&cache.abs_path(Path::new(".")))
-                                      .expect("couldn't convert path to JSON"));
+    let root_path = cache.abs_path(Path::new("."));
     let url = Url::from_file_path(cache.abs_path(&source_file_path)).expect("couldn't convert file path to URL");
-    let text_doc = serde_json::to_string(&TextDocumentIdentifier::new(url)).expect("couldn't convert path to JSON");
-    let messages = vec![Message::new("initialize", vec![("processId", "0".to_owned()),
-                                                        ("capabilities", "{}".to_owned()),
-                                                        ("rootPath", root_path),
-                                                        ("rootUri", "null".to_owned()),
-                                                        ("trace", "\"off\"".to_owned())]),
-                        Message::new("textDocument/completion",
-                                     vec![
-                                        ("textDocument", text_doc.to_owned()),
-                                        ("position",  serde_json::to_string(&cache.mk_ls_position(src(&source_file_path, 22, "rld"))).expect("couldn't convert path to JSON"))
-                                    ]),
-                        Message::new("textDocument/completion",
-                                     vec![
-                                        ("textDocument", text_doc.to_owned()),
-                                        ("position", serde_json::to_string(&cache.mk_ls_position(src(&source_file_path, 25, "x)"))).expect("couldn't convert path to JSON"))
-                                     ])];
+    let text_doc = TextDocumentIdentifier::new(url);
+
+    let messages = vec![
+        ServerMessage::simple_test_initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+        ServerMessage::Request(Request { id: 11, method: Method::Completion(TextDocumentPositionParams {
+            text_document: text_doc.clone(),
+            position: cache.mk_ls_position(src(&source_file_path, 22, "rld"))
+        })}),
+        ServerMessage::Request(Request { id: 22, method: Method::Completion(TextDocumentPositionParams {
+            text_document: text_doc.clone(),
+            position: cache.mk_ls_position(src(&source_file_path, 25, "x)"))
+        })}),
+    ];
+
     let (server, results) = mock_server(messages);
     // Initialise and build.
     assert_eq!(ls_server::LsService::handle_message(server.clone()),
                ls_server::ServerStateChange::Continue);
-    expect_messages(results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains("capabilities"),
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
 
     assert_eq!(ls_server::LsService::handle_message(server.clone()),
                ls_server::ServerStateChange::Continue);
-    expect_messages(results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains("[{\"label\":\"world\",\"kind\":6,\"detail\":\"let world = \\\"world\\\";\"}]")]);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(11)).expect_contains(r#"[{"label":"world","kind":6,"detail":"let world = \"world\";"}]"#)]);
 
     assert_eq!(ls_server::LsService::handle_message(server.clone()),
                ls_server::ServerStateChange::Continue);
-    expect_messages(results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains("[{\"label\":\"x\",\"kind\":5,\"detail\":\"u64\"}]")]);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(22)).expect_contains(r#"{"label":"x","kind":5,"detail":"u64"#)]);
 }
 
 #[test]
@@ -396,7 +326,7 @@ fn test_parse_error_on_malformed_input() {
 }
 
 // Initialise and run the internals of an LS protocol RLS server.
-fn mock_server(messages: Vec<Message>) -> (Arc<ls_server::LsService>, LsResultList)
+fn mock_server(messages: Vec<ServerMessage>) -> (Arc<ls_server::LsService>, LsResultList)
 {
     let analysis = Arc::new(analysis::AnalysisHost::new(analysis::Target::Debug));
     let vfs = Arc::new(vfs::Vfs::new());
@@ -420,12 +350,12 @@ fn mock_raw_server(messages: Vec<String>) -> (Arc<ls_server::LsService>, LsResul
 }
 
 struct MockMsgReader {
-    messages: Vec<Message>,
+    messages: Vec<ServerMessage>,
     cur: Mutex<usize>,
 }
 
 impl MockMsgReader {
-    fn new(messages: Vec<Message>) -> MockMsgReader {
+    fn new(messages: Vec<ServerMessage>) -> MockMsgReader {
         MockMsgReader {
             messages: messages,
             cur: Mutex::new(0),
@@ -447,21 +377,6 @@ impl MockRawMsgReader {
     }
 }
 
-// TODO should have a structural way of making params, rather than taking Strings
-struct Message {
-    method: &'static str,
-    params: Vec<(&'static str, String)>,
-}
-
-impl Message {
-    fn new(method: &'static str, params: Vec<(&'static str, String)>) -> Message {
-        Message {
-            method: method,
-            params: params,
-        }
-    }
-}
-
 impl ls_server::MessageReader for MockMsgReader {
     fn read_message(&self) -> Option<String> {
         // Note that we hold this lock until the end of the function, thus meaning
@@ -476,16 +391,7 @@ impl ls_server::MessageReader for MockMsgReader {
 
         let message = &self.messages[index];
 
-        let params = message.params.iter().map(|&(k, ref v)| format!("\"{}\":{}", k, v)).collect::<Vec<String>>().join(",");
-        // TODO don't hardcode the id, we should use fresh ids and use them to look up responses
-        let result = json!({
-            "method": message.method,
-            "id": 42,
-            "params": serde_json::from_str::<serde_json::Value>(&format!("{{ {} }}", params)).expect("couldn't convert path to JSON"),
-        }).to_string();
-        // println!("read_message: `{}`", result);
-
-        Some(result)
+        Some(message.to_message_str())
     }
 }
 


### PR DESCRIPTION
Implemented https://github.com/rust-lang-nursery/rls/issues/305#issuecomment-302269982.

* Changed Notification/Method enum variant names to match those implicitly-defined in languageserver-types crate (used for fetching LSP method name from ServerMessage)
* Implemented simple serialize method for ServerMessages
* Removed string-based Message in tests, those now use ServerMessage in both mock_(raw_)server scenarios