### PR TITLE
Set missing env vars from Cargo in a compilation step

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -357,6 +357,9 @@ impl BuildQueue {
                                 cmd_dep_info.arg(a);
                             }
                         }
+                        // Compilation may depend on env vars which Cargo sets during compile-time
+                        cmd_dep_info.envs(cmd.get_envs().iter().filter_map(|(k, v)| v.as_ref().map(|v| (k, v))));
+
                         if let Some(cwd) = cmd.get_cwd() {
                             cmd_dep_info.current_dir(cwd);
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@
 
 #![feature(rustc_private)]
 #![feature(concat_idents)]
+#![feature(command_envs)]
 
 extern crate cargo;
 #[macro_use]


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rls/issues/290. Although this seems to fix the issue with missing env vars causing compilation failures in some projects, there may be a better way of doing that in the long-term by not having to call rustc to get dep-info, judging from the comment in code.