### PR TITLE
Cache processes to execute for the workspace inter-target dep graph

### DIFF
--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -10,7 +10,7 @@
 
 use cargo::core::{PackageId, Shell, Target, Workspace, Verbosity};
 use cargo::ops::{compile_with_exec, Executor, Context, Packages, CompileOptions, CompileMode, CompileFilter, Unit};
-use cargo::util::{Config as CargoConfig, ProcessBuilder, homedir, important_paths, ConfigValue, CargoResult};
+use cargo::util::{Config as CargoConfig, process_builder, ProcessBuilder, homedir, important_paths, ConfigValue, CargoResult};
 use cargo::util::errors::{CargoErrorKind, process_error};
 use serde_json;
 
@@ -271,7 +271,7 @@ impl Executor for RlsExecutor {
         self.is_primary_crate(id)
     }
 
-    fn exec(&self, cargo_cmd: ProcessBuilder, id: &PackageId, _target: &Target) -> CargoResult<()> {
+    fn exec(&self, cargo_cmd: ProcessBuilder, id: &PackageId, target: &Target) -> CargoResult<()> {
         // Delete any stale data. We try and remove any json files with
         // the same crate name as Cargo would emit. This includes files
         // with the same crate name but different hashes, e.g., those
@@ -384,6 +384,24 @@ impl Executor for RlsExecutor {
             if let Some(cwd) = cargo_cmd.get_cwd() {
                 cmd.current_dir(cwd);
             }
+        }
+
+        // Cache executed command for the build plan
+        {
+            let mut cx = self.compilation_cx.lock().unwrap();
+
+            let mut store_cmd = process_builder::process(&rustc_exe);
+            store_cmd.args(&args.iter().map(OsString::from).collect::<Vec<_>>());
+            for (k, v) in cargo_cmd.get_envs().clone() {
+                if let Some(v) = v {
+                    store_cmd.env(&k, v);
+                }
+            }
+            if let Some(cwd) = cargo_cmd.get_cwd() {
+                cmd.current_dir(cwd);
+            }
+
+            cx.build_plan.cache_compiler_job(id, target, &store_cmd);
         }
 
         // Prepare modified cargo-generated args/envs for future rustc calls

--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -246,7 +246,9 @@ impl Executor for RlsExecutor {
     fn init(&self, cx: &Context, unit: &Unit) {
         let mut compilation_cx = self.compilation_cx.lock().unwrap();
         let plan = &mut compilation_cx.build_plan;
-        if let Err(err) = plan.emplace_dep(&unit, &cx) {
+        let only_primary = |unit: &Unit| self.is_primary_crate(unit.pkg.package_id());
+
+        if let Err(err) = plan.emplace_dep_with_filter(&unit, &cx, &only_primary) {
             error!("{:?}", err);
         }
     }


### PR DESCRIPTION
Followup to #449. This limits the inter-target dep graph to the targets in the workspace and caches appropriate `rustc` commands (after being modified by the RLS) for appropriate units to build.

This still needs implementing fetching dirty target dep graphs, sorting the nodes topologically and implementing a simple job queue. If this is too little to merge right now, I can push more changes to this branch so more work can be merged at once if needed.