### PR TITLE
Fix compilation

### DIFF
--- a/src/actions/lsp_extensions.rs
+++ b/src/actions/lsp_extensions.rs
@@ -12,6 +12,9 @@ use url_serde;
 use lsp_data::*;
 use url::Url;
 
+#[allow(non_upper_case_globals)]
+pub const REQUEST__Deglob: &'static str = "rustWorkspace/deglob";
+
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct PublishRustDiagnosticsParams {
     /// The URI for which diagnostic information is reported.

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,6 +15,7 @@ use serde_json;
 use build::*;
 use lsp_data::*;
 use actions::ActionHandler;
+use actions::lsp_extensions::*;
 
 use std::fmt;
 use std::io::{self, Read, Write, ErrorKind};


### PR DESCRIPTION
Add missing REQUEST__Deglob needed by https://github.com/rust-lang-nursery/rls/commit/bdcc0aea6062610be3c8b9c5db77731f79856cbb.
As a side note, should all method strings in [here](https://github.com/Xanewok/rls/blob/d8805a1fc5a33ac889ab35ebd56153882bc7de41/src/server.rs#L234) be replaced by appropriate `REQUEST__*` and `NOTIFICATION__*` identifiers from languageserver-types?