### PR TITLE
server: generalize Output.notify

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -160,7 +160,10 @@ impl InitActionContext {
             }
         };
 
-        out.notify("rustDocument/beginBuild");
+        out.notify(NotificationMessage::new(
+            NOTIFICATION_BUILD_BEGIN,
+            None,
+        ));
         self.build_queue.request_build(project_path, priority, move |result| {
             pbh.handle(result)
         });

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -21,6 +21,11 @@ use racer;
 use vfs::FileContents;
 
 pub use ls_types::*;
+use jsonrpc_core::version;
+
+pub const NOTIFICATION_DIAGNOSTICS_BEGIN: &'static str = "rustDocument/diagnosticsBegin";
+pub const NOTIFICATION_DIAGNOSTICS_END:   &'static str = "rustDocument/diagnosticsEnd";
+pub const NOTIFICATION_BUILD_BEGIN:       &'static str = "rustDocument/beginBuild";
 
 #[derive(Debug)]
 pub enum UrlFileParseError {
@@ -216,20 +221,18 @@ impl Default for InitializationOptions {
 
 /// An event-like (no response needed) notification message.
 #[derive(Debug, Serialize)]
-pub struct NotificationMessage<T>
-    where T: Debug + Serialize
-{
-    jsonrpc: &'static str,
-    pub method: String,
-    pub params: T,
+pub struct NotificationMessage {
+    jsonrpc: version::Version,
+    pub method: &'static str,
+    pub params: Option<PublishDiagnosticsParams>,
 }
 
-impl <T> NotificationMessage<T> where T: Debug + Serialize {
-    pub fn new(method: String, params: T) -> Self {
+impl NotificationMessage {
+    pub fn new(method: &'static str, params: Option<PublishDiagnosticsParams>) -> Self {
         NotificationMessage {
-            jsonrpc: "2.0",
-            method: method,
-            params: params
+            jsonrpc: version::Version::V2,
+            method,
+            params,
         }
     }
 }

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -123,11 +123,8 @@ pub trait Output: Sync + Send + Clone + 'static {
         self.response(output);
     }
 
-    fn notify(&self, message: &str) {
-        let output = serde_json::to_string(
-            &NotificationMessage::new(message.to_owned(), ())
-        ).unwrap();
-        self.response(output);
+    fn notify(&self, notification: NotificationMessage) {
+        self.response(serde_json::to_string(&notification).unwrap());
     }
 }
 


### PR DESCRIPTION
Fixes #43.

Subject line is maybe a bit confusing since this specializes `Output.notify` over the argument, but generalizes it over the encoding.

I was tempted to replace `lsp_data:: NotificationMessage` with [`jsonrpc_core::types::request::Notification`](https://docs.rs/jsonrpc-core/7.1.1/jsonrpc_core/types/request/struct.Notification.html) but that structure doesn't permit us to keep using [`languageserver_types::PublishDiagnosticsParams`](https://docs.rs/languageserver-types/0.12.0/languageserver_types/struct.PublishDiagnosticsParams.html).