### PR TITLE
Update rls-analysis and rls-data dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,8 +9,8 @@ dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-analysis 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-analysis 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-data 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-rustc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-vfs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -759,19 +759,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rls-analysis"
-version = "0.6.8"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-data 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rls-data"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1320,8 +1320,8 @@ dependencies = [
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
-"checksum rls-analysis 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fa390bdc70b0a90d07d9cd5c6989ba5fca2d59728903919ebda1a1b2037b18d7"
-"checksum rls-data 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11d339f1888e33e74d8032de0f83c40b2bdaaaf04a8cfc03b32186c3481fb534"
+"checksum rls-analysis 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd4e96e3a7d4cf3f31d789080ddd88fbe3251df2feb168049a24eda8b6046ed8"
+"checksum rls-data 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aea328fa69702c1b0fc395f2c71eae954bf984ac1e418c72f69221b6e3d15ff"
 "checksum rls-rustc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b21ea952e9bf1569929abf1bb920262cde04b7b1b26d8e0260286302807299d2"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rls-vfs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd34691a510938bb67fe0444fb363103c73ffb31c121d1e16bc92d8945ea8ff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ languageserver-types = "0.12"
 lazy_static = "0.2"
 log = "0.3"
 racer = "2.0.6"
-rls-analysis = "0.6.8"
-rls-data = { version = "0.10", features = ["serialize-serde"] }
+rls-analysis = "0.7"
+rls-data = { version = "0.11", features = ["serialize-serde"] }
 rls-rustc = "0.1"
 rls-span = { version = "0.4", features = ["serialize-serde"] }
 rls-vfs = { version = "0.4", features = ["racer-impls"] }

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -150,6 +150,8 @@ pub mod ls_util {
 pub fn source_kind_from_def_kind(k: DefKind) -> SymbolKind {
     match k {
         DefKind::Enum => SymbolKind::Enum,
+        DefKind::TupleVariant => SymbolKind::Constant,
+        DefKind::StructVariant => SymbolKind::Class,
         DefKind::Tuple => SymbolKind::Array,
         DefKind::Struct => SymbolKind::Class,
         DefKind::Union => SymbolKind::Class,
@@ -158,7 +160,8 @@ pub fn source_kind_from_def_kind(k: DefKind) -> SymbolKind {
         DefKind::Method |
         DefKind::Macro => SymbolKind::Function,
         DefKind::Mod => SymbolKind::Module,
-        DefKind::Type => SymbolKind::Interface,
+        DefKind::Type |
+        DefKind::ExternType => SymbolKind::Interface,
         DefKind::Local |
         DefKind::Static |
         DefKind::Const |

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -165,7 +165,7 @@ fn test_workspace_symbol() {
                                                                      // in foo.rs
                                                                      .expect_contains(r#"foo.rs"#)
                                                                      .expect_contains(r#""name":"nemo""#)
-                                                                     .expect_contains(r#""kind":2"#)
+                                                                     .expect_contains(r#""kind":5"#)
                                                                      .expect_contains(r#""range":{"start":{"line":0,"character":4},"end":{"line":0,"character":8}}"#)
                                                                      .expect_contains(r#""containerName":"foo""#)]);
 }


### PR DESCRIPTION
This will allow implementation of new DefKinds. 

The test needed to be adjusted because three new DefKind values were introduced, two of which were inserted at positions before DefKind::Struct.