### PR TITLE
Handle arguments with nested equal signs (fixes #512)

### DIFF
--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -610,6 +610,8 @@ fn dedup_flags(flag_str: &str) -> String {
 
         if bit.starts_with('-') {
             if bit.contains('=') {
+                // Split only on the first equals sign (there may be
+                // more than one)
                 let bits: Vec<_> = bit.splitn(2, '=').collect();
                 assert!(bits.len() == 2);
                 flags.insert(bits[0].to_owned() + "=", bits[1].to_owned());

--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -610,7 +610,7 @@ fn dedup_flags(flag_str: &str) -> String {
 
         if bit.starts_with('-') {
             if bit.contains('=') {
-                let bits: Vec<_> = bit.split('=').collect();
+                let bits: Vec<_> = bit.splitn(2, '=').collect();
                 assert!(bits.len() == 2);
                 flags.insert(bits[0].to_owned() + "=", bits[1].to_owned());
             } else {
@@ -674,5 +674,8 @@ mod test {
 
         assert!(dedup_flags("--error-format=json --error-format=json") == " --error-format=json");
         assert!(dedup_flags("--error-format=foo --error-format=json") == " --error-format=json");
+
+        assert!(dedup_flags("-C link-args=-fuse-ld=gold -C target-cpu=native -C link-args=-fuse-ld=gold") ==
+                " -Clink-args=-fuse-ld=gold -Ctarget-cpu=native");
     }
 }


### PR DESCRIPTION
This is consistent with treating the RHS of the first equals sign as an opaque value, which seems to be how the current code behaves for things with only one equals sign. It seems like there could be issues with that approach in general (i.e. some semantic understanding of the flags could be needed instead of just picking the last blob you saw), but this seems to solve the more immediate problem of multiple equal signs in arguments.