### PR TITLE
Update AppVeyor settings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,10 @@
 environment:
   global:
-    RUST_TEST_THREADS: 1
     PROJECT_NAME: rls
   matrix:
-    # Nightly channel
-    #- TARGET: i686-pc-windows-gnu
-    #  CHANNEL: nightly
-    #  BITS: 32
     - TARGET: i686-pc-windows-msvc
       CHANNEL: nightly
       BITS: 32
-    #- TARGET: x86_64-pc-windows-gnu
-    #  CHANNEL: nightly
-    #  BITS: 64
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: nightly
       BITS: 64
@@ -20,21 +12,23 @@ environment:
 install:
   - set PATH=C:\msys64\mingw%BITS%\bin;C:\msys64\usr\bin;%PATH%
   - curl -sSf -o rustup-init.exe https://win.rustup.rs
-  # Install rust, x86_64-pc-windows-msvc host
-  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly-x86_64-pc-windows-msvc
-  # Install the target we're compiling for
+  # Install rust
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %CHANNEL%-%TARGET%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
-  - set PATH=%PATH%;C:\Users\appveyor\.multirust\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\%TARGET%\lib
-  - if NOT "%TARGET%" == "x86_64-pc-windows-msvc" rustup target add %TARGET%
+  # Print version info
   - rustc -Vv
   - cargo -V
 
 
 build: false
 
+build_script:
+  # Build both build/test configurations to make sure both compile
+  - cargo build --release --verbose
+
 test_script:
-  - set RUST_TEST_THREADS=1
-  - cargo test --release --target %TARGET% --verbose
+  # Test compilation reuses built dependencies during `cargo build --release`
+  - cargo test --release --verbose
 
 cache:
   - target

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -428,7 +428,7 @@ fn test_bin_lib_project_no_cfg_test() {
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
-                                       ExpectedMessage::new(None).expect_contains(r#"[{"range":{"start":{"line":4,"character":24},"end":{"line":4,"character":40},"label":"not found in `bin_lib`"},"secondaryRanges":[],"severity":1,"code":"E0422","source":"rustc","message":"cannot find struct, variant or union type `LibCfgTestStruct` in module `bin_lib`\nnot found in `bin_lib`"}]"#),
+                                       ExpectedMessage::new(None).expect_contains("cannot find struct, variant or union type `LibCfgTestStruct` in module `bin_lib`"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
 }
 


### PR DESCRIPTION
Cleaned and updated AppVeyor CI configuration:

* Removed old, unnecessary `RUST_TEST_THREADS=1`
* Use default Rust toolchain for corresponding i686/x86_64 target (i.e. don't cross-compile from x86_64 to i686)
* Check compilation of both build/test configuration