### PR TITLE
Invalidate AppVeyor cache on Cargo.lock change

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,5 +31,5 @@ test_script:
   - cargo test --release --verbose
 
 cache:
-  - target
+  - target -> Cargo.lock
   - C:\Users\appveyor\.cargo\registry


### PR DESCRIPTION
inInvalidating cache on file change is described [here](https://www.appveyor.com/docs/build-cache/#configuring-cache-items).

I believe it makes sense to rebuild the cache when we change package set we pull for the build.

If the cache is updated incrementally (I believe it is? [recently](https://ci.appveyor.com/project/jonathandturner/rls-x6grn/build/1.0.655/job/p5ndgjpu6k9np32p#L344) ~400mb cache update was rejected because the limit of 1GB was exceeded) there's no point in leaving behind obsolete build artifacts - maybe this contributes to cache corruptions?