### PR TITLE
Add show_warnings to config

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -81,7 +81,7 @@ pub struct BuildQueue {
     // A vec of channels to pending build threads.
     pending: Mutex<Vec<Sender<Signal>>>,
     vfs: Arc<Vfs>,
-    config: Mutex<Config>,
+    pub config: Mutex<Config>,
 }
 
 #[derive(Debug)]
@@ -606,6 +606,8 @@ impl BuildQueue {
             }
         }
     }
+
+    
 }
 
 fn make_cargo_config(build_dir: &Path, shell: Shell) -> CargoConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,6 +164,7 @@ create_config! {
     cfg_test: bool, true, false, "build cfg(test) code";
     unstable_features: bool, false, false, "enable unstable features";
     wait_to_build: u64, 500, false, "time in milliseconds between receiving a change notification and starting build";
+    show_warnings: bool, true, false, "show warnings";
 }
 
 /// A rustfmt config (typically specified via rustfmt.toml)


### PR DESCRIPTION
Issue #252 

- Added `show_warnings` to config
- Implemented in `convert_build_results_to_notifications`
- Made config in `BuildQueue` public

First, am I filtering in the right place? This works, but I'm not sure if there is a better place to put the filter. Also, adding `pub` to `BuildQueue` feels dirty. Should config be some sort of shared object or accessed via method call?