### PR TITLE
Preserve UTF-8 file path in the resulting compiler diagnostics

### DIFF
--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -236,25 +236,23 @@ fn emit_notifications<O: Output>(
 ) {
     let cwd = ::std::env::current_dir().unwrap();
 
-    build_results
-        .iter()
-        .for_each(|(path, diagnostics)| {
-            let params = PublishDiagnosticsParams {
-                uri: Url::from_file_path(cwd.join(path)).unwrap(),
-                diagnostics: diagnostics.iter()
-                    .filter_map(|&(ref d, _)| {
-                        if show_warnings || d.severity != Some(DiagnosticSeverity::Warning) {
-                            Some(d.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect(),
-            };
+    for (path, diagnostics) in build_results {
+        let params = PublishDiagnosticsParams {
+            uri: Url::from_file_path(cwd.join(path)).unwrap(),
+            diagnostics: diagnostics.iter()
+                .filter_map(|&(ref d, _)| {
+                    if show_warnings || d.severity != Some(DiagnosticSeverity::Warning) {
+                        Some(d.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        };
 
-            out.notify(NotificationMessage::new(
-                ls_types::NOTIFICATION__PublishDiagnostics,
-                Some(params),
-            ));
-        })
+        out.notify(NotificationMessage::new(
+            ls_types::NOTIFICATION__PublishDiagnostics,
+            Some(params),
+        ));
+    }
 }

--- a/test_data/unicødë/Cargo.lock
+++ b/test_data/unicødë/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "unicødë"
+version = "0.1.0"
+

--- a/test_data/unicødë/Cargo.toml
+++ b/test_data/unicødë/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "unicødë"
+version = "0.1.0"
+authors = ["Igor Matuszewski <Xanewok@gmail.com>"]
+
+[dependencies]

--- a/test_data/unicødë/src/lib.rs
+++ b/test_data/unicødë/src/lib.rs
@@ -1,0 +1,9 @@
+struct Unused {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
Fixes rust-lang-nursery/rls-vscode#151.

Here is more context on the issue: https://github.com/rust-lang-nursery/rls-vscode/issues/151#issuecomment-331621292.

In short, `convert_message_to_json_strings()` didn't fully reconstruct utf-8 characters.
@nrc what's the cause for the [FIXME](https://github.com/rust-lang-nursery/rls/compare/master...Xanewok:utf8-diagnostics?expand=1#diff-48b18d7151f11423d709ca98bee07cefL187)?
The function is only called for rustc, not Cargo.
It looks like emitting json from rustc works, from what I can tell (am I missing something?) and that separate messages are emitted in each line, so I:
1. naively parse the string from utf8-stream (safe?)
2. split by lines
3. return the `Vec<String>` containing json strings

However, I'm not sure if that's correct/safe approach and what edge cases am I missing.