### PR TITLE
Clarify server/extension debugging

### DIFF
--- a/debugging.md
+++ b/debugging.md
@@ -173,21 +173,21 @@ components are delivered by Rustup).
 
 ## Logging
 
-You can view error messages and logging by setting `rust-client.showStdErr`
-to `true`. This will show logs in the 'output' panel under
-'extensions' (or 'RLS', both in the dropdown menu on the right of the panel).
-You can open the panel from the `View > Output` menu.
-
-You can also dump to a file by setting `rust-client.logToFile` to `true`. The file
-will be in the project root; each time you start the extension, you'll get a new
-file.
+When using VSCode extension, you can view error messages and logging in the
+Output window, under View > Output, in the 'Rust Language Server' channel
+that can be selected in the dropdown menu on the right of the panel.
 
 To see more info in the logs, set `RUST_LOG=rls=debug` in your environment. You
 can also set `RUST_LOG=rls_analysis=debug` to see logging specific to the
-data analysis.
+data analysis. In general, these will be printed to the standard error stream
+of the server.
 
 If you are seeing crashes in the logs, you can get a backtrace by setting
 `RUST_BACKTRACE=1`.
+
+You can also dump to a file by setting `rust-client.logToFile` to `true` in the
+VSCode extension. The file will be in the project root; each time you start the
+extension, you'll get a new file.
 
 You can get more info about VSCode and the extension itself by running VSCode
 with `--verbose`. However, I have only rarely found this to be useful. You can


### PR DESCRIPTION
This also removes the mention of `showStderr` vscode extension option, which was removed due to a bugfix.