### PR TITLE
Invalidate Cargo registry on Cargo.lock change in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,4 +29,4 @@ test_script:
 
 cache:
   - target -> Cargo.lock
-  - C:\Users\appveyor\.cargo\registry
+  - C:\Users\appveyor\.cargo\registry -> Cargo.lock


### PR DESCRIPTION
This probably makes more sense than invalidating `target` on Cargo.lock - when we change the lockfile, it's a good idea to start clean when fetching deps. We might not need previously downloaded packages after updates, preventing from bloating up the registry after numerous Cargo.lock updates.

Full dep download cycle takes additional ~1 minute, but will only happen on Cargo.lock update (which is rare).

r? @nrc 