### PR TITLE
Fixes completionItem/resolve response to match the LSP specification.

### DIFF
--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -767,12 +767,12 @@ impl<'a> Action<'a> for ResolveCompletion {
 }
 
 impl<'a> RequestAction<'a> for ResolveCompletion {
-    type Response = Vec<CompletionItem>;
+    type Response = CompletionItem;
     fn handle<O: Output>(&mut self, _id: usize, params: Self::Params, _ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
         // currently, we safely ignore this as a pass-through since we fully handle
         // textDocument/completion.  In the future, we may want to use this method as a
         // way to more lazily fill out completion information
-        Ok(vec![params])
+        Ok(params)
     }
 }
 


### PR DESCRIPTION
Adjusts the response to the completionItem/resolve message to be a single CompletionItem. 

Reference:
https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#completionItem_resolve