### PR TITLE
Infer appropriate crate target from workspace

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+pub use self::cargo::make_cargo_config;
+
 use data::Analysis;
 use vfs::Vfs;
 use config::Config;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -18,7 +18,7 @@ use env_logger;
 use serde_json;
 
 use analysis;
-use config::Config;
+use config::{Config, Inferrable};
 use server::{self as ls_server, ServerMessage, Request, Method};
 use jsonrpc_core;
 use vfs;
@@ -332,7 +332,7 @@ fn test_reformat_with_range() {
     ];
 
     let (mut server, results) = mock_server(messages);
-    
+
     // Initialise and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
@@ -356,7 +356,7 @@ fn test_multiple_binaries() {
     ];
 
     let mut config = Config::default();
-    config.build_bin = Some("bin2".to_owned());
+    config.build_bin = Inferrable::Specified(Some("bin2".to_owned()));
     let (mut server, results) = mock_server_with_config(messages, config);
     // Initialise and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
@@ -418,6 +418,7 @@ fn test_bin_lib_project() {
 
     let mut config = Config::default();
     config.cfg_test = true;
+    config.build_bin = Inferrable::Specified(Some("bin_lib".into()));
     let (mut server, results) = mock_server_with_config(messages, config);
     // Initialise and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
@@ -437,7 +438,10 @@ fn test_bin_lib_project_no_cfg_test() {
         ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())),
     ];
 
-    let (mut server, results) = mock_server(messages);
+    let mut config = Config::default();
+    config.build_lib = Inferrable::Specified(false);
+    config.build_bin = Inferrable::Specified(Some("bin_lib_no_cfg_test".into()));
+    let (mut server, results) = mock_server_with_config(messages, config);
     // Initialise and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -478,6 +478,63 @@ fn test_simple_workspace() {
 }
 
 #[test]
+fn test_infer_lib() {
+    let (cache, _tc) = init_env("infer_lib");
+
+    let root_path = cache.abs_path(Path::new("."));
+    let messages = vec![
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned()))
+    ];
+
+    let (mut server, results) = mock_server(messages);
+    // Initialise and build.
+    assert_eq!(ls_server::LsService::handle_message(&mut server),
+               ls_server::ServerStateChange::Continue);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
+                                       ExpectedMessage::new(None).expect_contains("struct is never used: `UnusedLib`"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
+}
+
+#[test]
+fn test_infer_bin() {
+    let (cache, _tc) = init_env("infer_bin");
+
+    let root_path = cache.abs_path(Path::new("."));
+    let messages = vec![
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned()))
+    ];
+
+    let (mut server, results) = mock_server(messages);
+    // Initialise and build.
+    assert_eq!(ls_server::LsService::handle_message(&mut server),
+               ls_server::ServerStateChange::Continue);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
+                                       ExpectedMessage::new(None).expect_contains("struct is never used: `UnusedBin`"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
+}
+
+#[test]
+fn test_infer_custom_bin() {
+    let (cache, _tc) = init_env("infer_custom_bin");
+
+    let root_path = cache.abs_path(Path::new("."));
+    let messages = vec![
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned()))
+    ];
+
+    let (mut server, results) = mock_server(messages);
+    // Initialise and build.
+    assert_eq!(ls_server::LsService::handle_message(&mut server),
+               ls_server::ServerStateChange::Continue);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
+                                       ExpectedMessage::new(None).expect_contains("struct is never used: `UnusedCustomBin`"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
+}
+
+#[test]
 fn test_omit_init_build() {
     let (cache, _tc) = init_env("omit_init_build");
 

--- a/test_data/infer_bin/Cargo.lock
+++ b/test_data/infer_bin/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "infer_bin"
+version = "0.1.0"
+

--- a/test_data/infer_bin/Cargo.toml
+++ b/test_data/infer_bin/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "infer_bin"
+version = "0.1.0"
+authors = ["Igor Matuszewski <Xanewok@gmail.com>"]
+
+[dependencies]

--- a/test_data/infer_bin/src/main.rs
+++ b/test_data/infer_bin/src/main.rs
@@ -1,0 +1,5 @@
+struct UnusedBin;
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/test_data/infer_custom_bin/Cargo.lock
+++ b/test_data/infer_custom_bin/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "infer_custom_bin"
+version = "0.1.0"
+

--- a/test_data/infer_custom_bin/Cargo.toml
+++ b/test_data/infer_custom_bin/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "infer_custom_bin"
+version = "0.1.0"
+authors = ["Igor Matuszewski <Xanewok@gmail.com>"]
+
+[[bin]]
+name = "custom_bin"
+path = "src/custom_bin.rs"
+
+[dependencies]

--- a/test_data/infer_custom_bin/src/custom_bin.rs
+++ b/test_data/infer_custom_bin/src/custom_bin.rs
@@ -1,0 +1,5 @@
+struct UnusedCustomBin;
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/test_data/infer_lib/Cargo.lock
+++ b/test_data/infer_lib/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "infer_lib"
+version = "0.1.0"
+

--- a/test_data/infer_lib/Cargo.toml
+++ b/test_data/infer_lib/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "infer_lib"
+version = "0.1.0"
+authors = ["Igor Matuszewski <Xanewok@gmail.com>"]
+
+[dependencies]

--- a/test_data/infer_lib/src/lib.rs
+++ b/test_data/infer_lib/src/lib.rs
@@ -1,0 +1,8 @@
+struct UnusedLib;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+    }
+}


### PR DESCRIPTION
This is only a proof-of-concept and needs some ironing out. Most importantly it'd be good to handle properly inferred/default and explicitly stated values when updating the config via LSP message. Additionally, it'd be good not to duplicate code that creates a `Workspace`, although I'm not really sure how to do that, as Workspace needs to be created with borrows and I'm not sure how to cleanly separate a struct that would hold the data and Workspace without running into self-borrowing issues when initializing.

Right now it works like this: On RLS initialize, call `infer_config_defaults` which creates a `Workspace` and queries appropriate package's targets to see which crate targets are available (including inferred `lib` and `bin` ones). Then, these are set as follows: prioritize `lib` over `bin`, and prefer default `bin` over a first `bin` on the list. These are just mindlessly copied into current config and during config change, we just ignore those (which we shouldn't, it needs work).

Everything marked with `TODO:` I'd like to resolve first before merging.