### PR TITLE
Support analyzing a specific binary in project

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,10 @@ project.
 Currently we accept the following options:
 
 * `build_lib` (`bool`, defaults to `false`) checks the project as if you passed
-  the `--lib` argument to cargo.
+  the `--lib` argument to cargo. Mutually exclusive with, and preferred over
+  `build_bin`.
+* `build_bin` (`String`, defaults to `""`) checks the project as if you passed
+  `-- bin <build_bin>` argument to cargo. Mutually exclusive with `build_lib`.
 * `cfg_test` (`bool`, defaults to `true`) checks the project as if you were
   running `cargo test` rather than `cargo build`. I.e., compiles (but does not
   run) test code.

--- a/rls/src/build.rs
+++ b/rls/src/build.rs
@@ -447,11 +447,26 @@ impl BuildQueue {
             let mut manifest_path = build_dir.clone();
             manifest_path.push("Cargo.toml");
             trace!("manifest_path: {:?}", manifest_path);
+            // TODO: Add support for virtual manifests and multiple packages 
             let ws = Workspace::new(&manifest_path, &config).expect("could not create cargo workspace");
+            let current_package = ws.current().unwrap(); 
+            let targets = current_package.targets(); 
+
+            let bins = {
+                if rls_config.build_bin.is_empty() { 
+                    vec![]
+                } else {
+                    let mut bins = targets.iter().filter(|x| x.is_bin()); 
+                    let bin = bins.find(|x| x.name() == rls_config.build_bin);
+                    match bin { None => vec![], Some(bin) => vec![bin.name().to_owned()]}
+                }
+            };
 
             let mut opts = CompileOptions::default(&config, CompileMode::Check);
             if rls_config.build_lib {
-                opts.filter = CompileFilter::new(true, &[], false, &[], false, &[], false, &[], false);
+                opts.filter = CompileFilter::new(true, &[], false, &[], false, &[], false, &[], false); 
+            } else if !bins.is_empty() {
+                opts.filter = CompileFilter::new(false, &bins, false, &[], false, &[], false, &[], false);
             }
             if !rls_config.target.is_empty() {
                 opts.target = Some(&rls_config.target);

--- a/rls/src/build.rs
+++ b/rls/src/build.rs
@@ -458,7 +458,13 @@ impl BuildQueue {
                 } else {
                     let mut bins = targets.iter().filter(|x| x.is_bin()); 
                     let bin = bins.find(|x| x.name() == rls_config.build_bin);
-                    match bin { None => vec![], Some(bin) => vec![bin.name().to_owned()]}
+                    match bin {
+                        Some(bin) => vec![bin.name().to_owned()],
+                        None => {
+                            debug!("cargo - couldn't find binary `{}` (specified in rls toml file)", rls_config.build_bin);
+                            vec![]
+                        }
+                    }
                 }
             };
 

--- a/rls/src/config.rs
+++ b/rls/src/config.rs
@@ -154,6 +154,7 @@ create_config! {
     target: String, String::new(), false, "--target";
     rustflags: String, String::new(), false, "flags added to RUSTFLAGS";
     build_lib: bool, false, false, "cargo check --lib";
+    build_bin: String, String::new(), false, "cargo check --bin <name>";
     cfg_test: bool, true, false, "build cfg(test) code";
     unstable_features: bool, false, false, "enable unstable features";
 }

--- a/rls/src/test/mod.rs
+++ b/rls/src/test/mod.rs
@@ -336,6 +336,25 @@ fn test_reformat_with_range() {
 }
 
 #[test]
+fn test_multiple_binaries() {
+    let (cache, _tc) = init_env("multiple_bins");
+
+    let root_path = cache.abs_path(Path::new("."));
+    let messages = vec![
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned()))
+    ];
+
+    let (server, results) = mock_server(messages);
+    // Initialise and build.
+    assert_eq!(ls_server::LsService::handle_message(server.clone()),
+               ls_server::ServerStateChange::Continue);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
+                                       ExpectedMessage::new(None).expect_contains("unused variable: `bin_name2`"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
+}
+
+#[test]
 fn test_completion() {
     let (mut cache, _tc) = init_env("completion");
 

--- a/test_data/multiple_bins/Cargo.lock
+++ b/test_data/multiple_bins/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "multiple_bins"
+version = "0.1.0"
+

--- a/test_data/multiple_bins/Cargo.toml
+++ b/test_data/multiple_bins/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "multiple_bins"
+version = "0.1.0"
+authors = ["Igor Matuszewski <Xanewok@gmail.com>"]
+
+[[bin]]
+name = "bin1"
+path = "src/main.rs"
+
+[[bin]]
+name = "bin2"
+path = "src/main2.rs"
+
+[dependencies]

--- a/test_data/multiple_bins/rls.toml
+++ b/test_data/multiple_bins/rls.toml
@@ -1,0 +1,2 @@
+build_bin = "bin2"
+

--- a/test_data/multiple_bins/src/main.rs
+++ b/test_data/multiple_bins/src/main.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let bin_name1 = "bin1";
+
+    println!("Hello, world!");
+}

--- a/test_data/multiple_bins/src/main2.rs
+++ b/test_data/multiple_bins/src/main2.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let bin_name2 = "bin2";
+
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Added `build_bin` configuration, which allows to specify which crate should be compiled and analyzed. When both `build_lib` and `build_bin` are specified, `build_lib` is preferred.