### PR TITLE
Opt-out of build after `initialize`

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -65,8 +65,13 @@ impl ActionHandler {
         }
     }
 
-    pub fn init<O: Output>(&self, out: O) {
-        self.build_current_project(BuildPriority::Cargo, out);
+    pub fn init<O: Output>(&self, init_options: Option<InitializationOptions>, out: O) {
+        let omit_init_build = init_options.and_then(|x| x.omit_init_build)
+                                          .unwrap_or(false);
+        debug!("omit_init_build: {:?}", omit_init_build);
+        if !omit_init_build {
+            self.build_current_project(BuildPriority::Cargo, out);
+        }
     }
 
     // Respond to the `initialized` notification. We take this opportunity to

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -65,11 +65,10 @@ impl ActionHandler {
         }
     }
 
-    pub fn init<O: Output>(&self, init_options: Option<InitializationOptions>, out: O) {
-        let omit_init_build = init_options.and_then(|x| x.omit_init_build)
-                                          .unwrap_or(false);
-        debug!("omit_init_build: {:?}", omit_init_build);
-        if !omit_init_build {
+    pub fn init<O: Output>(&self, init_options: InitializationOptions, out: O) {
+        trace!("init: {:?}", init_options);
+
+        if !init_options.omit_init_build {
             self.build_current_project(BuildPriority::Cargo, out);
         }
     }

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -175,6 +175,15 @@ pub fn completion_item_from_racer_match(m : racer::Match) -> CompletionItem {
 
 /* -----------------  JSON-RPC protocol types ----------------- */
 
+/// Supported initilization options that can be passed in the `initialize`
+/// request, under `initialization_options` key. These are specific to the RLS.
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+pub struct InitializationOptions {
+    /// Should the build not be triggered immediately after receiving `initialize`
+    #[serde(rename="omitInitBuild")]
+    pub omit_init_build: Option<bool>,
+}
+
 /// An event-like (no response needed) notification message.
 #[derive(Debug, Serialize)]
 pub struct NotificationMessage<T>

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -178,10 +178,19 @@ pub fn completion_item_from_racer_match(m : racer::Match) -> CompletionItem {
 /// Supported initilization options that can be passed in the `initialize`
 /// request, under `initialization_options` key. These are specific to the RLS.
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
 pub struct InitializationOptions {
     /// Should the build not be triggered immediately after receiving `initialize`
     #[serde(rename="omitInitBuild")]
-    pub omit_init_build: Option<bool>,
+    pub omit_init_build: bool,
+}
+
+impl Default for InitializationOptions {
+    fn default() -> Self {
+        InitializationOptions {
+            omit_init_build: false
+        }
+    }
 }
 
 /// An event-like (no response needed) notification message.

--- a/src/server.rs
+++ b/src/server.rs
@@ -397,8 +397,14 @@ impl<O: Output> LsService<O> {
         self.output.success(id, ResponseData::Init(result));
 
         let root_path = params.root_path.map(PathBuf::from).expect("No root path");
+        let init_options: Option<InitializationOptions> = params.initialization_options
+                              .and_then(|options| serde_json::from_value(options)
+                                            .unwrap_or_else(|err| {
+                                                debug!("Error parsing initialization_options: {:?}", err);
+                                                None
+                                            }));
         self.handler.init(root_path);
-        self.handler.inited().init(self.output.clone());
+        self.handler.inited().init(init_options, self.output.clone());
     }
 
     pub fn handle_message(&mut self) -> ServerStateChange {

--- a/src/server.rs
+++ b/src/server.rs
@@ -397,12 +397,11 @@ impl<O: Output> LsService<O> {
         self.output.success(id, ResponseData::Init(result));
 
         let root_path = params.root_path.map(PathBuf::from).expect("No root path");
-        let init_options: Option<InitializationOptions> = params.initialization_options
-                              .and_then(|options| serde_json::from_value(options)
-                                            .unwrap_or_else(|err| {
-                                                debug!("Error parsing initialization_options: {:?}", err);
-                                                None
-                                            }));
+        let init_options: InitializationOptions =
+            params.initialization_options
+                      .and_then(|options| serde_json::from_value(options).ok())
+                      .unwrap_or_default();
+
         self.handler.init(root_path);
         self.handler.inited().init(init_options, self.output.clone());
     }

--- a/test_data/omit_init_build/Cargo.lock
+++ b/test_data/omit_init_build/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "omit_init_build"
+version = "0.1.0"
+

--- a/test_data/omit_init_build/Cargo.toml
+++ b/test_data/omit_init_build/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "omit_init_build"
+version = "0.1.0"
+authors = ["Igor Matuszewski <Xanewok@gmail.com>"]
+
+[dependencies]

--- a/test_data/omit_init_build/src/main.rs
+++ b/test_data/omit_init_build/src/main.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+struct Bar {
+    x: u64,
+}
+
+#[test]
+pub fn test_fn() {
+    let bar = Bar { x: 4 };
+    println!("bar: {}", bar.x);
+}
+
+pub fn main() {
+    let world = "world";
+    println!("Hello, {}!", world);
+
+    let bar2 = Bar { x: 5 };
+    println!("bar2: {}", bar2.x);
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rls/issues/419.

* Introduces new `InitializationOptions` structure defining options that are supported via `initialization_options` in `initialize` request.
* Allow for not building immediately after `initialize`, configurable via `omit_init_build` in `InitializationOptions`
* Bump up build priority from Normal to Cargo when compilation context isn't cached yet (in case we omit first build, don't catch `onDidChangeConfiguration` and start a Normal build - we always need Cargo as a first to resolve and build deps etc.)