### PR TITLE
Add support for cargo features

### DIFF
--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -147,6 +147,9 @@ fn run_cargo(compilation_cx: Arc<Mutex<CompilationContext>>,
                                 // TODO: Support more crate target types
                                 &[], false, &[], false, &[], false,
                                 false),
+        features: &opts.features,
+        all_features: opts.all_features,
+        no_default_features: opts.no_default_features,
         .. CompileOptions::default(&config, CompileMode::Check)
     };
 
@@ -438,6 +441,9 @@ struct CargoOptions {
     bins: bool,
     all: bool,
     exclude: Vec<String>,
+    all_features: bool,
+    no_default_features: bool,
+    features: Vec<String>,
 }
 
 impl Default for CargoOptions {
@@ -450,6 +456,9 @@ impl Default for CargoOptions {
             bins: false,
             all: false,
             exclude: vec![],
+            all_features: false,
+            no_default_features: false,
+            features: vec![],
         }
     }
 }
@@ -466,6 +475,9 @@ impl CargoOptions {
                 package,
                 all,
                 target: config.target.clone(),
+                features: config.features.clone(),
+                all_features: config.all_features,
+                no_default_features: config.no_default_features,
                 .. CargoOptions::default()
             }
         } else {
@@ -486,6 +498,9 @@ impl CargoOptions {
                 lib,
                 bin,
                 target: config.target.clone(),
+                features: config.features.clone(),
+                all_features: config.all_features,
+                no_default_features: config.no_default_features,
                 .. CargoOptions::default()
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,6 +117,9 @@ pub struct Config {
     /// Cargo target dir. If set overrides the default one.
     #[serde(skip_deserializing, skip_serializing)]
     pub target_dir: Option<PathBuf>,
+    pub features: Vec<String>,
+    pub all_features: bool,
+    pub no_default_features: bool,
 }
 
 impl Default for Config {
@@ -138,6 +141,9 @@ impl Default for Config {
             build_on_save: false,
             use_crate_blacklist: true,
             target_dir: None,
+            features: vec![],
+            all_features: false,
+            no_default_features: false,
         };
         result.normalise();
         result

--- a/test_data/features/Cargo.lock
+++ b/test_data/features/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "features"
+version = "0.1.0"
+

--- a/test_data/features/Cargo.toml
+++ b/test_data/features/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "features"
+version = "0.1.0"
+authors = ["Bastien Orivel <eijebong@bananium.fr>"]
+
+[features]
+default = ["baz"]
+foo = []
+bar = []
+baz = []

--- a/test_data/features/src/main.rs
+++ b/test_data/features/src/main.rs
@@ -1,0 +1,14 @@
+#[cfg(feature = "foo")]
+pub struct Foo;
+
+#[cfg(feature = "bar")]
+pub struct Bar;
+
+#[cfg(feature = "baz")]
+pub struct Baz;
+
+fn main() {
+    Foo {};
+    Bar {};
+    Baz {};
+}


### PR DESCRIPTION
I just mirrored the cargo build option within the rls config struct.

For some reasons I have some tests writing to stderr, I can't figure out where this is coming from. I don't know if it's a problem in my tests or not.