### PR TITLE
fix some typos, and use consistent US spelling of analyze

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -123,12 +123,12 @@ temporary logging you may find the `eprintln` macro useful.
 Test using `cargo test`.
 
 Testing is unfortunately minimal. There is support for regression tests, but not
-many actual tests exists yet. There is signifcant [work to do](https://github.com/rust-lang-nursery/rls/issues/12)
+many actual tests exists yet. There is significant [work to do](https://github.com/rust-lang-nursery/rls/issues/12)
 before we have a comprehensive testing story.
 
 You can run the RLS in command line mode by running with an argument (any
 argument), e.g., `cargo run -- foo`. You need to run it in the root directory of
-the project to be analysed. This should initialise the RLS (which will take some
+the project to be analyzed. This should initialize the RLS (which will take some
 time for large projects) and then give you a `>` prompt. Type `help` (or just
 `h`) to see the commands available.
 
@@ -223,7 +223,7 @@ inside your project's target directory.
 
 The goal of the RLS project is to provide an awesome IDE experience *now*. That
 means not waiting for incremental compilation support in the compiler. However,
-Rust is a somewhat complex language to analyse and providing precise and
+Rust is a somewhat complex language to analyze and providing precise and
 complete information about programs requires using the compiler.
 
 The RLS has two data sources - the compiler and Racer. The compiler is always
@@ -271,7 +271,7 @@ change](https://github.com/rust-lang-nursery/rls/issues/25)).
 
 ### Analysis data
 
-From the compiler, we get a serialised dump of its analysis data (from name
+From the compiler, we get a serialized dump of its analysis data (from name
 resolution and type checking). We combine data from all crates and the standard
 libraries and combine this into an index for the whole project. We cross-
 reference and store this data in HashMaps and use it to look up data for the

--- a/debugging.md
+++ b/debugging.md
@@ -137,7 +137,7 @@ Some crates can have surprisingly large data files. Large data files can slow
 down the RLS to the point of crashing (or appearing to crash). Check the json
 files in the `target/rls/deps/save-analysis` directory. Anything over 1mb is
 suspicious. You can test if this is important by deleting the json file(s) and
-restating the extension (you'd have to do this every time you do a full build,
+restarting the extension (you'd have to do this every time you do a full build,
 for example after `cargo clean` or updating the toolchain).
 
 If you find such large data files, please report an issue on this repo. We can

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -795,10 +795,10 @@ fn pos_to_racer_location(pos: Position) -> racer::Location {
     racer::Location::Coords(racer_coord(pos.row.one_indexed(), pos.col))
 }
 
-fn location_from_racer_match(mtch: racer::Match) -> Option<Location> {
-    let source_path = &mtch.filepath;
+fn location_from_racer_match(a_match: racer::Match) -> Option<Location> {
+    let source_path = &a_match.filepath;
 
-    mtch.coords.map(|coord| {
+    a_match.coords.map(|coord| {
         let (row, col) = from_racer_coord(coord);
         let loc = span::Location::new(row.zero_indexed(), col, source_path);
         ls_util::rls_location_to_location(&loc)

--- a/src/build/environment.rs
+++ b/src/build/environment.rs
@@ -67,7 +67,7 @@ impl<'a> Drop for Environment<'a> {
 /// It uses two locks instead of one, because RLS, while executing a Cargo build routine, not only
 /// needs to guarantee consistent env vars across the Cargo invocation, but also, while holding it,
 /// it needs to provide a more fine-grained way to synchronize env vars across different inner
-/// compiler invokations, for which Cargo sets specific env vars.
+/// compiler invocations, for which Cargo sets specific env vars.
 /// To enforce proper env var guarantees, regular rustc and Cargo build routines must first acquire
 /// the first, outer lock. Only then, if needed, nested rustc calls inside Cargo routine can
 /// acquire the second, inner lock.

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -88,11 +88,11 @@ struct Internals {
 
 #[derive(Debug)]
 pub enum BuildResult {
-    // Build was succesful, argument is warnings.
+    // Build was successful, argument is warnings.
     Success(Vec<String>, Vec<Analysis>),
     // Build finished with errors, argument is errors and warnings.
     Failure(Vec<String>, Vec<Analysis>),
-    // Build was coelesced with another build.
+    // Build was coalesced with another build.
     Squashed,
     // There was an error attempting to build.
     Err,
@@ -320,11 +320,11 @@ impl BuildQueue {
                 thread::sleep(Duration::from_millis(wait_to_build));
 
                 // Check if a new build arrived while we were sleeping.
-                let interupt = {
+                let interrupt = {
                     let queued = queued.lock().unwrap();
                     queued.0.is_pending() || queued.1.is_pending()
                 };
-                if interupt {
+                if interrupt {
                     and_then(BuildResult::Squashed);
                     continue;
                 }
@@ -398,7 +398,7 @@ impl Internals {
         }
 
         let result = self.build();
-        // On a successful build, clear dirty files that were successfuly built
+        // On a successful build, clear dirty files that were successfully built
         // now. It's possible that a build was scheduled with given files, but
         // user later changed them. These should still be left as dirty (not built).
         match *&result {

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -73,7 +73,7 @@ pub fn rustc(vfs: &Vfs, args: &[String], envs: &HashMap<String, Option<OsString>
     });
 
     // FIXME(#25) given that we are running the compiler directly, there is no need
-    // to serialise the error messages - we should pass them in memory.
+    // to serialize the error messages - we should pass them in memory.
     let err_buf = Arc::try_unwrap(err_buf).unwrap().into_inner().unwrap();
     let err_buf = String::from_utf8(err_buf).unwrap();
     let stderr_json_msgs: Vec<_> = err_buf.lines().map(String::from).collect();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -228,8 +228,8 @@ impl server::MessageReader for ChannelMsgReader {
     }
 }
 
-// Initialise a server, returns the sender end of a channel for posting messages.
-// The initialised server will live on its own thread and look after the receiver.
+// Initialize a server, returns the sender end of a channel for posting messages.
+// The initialized server will live on its own thread and look after the receiver.
 fn init() -> Sender<String> {
     let analysis = Arc::new(AnalysisHost::new(Target::Debug));
     let vfs = Arc::new(Vfs::new());
@@ -243,7 +243,7 @@ fn init() -> Sender<String> {
     thread::spawn(move || LsService::run(service));
 
     sender.send(initialize(::std::env::current_dir().unwrap().to_str().unwrap().to_owned()).to_string()).expect("Error sending init");
-    println!("Initialising (look for `diagnosticsEnd` message)...");
+    println!("Initializing (look for `diagnosticsEnd` message)...");
 
     sender
 }

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -107,7 +107,7 @@ pub trait Output: Sync + Send + Clone + 'static {
         let data = match serde_json::to_string(data) {
             Ok(data) => data,
             Err(e) => {
-                debug!("Could not serialise data for success message. ");
+                debug!("Could not serialize data for success message. ");
                 debug!("  Data: `{:?}`", data);
                 debug!("  Error: {:?}", e);
                 return;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -337,7 +337,7 @@ impl<O: Output> LsService<O> {
                     if $method == <$n_action as Action>::METHOD {
                         let notification = msg.parse_as_notification::<$n_action>()?;
                         if let Err(_) = notification.dispatch(&mut self.state, &mut self.ctx, self.output.clone()) {
-                            debug!("Error handling notifcation: {:?}", msg);
+                            debug!("Error handling notification: {:?}", msg);
                         }
                         handled = true;
                     }
@@ -346,7 +346,7 @@ impl<O: Output> LsService<O> {
                     if $method == <$r_action as Action>::METHOD {
                         let request = msg.parse_as_request::<$r_action>()?;
                         if let Err(_) = request.dispatch(&mut self.state, &mut self.ctx, self.output.clone()) {
-                            debug!("Error handling notifcation: {:?}", msg);
+                            debug!("Error handling notification: {:?}", msg);
                         }
                         handled = true;
                     }

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -71,7 +71,7 @@ impl Environment {
         f(config);
     }
 
-    // Initialise and run the internals of an LS protocol RLS server.
+    // Initialize and run the internals of an LS protocol RLS server.
     pub fn mock_server(&mut self, messages: Vec<String>) -> (ls_server::LsService<RecordOutput>, LsResultList) {
         let analysis = Arc::new(analysis::AnalysisHost::new(analysis::Target::Debug));
         let vfs = Arc::new(vfs::Vfs::new());

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -77,7 +77,7 @@ fn test_shutdown() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -108,7 +108,7 @@ fn test_goto_def() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -140,7 +140,7 @@ fn test_hover() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -168,7 +168,7 @@ fn test_workspace_symbol() {
 
     env.with_config(|c| c.cfg_test = true);
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -215,7 +215,7 @@ fn test_find_all_refs() {
 
     env.with_config(|c| c.cfg_test = true);
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -249,7 +249,7 @@ fn test_find_all_refs_no_cfg_test() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -273,7 +273,7 @@ fn test_borrow_error() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -301,7 +301,7 @@ fn test_highlight() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -334,7 +334,7 @@ fn test_rename() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -371,7 +371,7 @@ fn test_reformat() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -411,7 +411,7 @@ fn test_reformat_with_range() {
 
     let (mut server, results) = env.mock_server(messages);
 
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -436,7 +436,7 @@ fn test_multiple_binaries() {
 
     env.with_config(|c| c.build_bin = Inferrable::Specified(Some("bin2".to_owned())));
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -469,7 +469,7 @@ fn test_completion() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -501,7 +501,7 @@ fn test_bin_lib_project() {
         c.build_bin = Inferrable::Specified(Some("bin_lib".into()));
     });
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -526,7 +526,7 @@ fn test_bin_lib_project() {
 //         c.build_bin = Inferrable::Specified(Some("bin_lib".into()));
 //     });
 //     let (mut server, results) = env.mock_server(messages);
-//     // Initialise and build.
+//     // Initialize and build.
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
 //     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -549,7 +549,7 @@ fn test_bin_lib_project() {
 
 //     env.with_config(|c| c.workspace_mode = true);
 //     let (mut server, results) = env.mock_server(messages);
-//     // Initialise and build.
+//     // Initialize and build.
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
 //     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -573,7 +573,7 @@ fn test_infer_lib() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -593,7 +593,7 @@ fn test_infer_bin() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -613,7 +613,7 @@ fn test_infer_custom_bin() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -704,7 +704,7 @@ fn test_find_impls() {
     ];
 
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(),
@@ -749,7 +749,7 @@ fn test_features() {
 
     env.with_config(|c| c.features = vec!["foo".to_owned()]);
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -770,7 +770,7 @@ fn test_all_features() {
 
     env.with_config(|c| c.all_features = true);
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -793,7 +793,7 @@ fn test_no_default_features() {
         c.features = vec!["foo".to_owned(), "bar".to_owned()]
     });
     let (mut server, results) = env.mock_server(messages);
-    // Initialise and build.
+    // Initialize and build.
     assert_eq!(ls_server::LsService::handle_message(&mut server),
                ls_server::ServerStateChange::Continue);
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
@@ -814,7 +814,7 @@ fn test_no_default_features() {
 //     ];
 //
 //     let (mut server, results) = env.mock_server(messages);
-//     // Initialise and build.
+//     // Initialize and build.
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
 //     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),


### PR DESCRIPTION
This is the result of me testing out a WIP source code spell-checker
and your project was the random target this time.

In  addition to these changes,
there is also a unfixed typo in external crate languageserver-types, `unregisterations` as used at https://github.com/rust-lang-nursery/rls/blob/master/src/actions/notifications.rs#L221 and defined in https://github.com/gluon-lang/languageserver-types/blob/ee0020870dbca2c96f777c1962f07d3ad74afd9b/src/lib.rs#L1169
