### PR TITLE
Use jsonrpc-core data for improved and more consistent error handling flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,8 @@ name = "rls"
 version = "0.1.0"
 dependencies = [
  "cargo 0.21.0 (git+https://github.com/rust-lang/cargo)",
- "derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 7.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "languageserver-types 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -323,6 +323,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "gcc"
 version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +393,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsonrpc-core"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1108,6 +1125,7 @@ dependencies = [
 "checksum flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "36df0166e856739905cd3d7e0b210fe818592211a008862599845e012d8d304c"
 "checksum foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e4056b9bd47f8ac5ba12be771f77a0dae796d1bbaaf5fd0b9c2d38b69b8a29d"
 "checksum fs2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ab76cfd2aaa59b7bf6688ad9ba15bbae64bff97f04ea02144cfd3443e5c2866"
+"checksum futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4b63a4792d4f8f686defe3b39b92127fea6344de5d38202b2ee5a11bbbf29d6a"
 "checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
 "checksum git2 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aa01936ac96555c083c0e8553f672616274408d9d3fc5b8696603fbf63ff43ee"
@@ -1117,6 +1135,7 @@ dependencies = [
 "checksum idna 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2233d4940b1f19f0418c158509cd7396b8d70a5db5705ce410914dc8fa603b37"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum jobserver 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4e28adc987f6d0521ef66ad60b055968107b164b3bb3cf3dc8474e0a380474a6"
+"checksum jsonrpc-core 7.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da622868a84d3f4fd897f6408ba6714aabf663302802358564b384157c1a5bfa"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum languageserver-types 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "680aee78c75504fdcb172635a7b7da0dccaafa4c42d935e19576c14b27942362"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ build = "build.rs"
 
 [dependencies]
 cargo = { git = "https://github.com/rust-lang/cargo" }
-derive-new = "0.3"
 env_logger = "0.4"
 languageserver-types = "0.11.1"
 log = "0.3"
@@ -27,3 +26,4 @@ serde_derive = "1.0"
 toml = "0.4"
 url = "1.1.0"
 url_serde = "0.2.0"
+jsonrpc-core = "7.0.1"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -14,8 +14,9 @@
 
 use analysis::{AnalysisHost, Target};
 use config::Config;
-use server::{self, ServerMessage, Request, Notification, Method, LsService, ParseError, ResponseData};
+use server::{self, ServerMessage, Request, Notification, Method, LsService, ResponseData};
 use vfs::Vfs;
+use jsonrpc_core;
 
 use ls_types::{ClientCapabilities, TextDocumentPositionParams, TextDocumentIdentifier, TraceOption, Position, InitializeParams, RenameParams};
 use std::time::Duration;
@@ -54,7 +55,7 @@ pub fn run() {
             Some(a) => a,
             None => continue,
         };
-        
+
         // Switch on the action and build an appropriate message.
         let msg = match action {
             "def" => {
@@ -216,7 +217,7 @@ impl ChannelMsgReader {
 }
 
 impl server::MessageReader for ChannelMsgReader {
-    fn parsed_message(&self) -> Option<Result<ServerMessage, ParseError>> {
+    fn parsed_message(&self) -> Option<Result<ServerMessage, Option<jsonrpc_core::Failure>>> {
         let channel = self.channel.lock().unwrap();
         let msg = channel.recv().expect("Error reading from channel");
         Some(Ok(msg))

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,6 @@
 #![feature(fnbox)]
 
 extern crate cargo;
-#[macro_use]
-extern crate derive_new;
 extern crate env_logger;
 extern crate languageserver_types as ls_types;
 #[macro_use]
@@ -40,6 +38,7 @@ extern crate serde_json;
 extern crate toml;
 extern crate url;
 extern crate url_serde;
+extern crate jsonrpc_core;
 
 use std::sync::Arc;
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -15,10 +15,12 @@ mod harness;
 
 use std::sync::{Arc, Mutex};
 use env_logger;
+use serde_json;
 
 use analysis;
 use config::Config;
 use server::{self as ls_server, ServerMessage, Request, Method};
+use jsonrpc_core;
 use vfs;
 
 use self::harness::{expect_messages, ExpectedMessage, init_env, mock_server, mock_server_with_config, RecordOutput, src};
@@ -459,5 +461,9 @@ fn test_parse_error_on_malformed_input() {
 
     let error = results.lock().unwrap()
         .pop().expect("no error response");
-    assert!(error.contains(r#""code": -32700"#))
+
+    let failure: jsonrpc_core::Failure = serde_json::from_str(&error)
+        .expect("Couldn't parse json failure response");
+
+    assert!(failure.error.code == jsonrpc_core::ErrorCode::ParseError);
 }


### PR DESCRIPTION
Laying foundations for https://github.com/rust-lang-nursery/rls/issues/395, https://github.com/rust-lang-nursery/rls/issues/376 and proper https://github.com/rust-lang-nursery/rls/issues/360 - JSON-RPC conformance in general and tidying the server flow logic a bit.

* Pulls in `jsonrpc_core::Id` for the `number | string | null` id type in JSON-RPC which we didn't support until recently
* Introduces more error codes
* Uses `jsonrpc_core` structs instead of our custom ones for failure/error message logic.

I have also some pending WIP changes planned for `{Notification,Request}Message` ([here](https://github.com/rust-lang-nursery/rls/blob/master/src/lsp_data.rs#L176-L217)), but I still need to work on stronger typifying, will probably land with https://github.com/gluon-lang/languageserver-types/issues/19.

Moving completely to using `jsonrpc-core` means making a lot of internal changes, so I figured it'd be nice to move a small, self-contained portion and see if the approach is okay.