### PR TITLE
Create and cache inter-target dep graph during Cargo build routine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,10 +98,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cargo"
 version = "0.22.0"
-source = "git+https://github.com/rust-lang/cargo#2f36e93c392c1895e640f534db9997b50cbd42e1"
+source = "git+https://github.com/rust-lang/cargo#bcf3997b1fa177afc5b6c632a6fbbf6cc75df427"
 dependencies = [
  "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "crates-io 0.11.0 (git+https://github.com/rust-lang/cargo)",
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -126,6 +127,7 @@ dependencies = [
  "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "psapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -179,9 +181,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crates-io"
 version = "0.11.0"
-source = "git+https://github.com/rust-lang/cargo#2f36e93c392c1895e640f534db9997b50cbd42e1"
+source = "git+https://github.com/rust-lang/cargo#bcf3997b1fa177afc5b6c632a6fbbf6cc75df427"
 dependencies = [
  "curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1224,6 +1243,8 @@ dependencies = [
 "checksum clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2267a8fdd4dce6956ba6649e130f62fb279026e5e84b92aa939ac8f85ce3f9f0"
 "checksum cmake 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ebbb35d3dc9cd09497168f33de1acb79b265d350ab0ac34133b98f8509af1f"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+"checksum core-foundation 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5909502e547762013619f4c4e01cc7393c20fe2d52d7fa471c1210adb2320dc7"
+"checksum core-foundation-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bc9fb3d6cb663e6fd7cf1c63f9b144ee2b1e4a78595a0451dd34bff85b9a3387"
 "checksum crates-io 0.11.0 (git+https://github.com/rust-lang/cargo)" = "<none>"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7034c534a1d7d22f7971d6088aa9d281d219ef724026c3428092500f41ae9c2c"

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -114,7 +114,7 @@ struct CompilationContext {
     build_dir: Option<PathBuf>,
     /// Build plan, which should know all the inter-package/target dependencies
     /// along with args/envs. Only contains inter-package dep-graph for now.
-    build_plan: Option<BuildPlan>,
+    build_plan: BuildPlan
 }
 
 impl CompilationContext {
@@ -123,7 +123,7 @@ impl CompilationContext {
             args: vec![],
             envs: HashMap::new(),
             build_dir: None,
-            build_plan: None,
+            build_plan: BuildPlan::new(),
         }
     }
 }


### PR DESCRIPTION
Depends on #448. Since it seems this PR also pulls this automatically, I'm not sure if it's possible to merge one and the other with proper history, so I can update this PR if #448 will be merged to include only the last commit.

Also depends on https://github.com/rust-lang/cargo/pull/4416, so until that's merged, I'm using the https://github.com/Xanewok/cargo/tree/more-executor-params branch with the changes.
By exposing `&Unit` in `Executor::init()` we can create a target dependency graph with ease, without having to explicitly copy over any Cargo code. This only currently fetches the dep graph after each `cargo` build routine, an example output (done for the `rls` itself) can be found here: https://pastebin.com/iSz4pcuK.

Next stage should be to cache exact `ProcessBuilder`s for executed units of work and create our own JobQueue (or maybe it'll be possible to reuse more Cargo API, since we'll have pseudo-`Unit`s at our disposal).