### PR TITLE
Support formatting config via rustfmt.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rustfmt"
 version = "0.9.0"
-source = "git+https://github.com/rust-lang-nursery/rustfmt?branch=libsyntax#d5d506811015927359f9a6b8e7a1566d5e03d877"
+source = "git+https://github.com/rust-lang-nursery/rustfmt?branch=libsyntax#6c1de7694782d9f710b2f00b1f650f266a99b384"
 dependencies = [
  "diff 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -449,7 +449,7 @@ impl ActionHandler {
         };
         let config = self.fmt_config.lock().unwrap();
         let mut buf = Vec::<u8>::new();
-        match format_input(input, &config, Some(&mut buf)) {
+        match format_input(input, config.get_rustfmt_config(), Some(&mut buf)) {
             Ok((summary, ..)) => {
                 // format_input returns Ok even if there are any errors, i.e., parsing errors.
                 if summary.has_no_errors() {

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -16,7 +16,7 @@ use url::Url;
 use vfs::{Vfs, Change, FileContents};
 use racer;
 use rustfmt::{Input as FmtInput, format_input};
-use rustfmt::config::{self, WriteMode};
+use config::FmtConfig;
 use serde_json;
 use span;
 use Span;
@@ -43,6 +43,7 @@ pub struct ActionHandler {
     build_queue: Arc<BuildQueue>,
     current_project: Mutex<Option<PathBuf>>,
     previous_build_results: Mutex<BuildResults>,
+    fmt_config: Mutex<FmtConfig>,
 }
 
 impl ActionHandler {
@@ -55,6 +56,7 @@ impl ActionHandler {
             build_queue: build_queue,
             current_project: Mutex::new(None),
             previous_build_results: Mutex::new(HashMap::new()),
+            fmt_config: Mutex::new(FmtConfig::default()),
         }
     }
 
@@ -65,7 +67,16 @@ impl ActionHandler {
         }
         {
             let mut current_project = self.current_project.lock().unwrap();
-            *current_project = Some(root_path.clone());
+            if current_project
+                   .as_ref()
+                   .map_or(true, |existing| *existing != root_path) {
+                let new_path = root_path.clone();
+                {
+                    let mut config = self.fmt_config.lock().unwrap();
+                    *config = FmtConfig::from(&new_path);
+                }
+                *current_project = Some(new_path);
+            }
         }
         self.build(&root_path, BuildPriority::Immediate, out);
     }
@@ -436,11 +447,7 @@ impl ActionHandler {
                 return;
             }
         };
-
-        let mut config = config::Config::default();
-        config.set().skip_children(true);
-        config.set().write_mode(WriteMode::Plain);
-
+        let config = self.fmt_config.lock().unwrap();
         let mut buf = Vec::<u8>::new();
         match format_input(input, &config, Some(&mut buf)) {
             Ok((summary, ..)) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -169,19 +169,10 @@ impl FmtConfig {
     /// Look for `.rustmt.toml` or `rustfmt.toml` in `path`, falling back
     /// to the default config if neither exist
     pub fn from(path: &Path) -> FmtConfig {
-        const FMT_CONFIG_NAMES: [&str; 2] = [".rustfmt.toml", "rustfmt.toml"];
-        for fmt_config_name in &FMT_CONFIG_NAMES {
-            let config_path = path.to_owned().join(fmt_config_name);
-            let config_file = File::open(config_path);
-            if let Ok(mut f) = config_file {
-                let mut toml = String::new();
-                f.read_to_string(&mut toml).unwrap();
-                if let Ok(config) = RustfmtConfig::from_toml(&toml) {
-                    let mut config = FmtConfig(config);
-                    config.set_rls_options();
-                    return config;
-                }
-            }
+        if let Ok((config, _)) = RustfmtConfig::from_resolved_toml_path(path) {
+            let mut config = FmtConfig(config);
+            config.set_rls_options();
+            return config;
         }
         FmtConfig::default()
     }


### PR DESCRIPTION
Although formatting is behind an unstable flag, I find it usable other than the lack of support for project rustfmt.toml, one of the bullets in #3 . If this isn’t the approach you’d like to take to configuring rustfmt (i.e. you want to pass it via `DocumentFormattingParams` or some other configuration scheme) feel free to reject.

Also, the recently added reformatting unit test fails for me even before this change with a rustfmt parsing error. 