### PR TITLE
Revert "Remove unnecessary `&`"

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -257,7 +257,7 @@ impl ActionHandler {
 
     pub fn find_impls<O: Output>(&self, id: usize, params: TextDocumentPositionParams, out: O) {
         let t = thread::current();
-        let file_path = parse_file_path!(params.text_document.uri, "find_impls");
+        let file_path = parse_file_path!(&params.text_document.uri, "find_impls");
         let span = self.convert_pos_to_span(file_path, params.position);
         let type_id = self.analysis.id(&span).expect("Analysis: Getting typeid from span");
         let analysis = self.analysis.clone();


### PR DESCRIPTION
This reverts commit ca84ba5c2a8498425d6002739325d3ebbf267f2e.
Other `parse_file_path!`s have also `&` arguments and this fixes a compilation error.
@nrc r?