### PR TITLE
Use the debug compiler for CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ os:
 rust:
   - nightly
 script:
-  - cargo build --release --verbose
-  - cargo test --release --verbose
+  # compile #[cfg(not(test))] code
+  - cargo build --verbose
+  - cargo test --verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,13 +22,10 @@ install:
 
 build: false
 
-build_script:
-  # Build both build/test configurations to make sure both compile
-  - cargo build --release --verbose
-
 test_script:
-  # Test compilation reuses built dependencies during `cargo build --release`
-  - cargo test --release --verbose
+  # compile #[cfg(not(test))] code
+  - cargo build --verbose
+  - cargo test --verbose
 
 cache:
   - target


### PR DESCRIPTION
Currently the release compiler is used in CI testing. If we used the debug compiler here we could cut down our full re-builds from ~30 minutes to ~10. And re-builds on the same nightly / cache to ~3 minutes.

The debug compiler seems pretty much designed for CI - fast builds to prove correctness. Obviously fast CI testing is valuable for handling PRs. I had a quick look through the last couple of blame commits but couldn't see a reason to use _--release_. I'd be interested to learn why it's worth the extra effort.