### PR TITLE
Append the label value of the primary spans of diagnostics to the LSP diagnostics message if it is available.

### DIFF
--- a/src/actions/compiler_message_parsing.rs
+++ b/src/actions/compiler_message_parsing.rs
@@ -105,7 +105,13 @@ pub fn parse(message: &str) -> Result<FileDiagnostic, ParseError> {
             None => String::new(),
         })),
         source: Some("rustc".into()),
-        message: message.message,
+        message: {
+            if let Some(label) = primary.label {
+                format!("{}\n{}", message.message, label)
+            } else {
+                message.message
+            }
+        },
     };
 
     Ok(FileDiagnostic {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -209,6 +209,25 @@ fn test_borrow_error() {
 }
 
 #[test]
+fn test_mismatched_types() {
+    let (cache, _tc) = init_env("mismatched_types");
+
+    let root_path = cache.abs_path(Path::new("."));
+    let messages = vec![
+        ServerMessage::initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned()))
+    ];
+
+    let (mut server, results) = mock_server(messages);
+    // Initialise and build.
+    assert_eq!(ls_server::LsService::handle_message(&mut server),
+               ls_server::ServerStateChange::Continue);
+    expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
+                                       ExpectedMessage::new(None).expect_contains(r#""message":"mismatched types\nexpected u32, found &str""#),
+                                       ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
+}
+
+#[test]
 fn test_highlight() {
     let (mut cache, _tc) = init_env("highlight");
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -204,7 +204,7 @@ fn test_borrow_error() {
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
-                                       ExpectedMessage::new(None).expect_contains(r#""message":"cannot borrow `x` as mutable more than once at a time""#),
+                                       ExpectedMessage::new(None).expect_contains(r#""message":"cannot borrow `x` as mutable more than once at a time\nsecond mutable borrow occurs here""#),
                                        ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
 }
 

--- a/test_data/mismatched_types/Cargo.lock
+++ b/test_data/mismatched_types/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "mismatched_types"
+version = "0.1.0"
+

--- a/test_data/mismatched_types/Cargo.toml
+++ b/test_data/mismatched_types/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "mismatched_types"
+version = "0.1.0"
+authors = ["Nelson Chen <crazysim@gmail.com>"]
+
+[dependencies]

--- a/test_data/mismatched_types/src/main.rs
+++ b/test_data/mismatched_types/src/main.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let a_string = "hoop";
+    u32_only(a_string);
+}
+
+fn u32_only(i: u32) -> u32 {
+    i
+}


### PR DESCRIPTION
This is very useful in diagnostic messages where the label has specific
diagnostics information for the site and little in the message. The most
popular message and an example is detailed as follows:

In cases like E0308 or better known as "mismatched types", the message
is simply "mismatched types".

Users seeing "mismatched types" in their editing buffers would have had
to immediately step out of their buffers and run whatever compiles the
line in their terminals to take a look at what is described here as the
label in order to figure out what and how the types are in conflict.

Related: https://github.com/rust-lang-nursery/rls-vscode/issues/103