### PR TITLE
Workspaces

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -299,7 +299,7 @@ impl BuildQueue {
                 if interupt {
                     and_then(BuildResult::Squashed);
                     continue;
-                }                
+                }
             }
 
             // Run the build.
@@ -375,10 +375,16 @@ impl Internals {
 
         // Don't hold this lock when we run Cargo.
         let needs_to_run_cargo = self.compilation_cx.lock().unwrap().args.is_empty();
-        if needs_to_run_cargo {
-            if let BuildResult::Err = self.cargo() {
-                return BuildResult::Err;
-            }
+        let workspace_mode = self.config.lock().unwrap().workspace_mode; 
+ 
+        if workspace_mode || needs_to_run_cargo { 
+            let result = self.cargo(); 
+ 
+            match result { 
+                BuildResult::Err => return BuildResult::Err, 
+                _ if workspace_mode => return result, 
+                _ => {}, 
+            }; 
         }
 
         let compile_cx = self.compilation_cx.lock().unwrap();

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -199,7 +199,7 @@ impl Drop for Environment {
     }
 }
 
-fn convert_message_to_json_strings(input: Vec<u8>) -> Vec<String> {
+pub fn convert_message_to_json_strings(input: Vec<u8>) -> Vec<String> {
     let mut output = vec![];
 
     // FIXME: this is *so gross*  Trying to work around cargo not supporting json messages

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,8 @@ pub struct Config {
     pub unstable_features: bool,
     pub wait_to_build: u64,
     pub show_warnings: bool,
+    pub workspace_mode: bool,
+    pub analyze_package: Option<String>,
 }
 
 impl Config {
@@ -40,6 +42,8 @@ impl Config {
             unstable_features: false,
             wait_to_build: DEFAULT_WAIT_TO_BUILD,
             show_warnings: true,
+            workspace_mode: false,
+            analyze_package: None,
         }
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -438,6 +438,30 @@ fn test_bin_lib_project_no_cfg_test() {
 }
 
 #[test]
+fn test_simple_workspace() {
+    let (cache, _tc) = init_env("simple_workspace");
+
+    let root_path = cache.abs_path(Path::new("."));
+
+    let messages = vec![
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
+    ];
+
+    let mut config = Config::default();
+    config.workspace_mode = true;
+    let (server, results) = mock_server_with_config(messages, config);
+    // Initialise and build.
+    assert_eq!(ls_server::LsService::handle_message(server.clone()),
+               ls_server::ServerStateChange::Continue);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
+                                       // TODO: it'd be convenient to test if compilation encountered an internal error
+                                       // or at least to check stderr's contents. We shouldn't check for presence of a warning here
+                                       ExpectedMessage::new(None).expect_contains("unused variable: `a`"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
+}
+
+#[test]
 fn test_parse_error_on_malformed_input() {
     let _ = env_logger::init();
     struct NoneMsgReader;

--- a/test_data/simple_workspace/Cargo.lock
+++ b/test_data/simple_workspace/Cargo.lock
@@ -1,0 +1,11 @@
+[root]
+name = "member_lib"
+version = "0.1.0"
+
+[[package]]
+name = "member_bin"
+version = "0.1.0"
+dependencies = [
+ "member_lib 0.1.0",
+]
+

--- a/test_data/simple_workspace/Cargo.toml
+++ b/test_data/simple_workspace/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = [
+  "member_lib",
+  "member_bin",
+]
+

--- a/test_data/simple_workspace/member_bin/Cargo.toml
+++ b/test_data/simple_workspace/member_bin/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "member_bin"
+version = "0.1.0"
+authors = ["Igor Matuszewski <Xanewok@gmail.com>"]
+
+[dependencies]
+member_lib = { path = "../member_lib" }

--- a/test_data/simple_workspace/member_bin/src/main.rs
+++ b/test_data/simple_workspace/member_bin/src/main.rs
@@ -1,0 +1,5 @@
+extern crate member_lib;
+
+fn main() {
+    let a = member_lib::MemberLibStruct;
+}

--- a/test_data/simple_workspace/member_lib/Cargo.toml
+++ b/test_data/simple_workspace/member_lib/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "member_lib"
+version = "0.1.0"
+authors = ["Igor Matuszewski <Xanewok@gmail.com>"]
+
+[dependencies]

--- a/test_data/simple_workspace/member_lib/src/lib.rs
+++ b/test_data/simple_workspace/member_lib/src/lib.rs
@@ -1,0 +1,8 @@
+pub struct MemberLibStruct;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+    }
+}


### PR DESCRIPTION
This is a prototype implementation for workspace support (https://github.com/rust-lang-nursery/rls/issues/132). It introduces these new options:
* `workspace_mode` - new behaviour is opt-in via this flag
* `analyze_package` - specified which package will be analyzed in workspace mode

The only thing that's not behind a `workspace_mode` check of some sorts is detection of package root manifest path [here](https://github.com/rust-lang-nursery/rls/compare/master...Xanewok:workspaces?expand=1#diff-9300feef84bdf7e5ab58b05fa4eb0794R547) It uses only .json file save-analysis data and uses Cargo exclusively, so there's a lot of room for possible optimizations. 

Tested on [webrender](https://github.com/servo/webrender) workspace and [simple_workspace](https://github.com/Xanewok/rls/commit/3f8e3f271acc145f704a2f67b42814250b9ac746#diff-ad1aa1df577b55811bf00177539a3456), which is added as a simple test case.

### Known issues
* Rebuild will be requested on every file change, however diagnostics can be properly provided only for saved files, since Cargo here isn't using a substituted file loader