### PR TITLE
Revert the UTF-8 test directory in the repository

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -712,25 +712,24 @@ fn test_find_impls() {
     // ]);
 }
 
-#[test]
-fn test_handle_utf8_directory() {
-    let mut env = Environment::new("unicødë");
-
-    let root_path = env.cache.abs_path(Path::new("."));
-    let root_url = Url::from_directory_path(&root_path).unwrap();
-    let messages = vec![
-        initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string()
-    ];
-
-    let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
-    assert_eq!(ls_server::LsService::handle_message(&mut server),
-               ls_server::ServerStateChange::Continue);
-    expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-                                       ExpectedMessage::new(None).expect_contains("beginBuild"),
-                                       ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
-                                       ExpectedMessage::new(None)
-                                           .expect_contains(root_url.path())
-                                           .expect_contains("struct is never used: `Unused`"),
-                                       ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);
-}
+// #[test]
+// fn test_handle_utf8_directory) {
+//     let mut env = Environment::new("unicødë");
+//
+//     let root_path = env.cache.abs_path(Path::new("."));
+//     let root_url = Url::from_directory_path(&root_path).unwrap();
+//     let messages = vec![
+//         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string()
+//     ];
+//
+//     let (mut server, results) = env.mock_server(messages);
+//     // Initialise and build.
+//     assert_eq!(ls_server::LsService::handle_message(&mut server),
+//                ls_server::ServerStateChange::Continue);
+//     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+//                                        ExpectedMessage::new(None).expect_contains("beginBuild"),
+//                                        ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
+//                                        ExpectedMessage::new(None)
+//                                            .expect_contains(root_url.path())
+//                                            .expect_contains("struct is never used: `Unused`"),
+//                                        ExpectedMessage::new(None).expect_contains("diagnosticsEnd")]);

--- a/test_data/unicødë/Cargo.lock
+++ b/test_data/unicødë/Cargo.lock
@@ -1,4 +1,0 @@
-[root]
-name = "unicødë"
-version = "0.1.0"
-

--- a/test_data/unicødë/Cargo.toml
+++ b/test_data/unicødë/Cargo.toml
@@ -1,6 +1,0 @@
-[package]
-name = "unicødë"
-version = "0.1.0"
-authors = ["Igor Matuszewski <Xanewok@gmail.com>"]
-
-[dependencies]

--- a/test_data/unicødë/src/lib.rs
+++ b/test_data/unicødë/src/lib.rs
@@ -1,9 +1,0 @@
-struct Unused {}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}


### PR DESCRIPTION
Fixes #506.

This removes the unicode test data folder for now. Faulty handling
prevents building rustc under macOS, so the test itself is also
commented out for now. When this is fixed, this test should be restored
(revert this commit) or reintroduced when another test harness is
introduced.