### PR TITLE
Use cached build plan mostly instead of Cargo to schedule a multi-target build 

### DIFF
--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -227,6 +227,8 @@ impl RlsExecutor {
         }
     }
 
+    /// Returns wheter a given package is a primary one (every member of the
+    /// workspace is considered as such).
     fn is_primary_crate(&self, id: &PackageId) -> bool {
         if self.workspace_mode {
             self.member_packages.lock().unwrap().contains(id)
@@ -253,13 +255,9 @@ impl Executor for RlsExecutor {
     }
 
     fn force_rebuild(&self, unit: &Unit) -> bool {
-        // TODO: Currently workspace_mode doesn't use rustc, so it doesn't
-        // need args. When we start using rustc, we might consider doing
-        // force_rebuild to retrieve args for given package if they're stale/missing
-        if self.workspace_mode {
-            return false;
-        }
-
+        // In workspace_mode we need to force rebuild every package in the
+        // workspace, even if it's not dirty at a time, to cache compiler
+        // invocations in the build plan.
         // We only do a cargo build if we want to force rebuild the last
         // crate (e.g., because some args changed). Therefore we should
         // always force rebuild the primary crate.

--- a/src/build/plan.rs
+++ b/src/build/plan.rs
@@ -8,44 +8,68 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashMap;
+//! This contains a build plan that is created during the Cargo build routine
+//! and stored afterwards, which can be later queried, given a list of dirty
+//! files, to retrieve a queue of compiler calls to be invoked (including
+//! appropriate arguments and env variables).
+//! The underlying structure is a dependency graph between simplified units
+//! (package id and crate target kind), as opposed to Cargo units (package with
+//! a target info, including crate target kind, profile and host/target kind).
+//! This will be used for a quick check recompilation and does not aim to
+//! reimplement all the intricacies of Cargo.
+//! The unit dependency graph in Cargo also distinguishes between compiling the
+//! build script and running it and collecting the build script output to modify
+//! the subsequent compilations etc. Since build script executions (not building)
+//! are not exposed via `Executor` trait in Cargo, we simply coalesce every unit
+//! with a same package and crate target kind (e.g. both building and running
+//! build scripts).
+
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 use cargo::core::{PackageId, Profile, Target, TargetKind};
 use cargo::ops::{Kind, Unit, Context};
 use cargo::util::{CargoResult, ProcessBuilder};
 
-pub type DependencyGraph = HashMap<OwnedUnit, Vec<OwnedUnit>>;
+/// Main key type by which `Unit`s will be distinguished in the build plan.
+pub type UnitKey = (PackageId, TargetKind);
 /// Holds the information how exactly the build will be performed for a given
 /// workspace with given, specified features.
-/// **TODO:** Use it to schedule an analysis build instead of relying on Cargo
-/// invocations.
 pub struct Plan {
-    pub dep_graph: DependencyGraph,
-    /// We don't make a distinction between Units with different Profiles,
-    /// as we're practically interested in bin, lib and (built, not run)
-    /// build scripts for each package, because for these we can run `rustc` job
-    pub compiler_jobs: HashMap<(PackageId, TargetKind), ProcessBuilder>,
+    // Stores a full Cargo `Unit` data for a first processed unit with a given key.
+    pub units: HashMap<UnitKey, OwnedUnit>,
+    // Main dependency graph between the simplified units.
+    pub dep_graph: HashMap<UnitKey, HashSet<UnitKey>>,
+    /// Reverse dependency graph that's used to construct a dirty compiler call queue.
+    pub rev_dep_graph: HashMap<UnitKey, HashSet<UnitKey>>,
+    /// Cached compiler calls used when creating a compiler call queue.
+    pub compiler_jobs: HashMap<UnitKey, ProcessBuilder>,
 }
 
 impl Plan {
     pub fn new() -> Plan {
         Plan {
+            units: HashMap::new(),
             dep_graph: HashMap::new(),
+            rev_dep_graph: HashMap::new(),
             compiler_jobs: HashMap::new(),
         }
     }
 
+    pub fn clear(&mut self) {
+        *self = Plan::new();
+    }
 
-    /// Cache a given compiler invocation in `ProcessBuilder` for a given `PackageId`
-    /// and `TargetKind` in `Target`, to be used when processing cached  build plan
+    /// Cache a given compiler invocation in `ProcessBuilder` for a given
+    /// `PackageId` and `TargetKind` in `Target`, to be used when processing
+    /// cached build plan.
     pub fn cache_compiler_job(&mut self, id: &PackageId, target: &Target, cmd: &ProcessBuilder) {
         let pkg_key = (id.clone(), target.kind().clone());
         self.compiler_jobs.insert(pkg_key, cmd.clone());
     }
 
     /// Emplace a given `Unit`, along with its `Unit` dependencies (recursively)
-    /// into dependency graph
+    /// into the dependency graph.
     #[allow(dead_code)]
     pub fn emplace_dep(&mut self, unit: &Unit, cx: &Context) -> CargoResult<()> {
         let null_filter = |_unit: &Unit| { true };
@@ -53,51 +77,76 @@ impl Plan {
     }
 
     /// Emplace a given `Unit`, along with its `Unit` dependencies (recursively)
-    /// into dependency graph as long as the passed `Unit` isn't filtered out by
-    /// the `filter` closure.
+    /// into the dependency graph as long as the passed `Unit` isn't filtered
+    /// out by the `filter` closure.
     pub fn emplace_dep_with_filter<Filter>(&mut self,
                                            unit: &Unit,
                                            cx: &Context,
                                            filter: &Filter) -> CargoResult<()>
                                            where Filter: Fn(&Unit) -> bool {
-        // We might not want certain deps to be added transitively (e.g. when
-        // creating only a sub-dep-graph, limiting the scope to the workspace)
-        if filter(unit) == false { return Ok(()); }
+        if !filter(unit) { return Ok(()); }
 
-        let key: OwnedUnit = unit.into();
-        // Process only those units, which are not yet in the dep graph
-        if let None = self.dep_graph.get(&key) {
-            let units = cx.dep_targets(unit)?;
-            let dep_keys: Vec<OwnedUnit> = units
-                                          .iter()
-                                          .map(|x| x.into())
-                                          .collect();
-            self.dep_graph.insert(key, dep_keys);
-            // Recursively process other remaining dependencies.
-            // TODO: Should we be careful about blowing the stack and do it
-            // iteratively instead?
-            for unit in units {
-                self.emplace_dep_with_filter(&unit, cx, filter)?;
-            }
+        let key = key_from_unit(unit);
+        self.units.entry(key.clone()).or_insert(unit.into());
+        // Process only those units, which are not yet in the dep graph.
+        if self.dep_graph.get(&key).is_some() { return Ok(()); }
+
+        // Keep all the additional Unit information for a given unit (It's
+        // worth remembering, that the units are only discriminated by a
+        // pair of (PackageId, TargetKind), so only first occurrence will be saved.
+        self.units.insert(key.clone(), unit.into());
+
+        // Fetch and insert relevant unit dependencies to the forward dep graph.
+        let units = cx.dep_targets(unit)?;
+        let dep_keys: HashSet<UnitKey> = units.iter()
+            // We might not want certain deps to be added transitively (e.g.
+            // when creating only a sub-dep-graph, limiting the scope).
+            .filter(|unit| filter(unit))
+            .map(key_from_unit)
+            // Units can depend on others with different Targets or Profiles
+            // (e.g. different `run_custom_build`) despite having the same UnitKey.
+            // We coalesce them here while creating the UnitKey dep graph.
+            .filter(|dep| key != *dep)
+            .collect();
+        self.dep_graph.insert(key.clone(), dep_keys.clone());
+
+        // We also need to track reverse dependencies here, as it's needed
+        // to quickly construct a work sub-graph from a set of dirty units.
+        self.rev_dep_graph.entry(key.clone()).or_insert(HashSet::new());
+        for unit in dep_keys {
+            let revs = self.rev_dep_graph.entry(unit).or_insert(HashSet::new());
+            revs.insert(key.clone());
+        }
+
+        // Recursively process other remaining forward dependencies.
+        for unit in units {
+            self.emplace_dep_with_filter(&unit, cx, filter)?;
         }
         Ok(())
     }
+}
 
-    pub fn clear(&mut self) {
-        self.dep_graph.clear();
-        self.compiler_jobs.clear();
+fn key_from_unit(unit: &Unit) -> UnitKey {
+    (unit.pkg.package_id().clone(), unit.target.kind().clone())
+}
+
+macro_rules! print_dep_graph {
+    ($name: expr, $graph: expr, $f: expr) => {
+        $f.write_str(&format!("{}:\n", $name))?;
+        for (key, deps) in &$graph {
+            $f.write_str(&format!("{:?}\n", key))?;
+            for dep in deps {
+                $f.write_str(&format!("- {:?}\n", dep))?;
+            }
+        }
     }
 }
 
 impl fmt::Debug for Plan {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("Dep graph:\n")?;
-        for (key, deps) in &self.dep_graph {
-            f.write_str(&format!("{:?}\n", key))?;
-            for dep in deps {
-                f.write_str(&format!("- {:?}\n", dep))?;
-            }
-        }
+        f.write_str(&format!("Units: {:?}\n", self.units))?;
+        print_dep_graph!("Dependency graph", self.dep_graph, f);
+        print_dep_graph!("Reverse dependency graph", self.rev_dep_graph, f);
         f.write_str(&format!("Compiler jobs: {:?}\n", self.compiler_jobs))?;
         Ok(())
     }

--- a/src/build/plan.rs
+++ b/src/build/plan.rs
@@ -293,10 +293,8 @@ impl JobQueue {
             trace!("Executing: {:?}", job);
             let mut args: Vec<_> = job.get_args().iter().cloned()
                 .map(|x| x.into_string().unwrap()).collect();
-            // TODO: is it crucial to pass *actual* executed program (e.g. rustc
-            // shim) or does the compiler API just care about the order and not
-            // which exact binary was run (1st argument)?
-            args.insert(0, "rustc".to_owned());
+
+            args.insert(0, job.get_program().clone().into_string().unwrap());
 
             match super::rustc::rustc(&internals.vfs, &args, job.get_envs(),
                                       &build_dir, internals.config.clone(),


### PR DESCRIPTION
WIP: This needs only plugging the logic in the `build/mod.rs`, which is relatively a small amount of work, but wanted to get a feedback if things are going in a good direction.
@nrc could you take a look and tell me if the overall design is good and if there are any obvious mistakes? I tried to debug and test intermediate functions and behaviour using the RLS and different crates and it works as intended, at least from what I tested on single-package projects.

This probably still will need some tweaking on the vfs side, as `vfs.get_changes().iter().map(|(k,_)| k.clone()).collect()` seems to retrieve not only dirty files, also disk-synced files, which are only open (which might fool the dirty crate heuristics).