### PR TITLE
Don't ignore incomplete server config, use default values if needed

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ use rustfmt::config::WriteMode;
 const DEFAULT_WAIT_TO_BUILD: u64 = 500;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub struct Config {
     pub sysroot: Option<String>,
     pub target: Option<String>,
@@ -35,8 +36,8 @@ pub struct Config {
     pub build_on_save: bool,
 }
 
-impl Config {
-    pub fn default() -> Config {
+impl Default for Config {
+    fn default() -> Config {
         Config {
             sysroot: None,
             target: None,


### PR DESCRIPTION
This probably fixes #431 and related.
In the current implementation serialization for RLS options can fail if not every option is provided, and if that happens, configuration is essentially ignored. Since for some time few options weren't included in the VS Code (and possibly ignored completely when using different clients) extension, user configuration had no effect.
This makes it so that missing options are set to the values set in `Default` impl for `Config`.