### PR TITLE
Support case-insensitive workspace/symbol completion

### DIFF
--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -48,7 +48,7 @@ impl<'a> RequestAction<'a> for WorkspaceSymbol {
         let analysis = ctx.analysis.clone();
 
         let rustw_handle: ::std::thread::JoinHandle<_> = thread::spawn(move || {
-            let defs = analysis.name_defs(&params.query).unwrap_or_else(|_| vec![]);
+            let defs = analysis.matching_defs(&params.query).unwrap_or_else(|_| vec![]);
             t.unpark();
 
             defs.into_iter().map(|d| {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -162,7 +162,7 @@ fn test_workspace_symbol() {
     let messages = vec![
         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
         request::<requests::WorkspaceSymbol>(42, WorkspaceSymbolParams {
-            query: "nemo".to_owned(),
+            query: "nem".to_owned(),
         }).to_string(),
     ];
 


### PR DESCRIPTION
use name_defs rather than matching_defs

resolves https://github.com/rust-lang-nursery/rls/issues/514

depends on https://github.com/nrc/rls-analysis/pull/118 (and a version bump to rls-analysis)