### PR TITLE
Ignore invalid file URI scheme in parse_file_path et al.

### DIFF
--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use std::collections::HashMap;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::path::PathBuf;
 use std::error::Error;
 
@@ -22,11 +22,32 @@ use vfs::FileContents;
 
 pub use ls_types::*;
 
-pub fn parse_file_path(uri: &Url) -> Result<PathBuf, Box<Error>> {
+#[derive(Debug)]
+pub enum UrlFileParseError {
+    InvalidScheme,
+    InvalidFilePath
+}
+
+impl Error for UrlFileParseError {
+    fn description(&self) -> &str {
+        match *self {
+            UrlFileParseError::InvalidScheme => "URI scheme is not `file`",
+            UrlFileParseError::InvalidFilePath => "Invalid file path in URI",
+        }
+    }
+}
+
+impl fmt::Display for UrlFileParseError where UrlFileParseError: Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+pub fn parse_file_path(uri: &Url) -> Result<PathBuf, UrlFileParseError> {
     if uri.scheme() != "file" {
-        Err("URI scheme is not `file`".into())
+        Err(UrlFileParseError::InvalidScheme)
     } else {
-        uri.to_file_path().map_err(|_err| "Invalid file path in URI".into())
+        uri.to_file_path().map_err(|_err| UrlFileParseError::InvalidFilePath)
     }
 }
 
@@ -59,7 +80,7 @@ pub mod ls_util {
                             span::Column::new_zero_indexed(p.character as u32))
     }
 
-    pub fn location_to_rls(l: Location) -> Result<span::Span<span::ZeroIndexed>, Box<Error>> {
+    pub fn location_to_rls(l: Location) -> Result<span::Span<span::ZeroIndexed>, UrlFileParseError> {
         parse_file_path(&l.uri).map(|path| Span::from_range(range_to_rls(l.range), path))
     }
 


### PR DESCRIPTION
(Somewhat) fixes #421 (and related).

This is a QoL (short-term) fix implemented as per @nrc's https://github.com/rust-lang-nursery/rls/issues/421#issuecomment-316521033:
> I think the best short-term solution is to not crash, notice non-file URLs and just ignore them.

This basically introduces `UrlFileParseError` implementing `Error` and it's now returned in a `Result<T, UrlFileParseError>` for `parse_file_path` and `convert_pos_to_span`, which uses it.

On an error that's related to invalid URI scheme, it just returns from the handler function.

`$log_name` and `$uri` variables in macro are used only for the underlying `trace!` macro call and I can remove them if it makes things unnecessarily verbose (repeating function name as literal, separating uri binding for clarity etc.).

I know that's not a complete fix, but at least it doesn't crash from what I've seen and properly works if a client edits the local file in `Source Control` option in VS Code (btw the non-`file` buffer is read-only in VS Code). 

Should I make a separate test case for non-`file` URIs?