### PR TITLE
Emit metadata for primary crate also being lib

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -351,13 +351,7 @@ impl BuildQueue {
                         // this info at all, or start our build here rather than on another thread
                         // so the dep-info is ready by the time we return from this callback.
                         let mut cmd_dep_info = Command::new("rustc");
-                        for a in &args {
-                            if a.starts_with("--emit") {
-                                cmd_dep_info.arg("--emit=dep-info");
-                            } else {
-                                cmd_dep_info.arg(a);
-                            }
-                        }
+                        cmd_dep_info.args(&args);
                         // Compilation may depend on env vars which Cargo sets during compile-time
                         cmd_dep_info.envs(cmd.get_envs().iter().filter_map(|(k, v)| v.as_ref().map(|v| (k, v))));
 


### PR DESCRIPTION
This fixes the problem with lib*.rmeta not being generated for primary crate lib target used for primary bin target, which is normally done by `cargo check` mode, but omitted explicitly by the RLS.
With this patch all affected, reported (in https://github.com/rust-lang-nursery/rls/issues/208) crates seems to be building properly with diagnostics data available.
However there still is a problem with diagnostics not being shown in lib.rs, which I'll further investigate.