### PR TITLE
Revert "Use proper ids for server->client messages" on branch rustfmt-42492

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "rls-data 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-vfs 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustfmt-nightly 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustfmt-nightly 0.1.8 (git+https://github.com/rust-lang-nursery/rustfmt?branch=rustfmt-42492)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -697,8 +697,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustfmt-nightly"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.1.8"
+source = "git+https://github.com/rust-lang-nursery/rustfmt?branch=rustfmt-42492#7333dfc95b4af5c7283ba03f33c50f108d2be3f5"
 dependencies = [
  "diff 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1153,7 +1153,7 @@ dependencies = [
 "checksum rls-vfs 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f19246a0fda45f2fb6eb34addef2a692c044cbf1c90ec7695583450fb5f23e7"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-"checksum rustfmt-nightly 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "31ac6fe40a9844ee2de3d51d0be2bbcdb361bad6f3667a02db8c4e2330afbbb5"
+"checksum rustfmt-nightly 0.1.8 (git+https://github.com/rust-lang-nursery/rustfmt?branch=rustfmt-42492)" = "<none>"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fdd61b85a0fa777f7fb7c454b9189b2941b110d1385ce84d7f76efdf1606a85"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rls-analysis = "0.4"
 rls-data = "0.7"
 rls-span = { version = "0.4" , features = ["serialize-serde"] }
 rls-vfs = { version = "0.4", features = ["racer-impls"] }
-rustfmt-nightly = "0.1"
+rustfmt-nightly = { git = "https://github.com/rust-lang-nursery/rustfmt", branch = "rustfmt-42492" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -471,8 +471,7 @@ impl ActionHandler {
         trace!("apply_suggestion {:?} {}", location, new_text);
         // FIXME should handle the response
         let output = serde_json::to_string(
-            &RequestMessage::new(out.provide_id(),
-                                 "workspace/applyEdit".to_owned(),
+            &RequestMessage::new("workspace/applyEdit".to_owned(),
                                  ApplyWorkspaceEditParams { edit: make_workspace_edit(location, new_text) })
         ).unwrap();
         out.response(output);
@@ -564,8 +563,7 @@ impl ActionHandler {
         // Send a workspace edit to make the actual change.
         // FIXME should handle the response
         let output = serde_json::to_string(
-            &RequestMessage::new(out.provide_id(),
-                                 "workspace/applyEdit".to_owned(),
+            &RequestMessage::new("workspace/applyEdit".to_owned(),
                                  ApplyWorkspaceEditParams { edit: make_workspace_edit(location, deglob_str) })
         ).unwrap();
         out.response(output);
@@ -660,16 +658,14 @@ impl ActionHandler {
                 // FIXME should handle the response
                 if unstable_features {
                     let output = serde_json::to_string(
-                        &RequestMessage::new(out.provide_id(),
-                                             NOTIFICATION__RegisterCapability.to_owned(),
+                        &RequestMessage::new(NOTIFICATION__RegisterCapability.to_owned(),
                                              RegistrationParams { registrations: vec![Registration { id: RANGE_FORMATTING_ID.to_owned(), method: REQUEST__RangeFormatting.to_owned(), register_options: serde_json::Value::Null },
                                                                                       Registration { id: RENAME_ID.to_owned(), method: REQUEST__Rename.to_owned(), register_options: serde_json::Value::Null }] })
                     ).unwrap();
                     out.response(output);
                 } else {
                     let output = serde_json::to_string(
-                        &RequestMessage::new(out.provide_id(),
-                                             NOTIFICATION__UnregisterCapability.to_owned(),
+                        &RequestMessage::new(NOTIFICATION__UnregisterCapability.to_owned(),
                                              UnregistrationParams { unregisterations: vec![Unregistration { id: RANGE_FORMATTING_ID.to_owned(), method: REQUEST__RangeFormatting.to_owned() },
                                                                                            Unregistration { id: RENAME_ID.to_owned(), method: REQUEST__Rename.to_owned() }] })
                     ).unwrap();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -193,10 +193,6 @@ impl server::Output for PrintlnOutput {
         println!("{}", output);
     }
 
-    fn provide_id(&self) -> u64 {
-        0
-    }
-
     fn success(&self, id: usize, data: ResponseData) {
         println!("{}: {:#?}", id, data);
     }

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -200,16 +200,16 @@ pub struct RequestMessage<T>
     where T: Debug + Serialize
 {
     jsonrpc: &'static str,
-    pub id: u64,
+    pub id: String,
     pub method: String,
     pub params: T,
 }
 
 impl <T> RequestMessage<T> where T: Debug + Serialize {
-    pub fn new(id: u64, method: String, params: T) -> Self {
+    pub fn new(method: String, params: T) -> Self {
         RequestMessage {
             jsonrpc: "2.0",
-            id,
+            id: "FIXME".to_owned(),
             method: method,
             params: params
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@
 #![feature(rustc_private)]
 #![feature(concat_idents)]
 #![feature(type_ascription)]
-#![feature(integer_atomics)]
 
 extern crate cargo;
 #[macro_use]

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,7 @@ use actions::ActionHandler;
 use std::fmt;
 use std::io::{self, Read, Write, ErrorKind};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering, AtomicU64};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::path::PathBuf;
 
 #[cfg(test)]
@@ -547,7 +547,6 @@ impl MessageReader for StdioMsgReader {
 
 pub trait Output: Sync + Send + Clone + 'static {
     fn response(&self, output: String);
-    fn provide_id(&self) -> u64;
 
     fn parse_error(&self) {
         self.response(r#"{"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}, "id": null}"#.to_owned());
@@ -602,17 +601,7 @@ pub trait Output: Sync + Send + Clone + 'static {
 }
 
 #[derive(Clone)]
-struct StdioOutput {
-    next_id: Arc<AtomicU64>,
-}
-
-impl StdioOutput {
-    pub fn new() -> StdioOutput {
-        StdioOutput {
-            next_id: Arc::new(AtomicU64::new(1)),
-        }
-    }
-}
+struct StdioOutput;
 
 impl Output for StdioOutput {
     fn response(&self, output: String) {
@@ -623,10 +612,6 @@ impl Output for StdioOutput {
         print!("{}", o);
         io::stdout().flush().unwrap();
     }
-
-    fn provide_id(&self) -> u64 {
-        self.next_id.fetch_add(1, Ordering::SeqCst)
-    }
 }
 
 pub fn run_server(analysis: Arc<AnalysisHost>, vfs: Arc<Vfs>) {
@@ -634,7 +619,7 @@ pub fn run_server(analysis: Arc<AnalysisHost>, vfs: Arc<Vfs>) {
     let service = LsService::new(analysis,
                                  vfs,
                                  Box::new(StdioMsgReader),
-                                 StdioOutput::new());
+                                 StdioOutput);
     LsService::run(service);
     debug!("Server shutting down");
 }

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -89,10 +89,6 @@ impl ls_server::Output for RecordOutput {
         let mut records = self.output.lock().unwrap();
         records.push(output);
     }
-
-    fn provide_id(&self) -> u64 {
-        0
-    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This reverts commit 7029815cea15aea47007343194d2a2b316cdf8e5.

It caused build failure on PowerPC in https://github.com/rust-lang/rust/pull/43115
r? @nrc 