### PR TITLE
Revert test for workspace_symbol

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -165,7 +165,7 @@ fn test_workspace_symbol() {
                                                                      // in foo.rs
                                                                      .expect_contains(r#"foo.rs"#)
                                                                      .expect_contains(r#""name":"nemo""#)
-                                                                     .expect_contains(r#""kind":5"#)
+                                                                     .expect_contains(r#""kind":2"#)
                                                                      .expect_contains(r#""range":{"start":{"line":0,"character":4},"end":{"line":0,"character":8}}"#)
                                                                      .expect_contains(r#""containerName":"foo""#)]);
 }


### PR DESCRIPTION
This was changed in f1c85ebcb196ff0c0374d74f2140e75382bf4e06 to account
for the new DefKinds in rls-data. However, this will not pass rustc
tests (i.e. `./x.py test src/tools/rls`) when updating the RLS submodule
in that project. I believe this is because the versions of rls-data are
different between rustc and the rls. In order for the RLS to be updated
with rustc, this test should be updated to pass. Then, once that change
is release to the nightly channel, the tests in this repo will pass
again.
I have tested this theory when running a locally built version of rustc
that has the lastest commit of the RLS (5930bab4ae6343bea0d8dec171e895b09cade5a4)
as the tip of the rls submodule. These tests pass in both the rustc and
rls repositories then.

Also, the previously referenced commit was incorrectly changed; `Kind`
should be 2 for the result, not 5.

Please see [this issue](https://github.com/rust-lang/rust/pull/45096) in rustc for more context.