### PR TITLE
Fixed parsing NoParams. Added version printing to debug logs. More types now derive Debug.

### DIFF
--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -22,6 +22,7 @@ use server::{Output, Action, NotificationAction, LsState, NoParams};
 
 use std::thread;
 
+#[derive(Debug, PartialEq)]
 pub struct Initialized;
 
 impl<'a> Action<'a> for Initialized {
@@ -58,6 +59,7 @@ impl<'a> NotificationAction<'a> for Initialized {
     }
 }
 
+#[derive(Debug)]
 pub struct DidOpen;
 
 impl<'a> Action<'a> for DidOpen {
@@ -80,6 +82,7 @@ impl<'a> NotificationAction<'a> for DidOpen {
     }
 }
 
+#[derive(Debug)]
 pub struct DidChange;
 
 impl<'a> Action<'a> for DidChange {
@@ -122,6 +125,7 @@ impl<'a> NotificationAction<'a> for DidChange {
     }
 }
 
+#[derive(Debug)]
 pub struct Cancel;
 
 impl<'a> Action<'a> for Cancel {
@@ -140,6 +144,7 @@ impl<'a> NotificationAction<'a> for Cancel {
     }
 }
 
+#[derive(Debug)]
 pub struct DidChangeConfiguration;
 
 impl<'a> Action<'a> for DidChangeConfiguration {
@@ -223,6 +228,7 @@ impl<'a> NotificationAction<'a> for DidChangeConfiguration {
     }
 }
 
+#[derive(Debug)]
 pub struct DidSave;
 
 impl<'a> Action<'a> for DidSave {
@@ -249,6 +255,7 @@ impl<'a> NotificationAction<'a> for DidSave {
     }
 }
 
+#[derive(Debug)]
 pub struct DidChangeWatchedFiles;
 
 impl<'a> Action<'a> for DidChangeWatchedFiles {


### PR DESCRIPTION
This fixes the problems mentioned here: https://github.com/rust-lang-nursery/rls/issues/214#issuecomment-330675842

Changed the `param` of `RawMessage` to represent the lack of parameters internally with a `serde_json::Value::Null`. This is because it's hard to parse `Option<serde_json::Value>` into an arbitrary type (an associated type of a `Notification` or a `Request`), as it doesn't implement `Deserializable`. Once `TryFrom` stabilises, I think it can be used, if `Option<serde_json::Value>` is preferable.

With these fixes, RLS now works for me with SublimeText and LSP.

Also, I found out as a new contributor that it was hard to know which version of RLS was running inside your editor, so I added version printing in the debug logs, like this: `Language Server Starting up. Version: rls-preview 0.122.0-nightly (ccc6218 2017-09-20)`. It should be a generally useful thing to have, right?