### PR TITLE
Update rustfmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rls-data = { version = "0.12", features = ["serialize-serde"] }
 rls-rustc = "0.1"
 rls-span = { version = "0.4", features = ["serialize-serde"] }
 rls-vfs = { version = "0.4", features = ["racer-impls"] }
-rustfmt-nightly = "0.2.13"
+rustfmt-nightly = "0.2.14"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
This allows the versions to be in sync for an upcoming update of the RLS and rustfmt in `rust-lang/rust`.