### PR TITLE
Use linked compiler during Cargo `exec()` callback

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -180,7 +180,8 @@ impl ActionHandler {
         out.notify("rustDocument/diagnosticsBegin");
         self.build_queue.request_build(project_path, priority, move |result| {
             match result {
-                BuildResult::Success(messages, new_analysis) | BuildResult::Failure(messages, new_analysis) => {
+                BuildResult::Success(messages, new_analysis) |
+                BuildResult::Failure(messages, new_analysis) => {
                     thread::spawn(move || {
                         trace!("build - Success");
 
@@ -202,10 +203,12 @@ impl ActionHandler {
 
                         debug!("reload analysis: {:?}", project_path_clone);
                         let cwd = ::std::env::current_dir().unwrap();
-                        if let Some(new_analysis) = new_analysis {
-                            analysis.reload_from_analysis(new_analysis, &project_path_clone, &cwd).unwrap();
-                        } else {
+                        if new_analysis.is_empty() {
                             analysis.reload(&project_path_clone, &cwd).unwrap();
+                        } else {
+                            for data in new_analysis.into_iter() {
+                                analysis.reload_from_analysis(data, &project_path_clone, &cwd).unwrap();
+                            }
                         }
 
                         out.notify("rustDocument/diagnosticsEnd");

--- a/src/build/environment.rs
+++ b/src/build/environment.rs
@@ -1,0 +1,131 @@
+use std::env;
+use std::ffi::OsString;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+// Ensures we don't race on the env vars. This is only also important in tests,
+// where we have multiple copies of the RLS running in the same process.
+lazy_static! {
+    static ref ENV_LOCK: Arc<EnvironmentLock> = Arc::new(EnvironmentLock::new());
+}
+
+/// An RAII helper to set and reset the env vars.
+/// Requires supplying an external lock guard to guarantee env var consistency across multiple threads.
+pub struct Environment<'a> {
+    old_vars: HashMap<String, Option<OsString>>,
+    _guard: MutexGuard<'a, ()>,
+}
+
+impl<'a> Environment<'a> {
+    pub fn push_with_lock(envs: &HashMap<String, Option<OsString>>, lock: MutexGuard<'a, ()>) -> Environment<'a> {
+        let mut result = Environment {
+            old_vars: HashMap::new(),
+            _guard: lock,
+        };
+
+        for (k, v) in envs {
+            result.push_var(k, v);
+        }
+        result
+    }
+
+    pub fn push_var(&mut self, key: &str, value: &Option<OsString>) {
+        self.old_vars.insert(key.to_owned(), env::var_os(key));
+        match *value {
+            Some(ref v) => env::set_var(key, v),
+            None => env::remove_var(key),
+        }
+    }
+}
+
+impl<'a> Drop for Environment<'a> {
+    fn drop(&mut self) {
+        for (k, v) in &self.old_vars {
+            match *v {
+                Some(ref v) => env::set_var(k, v),
+                None => env::remove_var(k),
+            }
+        }
+    }
+}
+
+/// Implements a double mutex with a not-so-strict lock order guarantee, that can be used to guard
+/// environment variables and guarantee consistency across multiple threads. Since environment
+/// is a global, shared resource with a static lifetime, the `EnvironmentLock` is effectively
+/// a singleton - a global, static instance.
+///
+/// It uses two locks instead of one, because RLS, while executing a Cargo build routine, not only
+/// needs to guarantee consistent env vars across the Cargo invocation, but also, while holding it,
+/// it needs to provide a more fine-grained way to synchronize env vars across different inner
+/// compiler invokations, for which Cargo sets specific env vars.
+/// To enforce proper env var guarantees, regular rustc and Cargo build routines must first acquire
+/// the first, outer lock. Only then, if needed, nested rustc calls inside Cargo routine can
+/// acquire the second, inner lock.
+/// We're using linked Cargo and rustc to optimize serialization and IPC overhead, which means
+/// we don't spawn different processes, hence why we share a single environment and need to provide
+/// synchronized access to it.
+pub struct EnvironmentLock {
+    outer: Mutex<()>,
+    inner: Mutex<()>,
+}
+
+/// Helper type that provides a unified way to access both outer and inner types of
+/// `EnvironmentLock` lock interfaces.
+pub enum EnvironmentLockFacade {
+    Outer(Arc<EnvironmentLock>),
+    Inner(InnerLock),
+}
+
+impl<'a> EnvironmentLockFacade {
+    /// Retrieves access to an underlying, corresponding `Mutex` lock of `EnvironmentLock` and
+    /// additionally returns `InnerLock` if the underlying lock is an `OuterLock`.
+    pub fn lock(&self) -> (MutexGuard<'a, ()>, Option<InnerLock>) {
+        match *self {
+            EnvironmentLockFacade::Outer(ref lock) => {
+                let (guard, inner) = lock.lock();
+                (guard, Some(inner))
+            },
+            EnvironmentLockFacade::Inner(ref lock) => (lock.lock(), None),
+        }
+    }
+}
+
+impl<'a> EnvironmentLock {
+    fn new() -> EnvironmentLock {
+        EnvironmentLock {
+            outer: Mutex::new(()),
+            inner: Mutex::new(()),
+        }
+    }
+
+    /// Retrieves a pointer to the single, static instance of an `EnvironmentLock`.
+    pub fn get() -> Arc<EnvironmentLock> { ENV_LOCK.clone() }
+
+
+    /// Acquires the first, outer lock and additionally return `InnerLock` interface, through which
+    /// user can access the second, inner lock. Does not enforce any guarantees regarding order of
+    /// locking, since `InnerLock` can be copied outside 'a lifetime and locked there.
+    pub fn lock(&self) -> (MutexGuard<'a, ()>, InnerLock) {
+        (ENV_LOCK.outer.lock().unwrap(), InnerLock{ })
+    }
+
+    /// Constructs a corresponding `EnvironmentLockFacade` value, erasing specific type of the lock.
+    pub fn as_facade(&self) -> EnvironmentLockFacade {
+        EnvironmentLockFacade::Outer(ENV_LOCK.clone())
+    }
+}
+
+/// Acts as an interface through which user can acquire the second, inner lock of `EnvironmentLock`.
+pub struct InnerLock;
+
+impl<'a> InnerLock {
+    /// Acquires the second, inner environment lock.
+    pub fn lock(&self) -> MutexGuard<'a, ()> {
+        ENV_LOCK.inner.lock().unwrap()
+    }
+
+    /// Constructs a corresponding `EnvironmentLockFacade` value, erasing specific type of the lock.
+    pub fn as_facade(&self) -> EnvironmentLockFacade {
+        EnvironmentLockFacade::Inner(Self { })
+    }
+}

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -77,9 +77,9 @@ struct Internals {
 #[derive(Debug)]
 pub enum BuildResult {
     // Build was succesful, argument is warnings.
-    Success(Vec<String>, Option<Analysis>),
+    Success(Vec<String>, Vec<Analysis>),
     // Build finished with errors, argument is errors and warnings.
-    Failure(Vec<String>, Option<Analysis>),
+    Failure(Vec<String>, Vec<Analysis>),
     // Build was coelesced with another build.
     Squashed,
     // There was an error attempting to build.

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -12,19 +12,20 @@ use data::Analysis;
 use vfs::Vfs;
 use config::Config;
 
+use self::environment::EnvironmentLock;
+
 use std::boxed::FnBox;
 use std::collections::HashMap;
-use std::env;
 use std::ffi::OsString;
 use std::io::{self, Write};
 use std::mem;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
-
+mod environment;
 mod cargo;
 mod rustc;
 
@@ -57,7 +58,7 @@ mod rustc;
 pub struct BuildQueue {
     internals: Arc<Internals>,
     // The build queue - we only have one low and one high priority build waiting.
-    // (low, high) priority builds. 
+    // (low, high) priority builds.
     // This lock should only be held transiently.
     queued: Arc<Mutex<(Build, Build)>>,
 }
@@ -68,6 +69,7 @@ struct Internals {
     // This can be further expanded for multi-crate target configuration.
     // This lock should only be held transiently.
     compilation_cx: Arc<Mutex<CompilationContext>>,
+    env_lock: Arc<EnvironmentLock>,
     vfs: Arc<Vfs>,
     // This lock should only be held transiently.
     config: Arc<Mutex<Config>>,
@@ -337,6 +339,9 @@ impl Internals {
             compilation_cx: Arc::new(Mutex::new(CompilationContext::new())),
             vfs,
             config,
+            // Since environment is global mutable state and we can run multiple server
+            // instances, be sure to use a global lock to ensure env var consistency
+            env_lock: EnvironmentLock::get(),
             building: AtomicBool::new(false),
         }
     }
@@ -385,16 +390,16 @@ impl Internals {
 
         // Don't hold this lock when we run Cargo.
         let needs_to_run_cargo = self.compilation_cx.lock().unwrap().args.is_empty();
-        let workspace_mode = self.config.lock().unwrap().workspace_mode; 
- 
-        if workspace_mode || needs_to_run_cargo { 
+        let workspace_mode = self.config.lock().unwrap().workspace_mode;
+
+        if workspace_mode || needs_to_run_cargo {
             let result = cargo::cargo(self);
- 
-            match result { 
-                BuildResult::Err => return BuildResult::Err, 
-                _ if workspace_mode => return result, 
-                _ => {}, 
-            }; 
+
+            match result {
+                BuildResult::Err => return BuildResult::Err,
+                _ if workspace_mode => return result,
+                _ => {},
+            };
         }
 
         let compile_cx = self.compilation_cx.lock().unwrap();
@@ -402,7 +407,8 @@ impl Internals {
         assert!(!args.is_empty());
         let envs = &compile_cx.envs;
         let build_dir = compile_cx.build_dir.as_ref().unwrap();
-        rustc::rustc(&self.vfs, args, envs, build_dir, self.config.clone())
+        let env_lock = self.env_lock.as_facade();
+        rustc::rustc(&self.vfs, args, envs, build_dir, self.config.clone(), env_lock)
     }
 }
 
@@ -415,51 +421,5 @@ impl Write for BufWriter {
     }
     fn flush(&mut self) -> io::Result<()> {
         self.0.lock().unwrap().flush()
-    }
-}
-
-
-// Ensures we don't race on the env vars. This is only likely in tests, where we
-// have multiple copies of the RLS running in the same process.
-lazy_static! {
-    static ref ENV_LOCK: Mutex<()> = Mutex::new(());
-}
-
-// An RAII helper to set and reset the current working directory and env vars.
-struct Environment<'a> {
-    old_vars: HashMap<String, Option<OsString>>,
-    _guard: MutexGuard<'a, ()>,
-}
-
-impl<'a> Environment<'a> {
-    fn push(envs: &HashMap<String, Option<OsString>>) -> Environment<'a> {
-        let mut result = Environment {
-            old_vars: HashMap::new(),
-            _guard: ENV_LOCK.lock().unwrap(),
-        };
-
-        for (k, v) in envs {
-            result.push_var(k, v);
-        }
-        result
-    }
-
-    fn push_var(&mut self, key: &str, value: &Option<OsString>) {
-        self.old_vars.insert(key.to_owned(), env::var_os(key));
-        match *value {
-            Some(ref v) => env::set_var(key, v),
-            None => env::remove_var(key),
-        }
-    }
-}
-
-impl<'a> Drop for Environment<'a> {
-    fn drop(&mut self) {
-        for (k, v) in &self.old_vars {
-            match *v {
-                Some(ref v) => env::set_var(k, v),
-                None => env::remove_var(k),
-            }
-        }
     }
 }

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -26,7 +26,8 @@ use self::syntax::ast;
 use self::syntax::codemap::{FileLoader, RealFileLoader};
 
 use config::Config;
-use build::{BufWriter, BuildResult, Environment};
+use build::{BufWriter, BuildResult};
+use build::environment::{Environment, EnvironmentLockFacade};
 use data::Analysis;
 use vfs::Vfs;
 
@@ -38,7 +39,7 @@ use std::sync::{Arc, Mutex};
 
 
 // Runs a single instance of rustc. Runs in-process.
-pub fn rustc(vfs: &Vfs, args: &[String], envs: &HashMap<String, Option<OsString>>, build_dir: &Path, rls_config: Arc<Mutex<Config>>) -> BuildResult {
+pub fn rustc(vfs: &Vfs, args: &[String], envs: &HashMap<String, Option<OsString>>, build_dir: &Path, rls_config: Arc<Mutex<Config>>, env_lock: EnvironmentLockFacade) -> BuildResult {
     trace!("rustc - args: `{:?}`, envs: {:?}, build dir: {:?}", args, envs, build_dir);
 
     let changed = vfs.get_cached_files();
@@ -49,7 +50,9 @@ pub fn rustc(vfs: &Vfs, args: &[String], envs: &HashMap<String, Option<OsString>
         local_envs.insert(String::from("RUST_LOG"), None);
     }
 
-    let _restore_env = Environment::push(&local_envs);
+    let (guard, _) = env_lock.lock();
+    let _restore_env = Environment::push_with_lock(&local_envs, guard);
+
     let buf = Arc::new(Mutex::new(vec![]));
     let err_buf = buf.clone();
     let args = args.to_owned();

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -76,6 +76,7 @@ pub fn rustc(vfs: &Vfs, args: &[String], envs: &HashMap<String, Option<OsString>
         .unwrap());
 
     let analysis = analysis.lock().unwrap().clone();
+    let analysis = analysis.map(|analysis| vec![analysis]).unwrap_or(vec![]);
     match exit_code {
         Ok(0) => BuildResult::Success(stderr_json_msg, analysis),
         _ => BuildResult::Failure(stderr_json_msg, analysis),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -465,9 +465,11 @@ fn test_simple_workspace() {
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
-                                       // TODO: it'd be convenient to test if compilation encountered an internal error
-                                       // or at least to check stderr's contents. We shouldn't check for presence of a warning here
-                                       ExpectedMessage::new(None).expect_contains("unused variable: `a`"),
+                                       // TODO: Ideally we should check for message contents for different crates/targets,
+                                       // however order of received messages is non-deterministic and this
+                                       // would require implementing something like `or_expect_contains`
+                                       ExpectedMessage::new(None).expect_contains("publishDiagnostics"),
+                                       ExpectedMessage::new(None).expect_contains("publishDiagnostics"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
 }
 

--- a/test_data/simple_workspace/member_lib/src/lib.rs
+++ b/test_data/simple_workspace/member_lib/src/lib.rs
@@ -1,5 +1,7 @@
 pub struct MemberLibStruct;
 
+struct Unused;
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
This is a first step to not be as reliant on Cargo and makes it so RLS uses linked compiler instead of `rustc` or `$RUSTC` process.
Passing analysis data from the compiler should be faster in few cases since analysis data will be passed in-memory, rather than unconditionally via file on disk. Additionally `cargo` routine can now collect diagnostics messages and display them until subsequent bare `rustc` build routine is performed. 