### PR TITLE
support "workspace/symbol" lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-analysis 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-analysis 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-rustc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -759,7 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rls-analysis"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1320,7 +1320,7 @@ dependencies = [
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
-"checksum rls-analysis 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4302cc8291570d7f817945845d8c01756e833dbc93c0a87d4f6c9a0b0b7992f1"
+"checksum rls-analysis 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fa390bdc70b0a90d07d9cd5c6989ba5fca2d59728903919ebda1a1b2037b18d7"
 "checksum rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11d339f1888e33e74d8032de0f83c40b2bdaaaf04a8cfc03b32186c3481fb534"
 "checksum rls-rustc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b21ea952e9bf1569929abf1bb920262cde04b7b1b26d8e0260286302807299d2"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ languageserver-types = "0.12"
 lazy_static = "0.2"
 log = "0.3"
 racer = "2.0.6"
-rls-analysis = "0.6.7"
+rls-analysis = "0.6.8"
 rls-data = { version = "0.10", features = ["serialize-serde"] }
 rls-rustc = "0.1"
 rls-span = { version = "0.4", features = ["serialize-serde"] }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -333,6 +333,7 @@ impl<O: Output> LsService<O> {
                 requests::FindImpls,
                 requests::Deglob,
                 requests::Symbols,
+                requests::WorkspaceSymbol,
                 requests::Formatting,
                 requests::RangeFormatting,
                 requests::Hover;

--- a/test_data/workspace_symbol/Cargo.lock
+++ b/test_data/workspace_symbol/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "workspace_symbol"
+version = "0.1.0"
+

--- a/test_data/workspace_symbol/Cargo.toml
+++ b/test_data/workspace_symbol/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "workspace_symbol"
+version = "0.1.0"
+authors = ["Stuart Hinson <stuart.hinson@gmail.com>"]
+
+[dependencies]

--- a/test_data/workspace_symbol/src/foo.rs
+++ b/test_data/workspace_symbol/src/foo.rs
@@ -1,0 +1,1 @@
+mod nemo {}

--- a/test_data/workspace_symbol/src/main.rs
+++ b/test_data/workspace_symbol/src/main.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod x {
+    pub fn nemo() {}
+}
+
+mod foo;
+
+pub fn main() {
+    x::nemo();
+}


### PR DESCRIPTION
Support for workspace/symbol, https://github.com/rust-lang-nursery/rls/issues/353

Depends on https://github.com/nrc/rls-analysis/commit/f04c79c9d3c02b6529c3098edd9256202674832b , so Cargo.toml will need to be updated with the new rls-analysis version (once it's released) to compile.

