### PR TITLE
Fix a test which keeps failing

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -190,7 +190,7 @@ fn test_workspace_symbol() {
                                                                      // in foo.rs
                                                                      .expect_contains(r#"foo.rs"#)
                                                                      .expect_contains(r#""name":"nemo""#)
-                                                                     .expect_contains(r#""kind":2"#)
+                                                                     .expect_contains(r#""kind":5"#)
                                                                      .expect_contains(r#""range":{"start":{"line":0,"character":4},"end":{"line":0,"character":8}}"#)
                                                                      .expect_contains(r#""containerName":"foo""#)]);
 }


### PR DESCRIPTION
Running `cargo test` fails due to `test_workspace_symbol`. This PR fixes it. 
Sorry if the failure ought to be intentional, I could not find any relevant issues myself.