### PR TITLE
Add stdin-nonblocking request handling

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -81,16 +81,17 @@ impl ActionContext {
         *self = ActionContext::Init(ctx);
     }
 
-    fn inited(&self) -> &InitActionContext {
+    pub fn inited(&self) -> InitActionContext {
         match *self {
             ActionContext::Uninit(_) => panic!("ActionContext not initialized"),
-            ActionContext::Init(ref ctx) => ctx,
+            ActionContext::Init(ref ctx) => ctx.clone(),
         }
     }
 }
 
 /// Persistent context shared across all requests and actions after the RLS has
 /// been initialized.
+#[derive(Clone)]
 pub struct InitActionContext {
     analysis: Arc<AnalysisHost>,
     vfs: Arc<Vfs>,
@@ -101,7 +102,6 @@ pub struct InitActionContext {
     build_queue: BuildQueue,
 
     config: Arc<Mutex<Config>>,
-    fmt_config: FmtConfig,
 }
 
 /// Persistent context shared across all requests and actions before the RLS has
@@ -131,7 +131,6 @@ impl InitActionContext {
                config: Arc<Mutex<Config>>,
                current_project: PathBuf) -> InitActionContext {
         let build_queue = BuildQueue::new(vfs.clone(), config.clone());
-        let fmt_config = FmtConfig::from(&current_project);
         InitActionContext {
             analysis,
             vfs,
@@ -139,8 +138,11 @@ impl InitActionContext {
             current_project,
             previous_build_results: Arc::new(Mutex::new(HashMap::new())),
             build_queue,
-            fmt_config,
         }
+    }
+
+    fn fmt_config(&self) -> FmtConfig {
+        FmtConfig::from(&self.current_project)
     }
 
     fn init<O: Output>(&self, init_options: &InitializationOptions, out: O) {

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -81,6 +81,7 @@ impl ActionContext {
         *self = ActionContext::Init(ctx);
     }
 
+    /// Returns an initialiased wrapped context, or panics if not initialised.
     pub fn inited(&self) -> InitActionContext {
         match *self {
             ActionContext::Uninit(_) => panic!("ActionContext not initialized"),

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -21,7 +21,7 @@ use Span;
 
 use build::*;
 use lsp_data::*;
-use server::{Output, Action, NotificationAction, LsState, NoParams};
+use server::{Output, Action, BlockingNotificationAction, LsState, NoParams};
 
 use std::thread;
 
@@ -29,16 +29,16 @@ use std::thread;
 #[derive(Debug, PartialEq)]
 pub struct Initialized;
 
-impl<'a> Action<'a> for Initialized {
+impl Action for Initialized {
     type Params = NoParams;
     const METHOD: &'static str = "initialized";
+}
 
+impl<'a> BlockingNotificationAction<'a> for Initialized {
     fn new(_: &'a mut LsState) -> Self {
         Initialized
     }
-}
 
-impl<'a> NotificationAction<'a> for Initialized {
     // Respond to the `initialized` notification. We take this opportunity to
     // dynamically register some options.
     fn handle<O: Output>(&mut self, _params: Self::Params, ctx: &mut ActionContext, out: O) -> Result<(), ()> {
@@ -62,16 +62,16 @@ impl<'a> NotificationAction<'a> for Initialized {
 #[derive(Debug)]
 pub struct DidOpen;
 
-impl<'a> Action<'a> for DidOpen {
+impl Action for DidOpen {
     type Params = DidOpenTextDocumentParams;
     const METHOD: &'static str = "textDocument/didOpen";
+}
 
+impl<'a> BlockingNotificationAction<'a> for DidOpen {
     fn new(_: &'a mut LsState) -> Self {
         DidOpen
     }
-}
 
-impl<'a> NotificationAction<'a> for DidOpen {
     fn handle<O: Output>(&mut self, params: Self::Params, ctx: &mut ActionContext, _out: O) -> Result<(), ()> {
         trace!("on_open: {:?}", params.text_document.uri);
         let ctx = ctx.inited();
@@ -86,16 +86,16 @@ impl<'a> NotificationAction<'a> for DidOpen {
 #[derive(Debug)]
 pub struct DidChange;
 
-impl<'a> Action<'a> for DidChange {
+impl Action for DidChange {
     type Params = DidChangeTextDocumentParams;
     const METHOD: &'static str = "textDocument/didChange";
+}
 
+impl<'a> BlockingNotificationAction<'a> for DidChange {
     fn new(_: &'a mut LsState) -> Self {
         DidChange
     }
-}
 
-impl<'a> NotificationAction<'a> for DidChange {
     fn handle<O: Output>(&mut self, params: Self::Params, ctx: &mut ActionContext, out: O) -> Result<(), ()> {
         trace!("on_change: {:?}, thread: {:?}", params, thread::current().id());
 
@@ -133,16 +133,16 @@ impl<'a> NotificationAction<'a> for DidChange {
 #[derive(Debug)]
 pub struct Cancel;
 
-impl<'a> Action<'a> for Cancel {
+impl Action for Cancel {
     type Params = CancelParams;
     const METHOD: &'static str = "$/cancelRequest";
+}
 
+impl<'a> BlockingNotificationAction<'a> for Cancel {
     fn new(_: &'a mut LsState) -> Self {
         Cancel
     }
-}
 
-impl<'a> NotificationAction<'a> for Cancel {
     fn handle<O: Output>(&mut self, _params: CancelParams, _ctx: &mut ActionContext, _out: O) -> Result<(), ()> {
         // Nothing to do.
         Ok(())
@@ -154,16 +154,17 @@ impl<'a> NotificationAction<'a> for Cancel {
 #[derive(Debug)]
 pub struct DidChangeConfiguration;
 
-impl<'a> Action<'a> for DidChangeConfiguration {
+impl Action for DidChangeConfiguration {
     type Params = DidChangeConfigurationParams;
     const METHOD: &'static str = "workspace/didChangeConfiguration";
 
+}
+
+impl<'a> BlockingNotificationAction<'a> for DidChangeConfiguration {
     fn new(_: &'a mut LsState) -> Self {
         DidChangeConfiguration
     }
-}
 
-impl<'a> NotificationAction<'a> for DidChangeConfiguration {
     fn handle<O: Output>(&mut self, params: DidChangeConfigurationParams, ctx: &mut ActionContext, out: O) -> Result<(), ()> {
         trace!("config change: {:?}", params.settings);
         let ctx = ctx.inited();
@@ -239,16 +240,16 @@ impl<'a> NotificationAction<'a> for DidChangeConfiguration {
 #[derive(Debug)]
 pub struct DidSave;
 
-impl<'a> Action<'a> for DidSave {
+impl Action for DidSave {
     type Params = DidSaveTextDocumentParams;
     const METHOD: &'static str = "textDocument/didSave";
+}
 
+impl<'a> BlockingNotificationAction<'a> for DidSave {
     fn new(_: &'a mut LsState) -> Self {
         DidSave
     }
-}
 
-impl<'a> NotificationAction<'a> for DidSave {
     fn handle<O: Output>(&mut self, params: DidSaveTextDocumentParams, ctx: &mut ActionContext, out: O) -> Result<(), ()> {
         let ctx = ctx.inited();
         let file_path = parse_file_path!(&params.text_document.uri, "on_save")?;
@@ -268,16 +269,16 @@ impl<'a> NotificationAction<'a> for DidSave {
 #[derive(Debug)]
 pub struct DidChangeWatchedFiles;
 
-impl<'a> Action<'a> for DidChangeWatchedFiles {
+impl Action for DidChangeWatchedFiles {
     type Params = DidChangeWatchedFilesParams;
     const METHOD: &'static str = "workspace/didChangeWatchedFiles";
+}
 
+impl<'a> BlockingNotificationAction<'a> for DidChangeWatchedFiles {
     fn new(_: &'a mut LsState) -> Self {
         DidChangeWatchedFiles
     }
-}
 
-impl<'a> NotificationAction<'a> for DidChangeWatchedFiles {
     fn handle<O: Output>(
         &mut self,
         params: DidChangeWatchedFilesParams,

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -23,7 +23,8 @@ use rayon;
 
 use lsp_data;
 use lsp_data::*;
-use server::{Output, Ack, Action, RequestAction, LsState};
+use server::{Output, Ack, Action, RequestAction, ResponseError, BlockingRequestAction, LsState};
+use super::InitActionContext;
 use jsonrpc_core::types::ErrorCode;
 
 use std::collections::HashMap;
@@ -46,266 +47,275 @@ pub struct DeglobResult {
 /// A request for information about a symbol in this workspace.
 pub struct WorkspaceSymbol;
 
-impl<'a> Action<'a> for WorkspaceSymbol {
+impl Action for WorkspaceSymbol {
     type Params = lsp_data::WorkspaceSymbolParams;
     const METHOD: &'static str = "workspace/symbol";
-
-    fn new(_: &'a mut LsState) -> Self {
-        WorkspaceSymbol
-    }
 }
 
-impl<'a> RequestAction<'a> for WorkspaceSymbol {
+impl RequestAction for WorkspaceSymbol {
     type Response = Vec<SymbolInformation>;
 
-    fn handle<O: Output>(&mut self, _id: usize, params: Self::Params, ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
-        let ctx = ctx.inited();
-        let analysis = ctx.analysis.clone();
+    fn new() -> Self {
+        WorkspaceSymbol
+    }
 
-        let receiver = receive_from_thread(move || {
-            let defs = analysis.name_defs(&params.query).unwrap_or_else(|_| vec![]);
+    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+        Ok(vec![])
+    }
 
-            defs.into_iter().map(|d| {
-                SymbolInformation {
-                    name: d.name,
-                    kind:  source_kind_from_def_kind(d.kind),
-                    location: ls_util::rls_to_location(&d.span),
-                    container_name: d.parent.and_then(|id| analysis.get_def(id).ok()).map(|parent| parent.name)
-                }
-            }).collect()
-        });
+    fn handle(
+        &mut self,
+        ctx: InitActionContext,
+        params: Self::Params,
+    ) -> Result<Self::Response, ResponseError> {
+        let analysis = ctx.analysis;
 
-        Ok(receiver.recv_timeout(Duration::from_millis(::COMPILER_TIMEOUT))
-            .unwrap_or_else(|_| vec![]))
+        let defs = analysis.name_defs(&params.query).unwrap_or_else(|_| vec![]);
+
+        Ok(defs.into_iter().map(|d| {
+            SymbolInformation {
+                name: d.name,
+                kind:  source_kind_from_def_kind(d.kind),
+                location: ls_util::rls_to_location(&d.span),
+                container_name: d.parent.and_then(|id| analysis.get_def(id).ok()).map(|parent| parent.name)
+            }
+        }).collect())
     }
 }
 
 /// A request for a flat list of all symbols found in a given text document.
 pub struct Symbols;
 
-impl<'a> Action<'a> for Symbols {
+impl Action for Symbols {
     type Params = DocumentSymbolParams;
     const METHOD: &'static str = "textDocument/documentSymbol";
-
-    fn new(_: &'a mut LsState) -> Self {
-        Symbols
-    }
 }
 
-impl<'a> RequestAction<'a> for Symbols {
+impl RequestAction for Symbols {
     type Response = Vec<SymbolInformation>;
-    fn handle<O: Output>(&mut self, _id: usize, params: Self::Params, ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
-        let ctx = ctx.inited();
+
+    fn new() -> Self {
+        Symbols
+    }
+
+    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+        Ok(vec![])
+    }
+
+    fn handle(
+        &mut self,
+        ctx: InitActionContext,
+        params: Self::Params,
+    ) -> Result<Self::Response, ResponseError> {
         let file_path = parse_file_path!(&params.text_document.uri, "symbols")?;
 
-        let analysis = ctx.analysis.clone();
+        let symbols = ctx.analysis.symbols(&file_path).unwrap_or_else(|_| vec![]);
 
-        let receiver = receive_from_thread(move || {
-            let symbols = analysis.symbols(&file_path).unwrap_or_else(|_| vec![]);
-
-            symbols.into_iter().map(|s| {
-                SymbolInformation {
-                    name: s.name,
-                    kind: source_kind_from_def_kind(s.kind),
-                    location: ls_util::rls_to_location(&s.span),
-                    container_name: None // FIXME: more info could be added here
-                }
-            }).collect()
-        });
-
-        Ok(receiver.recv_timeout(Duration::from_millis(::COMPILER_TIMEOUT))
-            .unwrap_or_else(|_| vec![]))
+        Ok(symbols.into_iter().map(|s| {
+            SymbolInformation {
+                name: s.name,
+                kind: source_kind_from_def_kind(s.kind),
+                location: ls_util::rls_to_location(&s.span),
+                container_name: None // FIXME: more info could be added here
+            }
+        }).collect())
     }
 }
 
 /// Handles requests for hover information at a given point.
 pub struct Hover;
 
-impl<'a> Action<'a> for Hover {
+impl Action for Hover {
     type Params = TextDocumentPositionParams;
     const METHOD: &'static str = "textDocument/hover";
-
-    fn new(_: &'a mut LsState) -> Self {
-        Hover
-    }
 }
 
-impl<'a> RequestAction<'a> for Hover {
+impl RequestAction for Hover {
     type Response = lsp_data::Hover;
-    fn handle<O: Output>(&mut self, _id: usize, params: Self::Params, ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
-        let ctx = ctx.inited();
+
+    fn new() -> Self {
+        Hover
+    }
+
+    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+        Ok(lsp_data::Hover {
+            contents: vec![],
+            range: None,
+        })
+    }
+
+    fn handle(
+        &mut self,
+        ctx: InitActionContext,
+        params: Self::Params,
+    ) -> Result<Self::Response, ResponseError> {
         let file_path = parse_file_path!(&params.text_document.uri, "hover")?;
         let span = ctx.convert_pos_to_span(file_path, params.position);
 
         trace!("hover: {:?}", span);
 
-        let analysis = ctx.analysis.clone();
-        let receiver = receive_from_thread(move || {
-            let ty = analysis.show_type(&span).unwrap_or_else(|_| String::new());
-            let docs = analysis.docs(&span).unwrap_or_else(|_| String::new());
-            let doc_url = analysis.doc_url(&span).unwrap_or_else(|_| String::new());
+        let analysis = ctx.analysis;
+        let ty = analysis.show_type(&span).unwrap_or_else(|_| String::new());
+        let docs = analysis.docs(&span).unwrap_or_else(|_| String::new());
+        let doc_url = analysis.doc_url(&span).unwrap_or_else(|_| String::new());
 
-            let mut contents = vec![];
-            if !docs.is_empty() {
-                contents.push(MarkedString::from_markdown(docs.into()));
-            }
-            if !doc_url.is_empty() {
-                contents.push(MarkedString::from_markdown(doc_url.into()));
-            }
-            if !ty.is_empty() {
-                contents.push(MarkedString::from_language_code("rust".into(), ty.into()));
-            }
-            lsp_data::Hover {
-                contents: contents,
-                range: None, // TODO: maybe add?
-            }
-        });
-
-        Ok(receiver.recv_timeout(Duration::from_millis(::COMPILER_TIMEOUT))
-            .unwrap_or_else(|_| lsp_data::Hover {
-                contents: vec![],
-                range: None,
-            }))
+        let mut contents = vec![];
+        if !docs.is_empty() {
+            contents.push(MarkedString::from_markdown(docs.into()));
+        }
+        if !doc_url.is_empty() {
+            contents.push(MarkedString::from_markdown(doc_url.into()));
+        }
+        if !ty.is_empty() {
+            contents.push(MarkedString::from_language_code("rust".into(), ty.into()));
+        }
+        Ok(lsp_data::Hover {
+            contents: contents,
+            range: None, // TODO: maybe add?
+        })
     }
 }
 
 /// Find all the implementations of a given trait.
 pub struct FindImpls;
 
-impl<'a> Action<'a> for FindImpls {
+impl Action for FindImpls {
     type Params = TextDocumentPositionParams;
     const METHOD: &'static str = "rustDocument/implementations";
-
-    fn new(_: &'a mut LsState) -> Self {
-        FindImpls
-    }
 }
 
-impl<'a> RequestAction<'a> for FindImpls {
+impl RequestAction for FindImpls {
     type Response = Vec<Location>;
-    fn handle<O: Output>(&mut self, id: usize, params: Self::Params, ctx: &mut ActionContext, out: O) -> Result<Self::Response, ()> {
-        let ctx = ctx.inited();
+
+    fn new() -> Self {
+        FindImpls
+    }
+
+    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+        Ok(vec![])
+    }
+
+    fn handle(
+        &mut self,
+        ctx: InitActionContext,
+        params: Self::Params,
+    ) -> Result<Self::Response, ResponseError> {
         let file_path = parse_file_path!(&params.text_document.uri, "find_impls")?;
         let span = ctx.convert_pos_to_span(file_path, params.position);
-        let analysis = ctx.analysis.clone();
+        let analysis = ctx.analysis;
 
-        let receiver = receive_from_thread(move || {
-            let type_id = analysis.id(&span)?;
-            let result = analysis.find_impls(type_id).map(|spans| {
-                spans.into_iter().map(|x| ls_util::rls_to_location(&x)).collect()
-            });
-            result
+        let type_id = analysis.id(&span).map_err(|_| ResponseError::Empty)?;
+        let result = analysis.find_impls(type_id).map(|spans| {
+            spans.into_iter().map(|x| ls_util::rls_to_location(&x)).collect()
         });
 
-        let result = receiver.recv_timeout(Duration::from_millis(::COMPILER_TIMEOUT));
         trace!("find_impls: {:?}", result);
 
-        match result {
-            Ok(Ok(r)) => Ok(r),
-            _ => {
-                out.failure_message(
-                    id,
-                    ErrorCode::InternalError,
-                    "Find Implementations failed to complete successfully"
-                );
-                Err(())
-            }
-        }
+        result.map_err(|_| ResponseError::Message(
+            ErrorCode::InternalError,
+            "Find Implementations failed to complete successfully".into(),
+        ))
     }
 }
 
 /// Get a list of definitions for item at the given point or identifier.
 pub struct Definition;
 
-impl<'a> Action<'a> for Definition {
+impl Action for Definition {
     type Params = TextDocumentPositionParams;
     const METHOD: &'static str = "textDocument/definition";
-
-    fn new(_: &'a mut LsState) -> Self {
-        Definition
-    }
 }
 
-impl<'a> RequestAction<'a> for Definition {
+impl RequestAction for Definition {
     type Response = Vec<Location>;
-    fn handle<O: Output>(&mut self, _id: usize, params: Self::Params, ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
-        let ctx = ctx.inited();
+
+    fn new() -> Self {
+        Definition
+    }
+
+    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+        Ok(vec![])
+    }
+
+    fn handle(
+        &mut self,
+        ctx: InitActionContext,
+        params: Self::Params,
+    ) -> Result<Self::Response, ResponseError> {
+        // Save-analysis thread.
         let file_path = parse_file_path!(&params.text_document.uri, "goto_def")?;
         let span = ctx.convert_pos_to_span(file_path.clone(), params.position);
-        let analysis = Arc::clone(&ctx.analysis);
-        let vfs = Arc::clone(&ctx.vfs);
-        let config = Arc::clone(&ctx.config);
+        let analysis = ctx.analysis;
+        let vfs = ctx.vfs;
 
-        let receiver = receive_from_thread(move || {
-            // If configured start racer concurrently and fallback to racer result
-            let racer_receiver = {
-                if config.lock().unwrap().goto_def_racer_fallback {
-                    Some(receive_from_thread(move || {
-                        let cache = racer::FileCache::new(vfs);
-                        let session = racer::Session::new(&cache);
-                        let location = pos_to_racer_location(params.position);
+        // If configured start racer concurrently and fallback to racer result
+        let racer_receiver = {
+            if ctx.config.lock().unwrap().goto_def_racer_fallback {
+                Some(receive_from_thread(move || {
+                    let cache = racer::FileCache::new(vfs);
+                    let session = racer::Session::new(&cache);
+                    let location = pos_to_racer_location(params.position);
 
-                        racer::find_definition(file_path, location, &session)
-                            .and_then(location_from_racer_match)
-                    }))
-                }
-                else { None }
-            };
-
-            match analysis.goto_def(&span) {
-                Ok(out) => {
-                    let result = vec![ls_util::rls_to_location(&out)];
-                    trace!("goto_def (compiler): {:?}", result);
-                    return result
-                }
-                _ => match racer_receiver {
-                    Some(receiver) => match receiver.recv() {
-                        Ok(Some(r)) =>  {
-                            trace!("goto_def (Racer): {:?}", r);
-                            return vec![r]
-                        }
-                        Ok(None) => {
-                            trace!("goto_def (Racer): None");
-                            return vec![]
-                        }
-                        _ => vec![]
-                    }
-                    _ => vec![]
-                }
+                    racer::find_definition(file_path, location, &session)
+                        .and_then(location_from_racer_match)
+                }))
             }
-        });
+            else { None }
+        };
 
-        Ok(receiver.recv_timeout(Duration::from_millis(::COMPILER_TIMEOUT))
-            .unwrap_or_else(|_| vec![]))
+        match analysis.goto_def(&span) {
+            Ok(out) => {
+                let result = vec![ls_util::rls_to_location(&out)];
+                trace!("goto_def (compiler): {:?}", result);
+                return Ok(result)
+            }
+            _ => match racer_receiver {
+                Some(receiver) => match receiver.recv() {
+                    Ok(Some(r)) =>  {
+                        trace!("goto_def (Racer): {:?}", r);
+                        return Ok(vec![r])
+                    }
+                    Ok(None) => {
+                        trace!("goto_def (Racer): None");
+                        return Ok(vec![])
+                    }
+                    _ => self.fallback_response()
+                }
+                _ => self.fallback_response()
+            }
+        }
     }
 }
 
 /// Find references to the symbol at the given point throughout the project.
 pub struct References;
 
-impl<'a> Action<'a> for References {
+impl Action for References {
     type Params = ReferenceParams;
     const METHOD: &'static str = "textDocument/references";
-
-    fn new(_: &'a mut LsState) -> Self {
-        References
-    }
 }
 
-impl<'a> RequestAction<'a> for References {
+impl RequestAction for References {
     type Response = Vec<Location>;
-    fn handle<O: Output>(&mut self, _id: usize, params: Self::Params, ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
-        let ctx = ctx.inited();
+
+    fn new() -> Self {
+        References
+    }
+
+    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+        Ok(vec![])
+    }
+
+    fn handle(
+        &mut self,
+        ctx: InitActionContext,
+        params: Self::Params,
+    ) -> Result<Self::Response, ResponseError> {
         let file_path = parse_file_path!(&params.text_document.uri, "find_all_refs")?;
         let span = ctx.convert_pos_to_span(file_path, params.position);
-        let analysis = ctx.analysis.clone();
 
-        let receiver = receive_from_thread(move || {
-            analysis.find_all_refs(&span, params.context.include_declaration)
-        });
-
-        let result = match receiver.recv_timeout(Duration::from_millis(::COMPILER_TIMEOUT)) {
-            Ok(Ok(t)) => t,
+        let result = match ctx.analysis.find_all_refs(&span, params.context.include_declaration) {
+            Ok(t) => t,
             _ => vec![],
         };
 
@@ -316,36 +326,37 @@ impl<'a> RequestAction<'a> for References {
 /// Get a list of possible completions at the given location.
 pub struct Completion;
 
-impl<'a> Action<'a> for Completion {
+impl Action for Completion {
     type Params = TextDocumentPositionParams;
     const METHOD: &'static str = "textDocument/completion";
-
-    fn new(_: &'a mut LsState) -> Self {
-        Completion
-    }
 }
 
-impl<'a> RequestAction<'a> for Completion {
+impl RequestAction for Completion {
     type Response = Vec<CompletionItem>;
-    fn handle<O: Output>(&mut self, _id: usize, params: Self::Params, ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
-        let ctx = ctx.inited();
-        let vfs = ctx.vfs.clone();
+
+    fn new() -> Self {
+        Completion
+    }
+
+    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+        Ok(vec![])
+    }
+
+    fn handle(
+        &mut self,
+        ctx: InitActionContext,
+        params: Self::Params,
+    ) -> Result<Self::Response, ResponseError> {
+        let vfs = ctx.vfs;
         let file_path = parse_file_path!(&params.text_document.uri, "complete")?;
 
-        let receiver = receive_from_thread(move || {
-            let cache = racer::FileCache::new(vfs);
-            let session = racer::Session::new(&cache);
+        let cache = racer::FileCache::new(vfs);
+        let session = racer::Session::new(&cache);
 
-            let location = pos_to_racer_location(params.position);
-            let results = racer::complete_from_file(file_path, location, &session);
+        let location = pos_to_racer_location(params.position);
+        let results = racer::complete_from_file(file_path, location, &session);
 
-            results.map(|comp| completion_item_from_racer_match(comp)).collect()
-        });
-
-        let result = receiver.recv_timeout(Duration::from_millis(::COMPILER_TIMEOUT))
-            .unwrap_or_else(|_| vec![]);
-
-        Ok(result)
+        Ok(results.map(|comp| completion_item_from_racer_match(comp)).collect())
     }
 }
 
@@ -354,86 +365,88 @@ impl<'a> RequestAction<'a> for Completion {
 /// to `References`.
 pub struct DocumentHighlight;
 
-impl<'a> Action<'a> for DocumentHighlight {
+impl Action for DocumentHighlight {
     type Params = TextDocumentPositionParams;
     const METHOD: &'static str = "textDocument/documentHighlight";
-
-    fn new(_: &'a mut LsState) -> Self {
-        DocumentHighlight
-    }
 }
 
-impl<'a> RequestAction<'a> for DocumentHighlight {
+impl RequestAction for DocumentHighlight {
     type Response = Vec<lsp_data::DocumentHighlight>;
-    fn handle<O: Output>(&mut self, _id: usize, params: Self::Params, ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
-        let ctx = ctx.inited();
+
+    fn new() -> Self {
+        DocumentHighlight
+    }
+
+    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+        Ok(vec![])
+    }
+
+    fn handle(
+        &mut self,
+        ctx: InitActionContext,
+        params: Self::Params,
+    ) -> Result<Self::Response, ResponseError> {
         let file_path = parse_file_path!(&params.text_document.uri, "highlight")?;
         let span = ctx.convert_pos_to_span(file_path, params.position);
-        let analysis = ctx.analysis.clone();
 
-        let receiver = receive_from_thread(move || {
-            analysis.find_all_refs(&span, true)
-        });
+        let result = ctx.analysis.find_all_refs(&span, true).unwrap_or_else(|_| vec![]);
 
-        let result = match receiver.recv_timeout(Duration::from_millis(::COMPILER_TIMEOUT)) {
-            Ok(Ok(t)) => t,
-            _ => vec![],
-        };
-
-        let refs: Vec<_> = result.iter().map(|span| lsp_data::DocumentHighlight {
+        Ok(result.iter().map(|span| lsp_data::DocumentHighlight {
             range: ls_util::rls_to_range(span.range),
             kind: Some(DocumentHighlightKind::Text),
-        }).collect();
-
-        Ok(refs)
+        }).collect())
     }
 }
 
 /// Rename the given symbol within the whole project.
 pub struct Rename;
 
-impl<'a> Action<'a> for Rename {
+impl Action for Rename {
     type Params = RenameParams;
     const METHOD: &'static str = "textDocument/rename";
-
-    fn new(_: &'a mut LsState) -> Self {
-        Rename
-    }
 }
 
-impl<'a> RequestAction<'a> for Rename {
+impl RequestAction for Rename {
     type Response = WorkspaceEdit;
-    fn handle<O: Output>(&mut self, _id: usize, params: Self::Params, ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
-        let ctx = ctx.inited();
+
+    fn new() -> Self {
+        Rename
+    }
+
+    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+        Ok(WorkspaceEdit { changes: HashMap::new() })
+    }
+
+    fn handle(
+        &mut self,
+        ctx: InitActionContext,
+        params: Self::Params,
+    ) -> Result<Self::Response, ResponseError> {
         let file_path = parse_file_path!(&params.text_document.uri, "rename")?;
         let span = ctx.convert_pos_to_span(file_path, params.position);
 
-        let analysis = ctx.analysis.clone();
-        let receiver = receive_from_thread(move || {
-            macro_rules! unwrap_or_empty {
-                ($e: expr) => {
-                    match $e {
-                        Ok(e) => e,
-                        Err(_) => {
-                            return vec![];
-                        }
+        let analysis = ctx.analysis;
+
+        macro_rules! unwrap_or_fallback {
+            ($e: expr) => {
+                match $e {
+                    Ok(e) => e,
+                    Err(_) => {
+                        return self.fallback_response();
                     }
                 }
             }
+        }
 
-            let id = unwrap_or_empty!(analysis.crate_local_id(&span));
-            let def = unwrap_or_empty!(analysis.get_def(id));
-            if def.name == "self" || def.name == "Self"
-                // FIXME(#578)
-                || def.kind == data::DefKind::Mod {
-                return vec![];
-            }
+        let id = unwrap_or_fallback!(analysis.crate_local_id(&span));
+        let def = unwrap_or_fallback!(analysis.get_def(id));
+        if def.name == "self" || def.name == "Self"
+            // FIXME(#578)
+            || def.kind == data::DefKind::Mod {
+            return self.fallback_response();
+        }
 
-            analysis.find_all_refs(&span, true).unwrap_or_else(|_| vec![])
-        });
-
-        let result = receiver.recv_timeout(Duration::from_millis(::COMPILER_TIMEOUT))
-            .unwrap_or_else(|_| vec![]);
+        let result = unwrap_or_fallback!(analysis.find_all_refs(&span, true));
 
         let mut edits: HashMap<Url, Vec<TextEdit>> = HashMap::new();
 
@@ -457,17 +470,18 @@ impl<'a> RequestAction<'a> for Rename {
 /// Currently, only the "rls.applySuggestion" command is supported.
 pub struct ExecuteCommand;
 
-impl<'a> Action<'a> for ExecuteCommand {
+impl Action for ExecuteCommand {
     type Params = ExecuteCommandParams;
     const METHOD: &'static str = "workspace/executeCommand";
+}
+
+impl<'a> BlockingRequestAction<'a> for ExecuteCommand {
+    type Response = Ack;
 
     fn new(_: &'a mut LsState) -> Self {
         ExecuteCommand
     }
-}
 
-impl<'a> RequestAction<'a> for ExecuteCommand {
-    type Response = Ack;
     fn handle<O: Output>(&mut self, id: usize, params: Self::Params, _ctx: &mut ActionContext, out: O) -> Result<Self::Response, ()> {
         match &*params.command {
             "rls.applySuggestion" => {
@@ -632,18 +646,26 @@ impl CodeAction {
 impl<'a> Action<'a> for CodeAction {
     type Params = CodeActionParams;
     const METHOD: &'static str = "textDocument/codeAction";
-
-    fn new(_: &'a mut LsState) -> Self {
-        CodeAction
-    }
 }
 
-impl<'a> RequestAction<'a> for CodeAction {
+impl RequestAction for CodeAction {
     type Response = Vec<Command>;
-    fn handle<O: Output>(&mut self, _id: usize, params: Self::Params, ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
+
+    fn new() -> Self {
+        CodeAction
+    }
+
+    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+        Ok(vec![])
+    }
+
+    fn handle(
+        &mut self,
+        ctx: InitActionContext,
+        params: Self::Params,
+    ) -> Result<Self::Response, ResponseError> {
         trace!("code_action {:?}", params);
 
-        let ctx = ctx.inited();
         let file_path = parse_file_path!(&params.text_document.uri, "code_action")?;
 
         let mut cmds = vec![];
@@ -656,17 +678,18 @@ impl<'a> RequestAction<'a> for CodeAction {
 /// Pretty print the given document.
 pub struct Formatting;
 
-impl<'a> Action<'a> for Formatting {
+impl Action for Formatting {
     type Params = DocumentFormattingParams;
     const METHOD: &'static str = "textDocument/formatting";
+}
+
+impl<'a> BlockingRequestAction<'a> for Formatting {
+    type Response = [TextEdit; 1];
 
     fn new(_: &'a mut LsState) -> Self {
         Formatting
     }
-}
 
-impl<'a> RequestAction<'a> for Formatting {
-    type Response = [TextEdit; 1];
     fn handle<O: Output>(&mut self, id: usize, params: Self::Params, ctx: &mut ActionContext, out: O) -> Result<Self::Response, ()> {
         reformat(id, params.text_document, None, &params.options, ctx, out)
     }
@@ -675,17 +698,18 @@ impl<'a> RequestAction<'a> for Formatting {
 /// Pretty print the source within the given location range.
 pub struct RangeFormatting;
 
-impl<'a> Action<'a> for RangeFormatting {
+impl Action for RangeFormatting {
     type Params = DocumentRangeFormattingParams;
     const METHOD: &'static str = "textDocument/rangeFormatting";
+}
+
+impl<'a> BlockingRequestAction<'a> for RangeFormatting {
+    type Response = [TextEdit; 1];
 
     fn new(_: &'a mut LsState) -> Self {
         RangeFormatting
     }
-}
 
-impl<'a> RequestAction<'a> for RangeFormatting {
-    type Response = [TextEdit; 1];
     fn handle<O: Output>(&mut self, id: usize, params: Self::Params, ctx: &mut ActionContext, out: O) -> Result<Self::Response, ()> {
         reformat(id, params.text_document, Some(params.range), &params.options, ctx, out)
     }
@@ -711,7 +735,7 @@ fn reformat<O: Output>(id: usize, doc: TextDocumentIdentifier, selection: Option
     };
 
     let range_whole_file = ls_util::range_from_vfs_file(&ctx.vfs, &path);
-    let mut config = ctx.fmt_config.get_rustfmt_config().clone();
+    let mut config = ctx.fmt_config().get_rustfmt_config().clone();
     if !config.was_set().hard_tabs() {
         config.set().hard_tabs(!opts.insert_spaces);
     }
@@ -764,17 +788,18 @@ fn reformat<O: Output>(id: usize, doc: TextDocumentIdentifier, selection: Option
 /// filled in after the initial completion's presentation.
 pub struct ResolveCompletion;
 
-impl<'a> Action<'a> for ResolveCompletion {
+impl Action for ResolveCompletion {
     type Params = CompletionItem;
     const METHOD: &'static str = "completionItem/resolve";
+}
+
+impl<'a> BlockingRequestAction<'a> for ResolveCompletion {
+    type Response = CompletionItem;
 
     fn new(_: &'a mut LsState) -> Self {
         ResolveCompletion
     }
-}
 
-impl<'a> RequestAction<'a> for ResolveCompletion {
-    type Response = CompletionItem;
     fn handle<O: Output>(&mut self, _id: usize, params: Self::Params, _ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
         // currently, we safely ignore this as a pass-through since we fully handle
         // textDocument/completion.  In the future, we may want to use this method as a
@@ -813,10 +838,10 @@ fn location_from_racer_match(a_match: racer::Match) -> Option<Location> {
 }
 
 lazy_static! {
-    static ref WORK_POOL: rayon::ThreadPool = rayon::ThreadPool::new(
+    pub static ref WORK_POOL: rayon::ThreadPool = rayon::ThreadPool::new(
         rayon::Configuration::default()
             .thread_name(|num| format!("request-worker-{}", num))
-            .panic_handler(|err| warn!("{:?}", err))
+            .panic_handler(|_| {})
     ).unwrap();
 }
 

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -24,13 +24,11 @@ use rayon;
 use lsp_data;
 use lsp_data::*;
 use server::{Output, Ack, Action, RequestAction, ResponseError, BlockingRequestAction, LsState};
-use super::InitActionContext;
 use jsonrpc_core::types::ErrorCode;
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Duration;
-use std::sync::{mpsc, Arc};
+use std::sync::mpsc;
 
 /// Represent the result of a deglob action for a single wildcard import.
 ///
@@ -643,7 +641,7 @@ impl CodeAction {
     }
 }
 
-impl<'a> Action<'a> for CodeAction {
+impl Action for CodeAction {
     type Params = CodeActionParams;
     const METHOD: &'static str = "textDocument/codeAction";
 }
@@ -669,8 +667,8 @@ impl RequestAction for CodeAction {
         let file_path = parse_file_path!(&params.text_document.uri, "code_action")?;
 
         let mut cmds = vec![];
-        Self::make_suggestion_fix_actions(&params, &file_path, ctx, &mut cmds);
-        Self::make_deglob_actions(&params, &file_path, ctx, &mut cmds);
+        Self::make_suggestion_fix_actions(&params, &file_path, &ctx, &mut cmds);
+        Self::make_deglob_actions(&params, &file_path, &ctx, &mut cmds);
         Ok(cmds)
     }
 }

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -838,10 +838,11 @@ fn location_from_racer_match(a_match: racer::Match) -> Option<Location> {
 }
 
 lazy_static! {
+    /// Thread pool for request execution allowing concurrent request processing.
     pub static ref WORK_POOL: rayon::ThreadPool = rayon::ThreadPool::new(
         rayon::Configuration::default()
             .thread_name(|num| format!("request-worker-{}", num))
-            .panic_handler(|_| {})
+            .panic_handler(|err| warn!("{:?}", err))
     ).unwrap();
 }
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -62,6 +62,7 @@ use self::plan::{Plan as BuildPlan, WorkStatus};
 /// used from multiple threads. It will spawn threads itself as necessary.
 //
 // See comment on `request_build` for implementation notes.
+#[derive(Clone)]
 pub struct BuildQueue {
     internals: Arc<Internals>,
     // The build queue - we only have one low and one high priority build waiting.

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -29,7 +29,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use url::Url;
 
 const VERBOSE: bool = false;
@@ -126,7 +126,7 @@ pub fn run() {
     }
 }
 
-fn def<'a>(file_name: &str, row: &str, col: &str) -> Request<'a, requests::Definition> {
+fn def(file_name: &str, row: &str, col: &str) -> Request<requests::Definition> {
     let params = TextDocumentPositionParams {
         text_document: TextDocumentIdentifier::new(url(file_name)),
         position: Position::new(u64::from_str(row).expect("Bad line number"),
@@ -135,11 +135,12 @@ fn def<'a>(file_name: &str, row: &str, col: &str) -> Request<'a, requests::Defin
     Request {
         id: next_id(),
         params,
+        received: Instant::now(),
         _action: PhantomData,
     }
 }
 
-fn rename<'a>(file_name: &str, row: &str, col: &str, new_name: &str) -> Request<'a, requests::Rename> {
+fn rename(file_name: &str, row: &str, col: &str, new_name: &str) -> Request<requests::Rename> {
     let params = RenameParams {
         text_document: TextDocumentIdentifier::new(url(file_name)),
         position: Position::new(u64::from_str(row).expect("Bad line number"),
@@ -149,11 +150,12 @@ fn rename<'a>(file_name: &str, row: &str, col: &str, new_name: &str) -> Request<
     Request {
         id: next_id(),
         params,
+        received: Instant::now(),
         _action: PhantomData,
     }
 }
 
-fn hover<'a>(file_name: &str, row: &str, col: &str) -> Request<'a, requests::Hover> {
+fn hover(file_name: &str, row: &str, col: &str) -> Request<requests::Hover> {
     let params = TextDocumentPositionParams {
         text_document: TextDocumentIdentifier::new(url(file_name)),
         position: Position::new(u64::from_str(row).expect("Bad line number"),
@@ -162,22 +164,24 @@ fn hover<'a>(file_name: &str, row: &str, col: &str) -> Request<'a, requests::Hov
     Request {
         id: next_id(),
         params,
+        received: Instant::now(),
         _action: PhantomData,
     }
 }
 
-fn workspace_symbol<'a>(query: &str) -> Request<'a, requests::WorkspaceSymbol> {
+fn workspace_symbol(query: &str) -> Request<requests::WorkspaceSymbol> {
     let params = WorkspaceSymbolParams {
         query: query.to_owned()
     };
     Request {
         id: next_id(),
         params,
+        received: Instant::now(),
         _action: PhantomData,
     }
 }
 
-fn format<'a>(file_name: &str, tab_size: u64, insert_spaces: bool) -> Request<'a, requests::Formatting> {
+fn format(file_name: &str, tab_size: u64, insert_spaces: bool) -> Request<requests::Formatting> {
     // no optional properties
     let properties = HashMap::default();
 
@@ -188,11 +192,12 @@ fn format<'a>(file_name: &str, tab_size: u64, insert_spaces: bool) -> Request<'a
     Request {
         id: next_id(),
         params,
+        received: Instant::now(),
         _action: PhantomData,
     }
 }
 
-fn range_format<'a>(file_name: &str, start_row: u64, start_col: u64, end_row: u64, end_col: u64, tab_size: u64, insert_spaces: bool) -> Request<'a, requests::RangeFormatting> {
+fn range_format(file_name: &str, start_row: u64, start_col: u64, end_row: u64, end_col: u64, tab_size: u64, insert_spaces: bool) -> Request<requests::RangeFormatting> {
     // no optional properties
     let properties = HashMap::default();
 
@@ -207,26 +212,28 @@ fn range_format<'a>(file_name: &str, start_row: u64, start_col: u64, end_row: u6
     Request {
         id: next_id(),
         params,
+        received: Instant::now(),
         _action: PhantomData,
     }
 }
 
-fn shutdown<'a>() -> Request<'a, server::ShutdownRequest<'a>> {
+fn shutdown<'a>() -> Request<server::ShutdownRequest<'a>> {
     Request {
         id: next_id(),
         params: NoParams {},
+        received: Instant::now(),
         _action: PhantomData,
     }
 }
 
-fn exit<'a>() -> Notification<'a, server::ExitNotification<'a>> {
+fn exit<'a>() -> Notification<server::ExitNotification<'a>> {
     Notification {
         params: NoParams {},
         _action: PhantomData,
     }
 }
 
-fn initialize<'a>(root_path: String) -> Request<'a, server::InitializeRequest> {
+fn initialize(root_path: String) -> Request<server::InitializeRequest> {
     let params = InitializeParams {
         process_id: None,
         root_path: Some(root_path), // FIXME(#299): This property is deprecated. Instead Use `root_uri`.
@@ -242,6 +249,7 @@ fn initialize<'a>(root_path: String) -> Request<'a, server::InitializeRequest> {
     Request {
         id: next_id(),
         params,
+        received: Instant::now(),
         _action: PhantomData,
     }
 }

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -1,0 +1,145 @@
+use super::requests::*;
+use jsonrpc_core::{self as jsonrpc};
+use server::{Request, Response, Action};
+use server::io::Output;
+use actions::InitActionContext;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+use std::fmt;
+
+lazy_static! {
+    static ref TIMEOUT: Duration = Duration::from_millis(::COMPILER_TIMEOUT);
+}
+
+/// Macro enum `DispatchRequest` packing in various similar `Request` types
+macro_rules! define_dispatch_request_enum {
+    ($($request_type:ident),*) => {
+        pub enum DispatchRequest {
+            $(
+                $request_type($request_type, Request<$request_type>, InitActionContext),
+            )*
+        }
+
+        $(
+            impl From<(Request<$request_type>, InitActionContext)> for DispatchRequest {
+                fn from((req, ctx): (Request<$request_type>, InitActionContext)) -> Self {
+                    DispatchRequest::$request_type($request_type::new(), req, ctx)
+                }
+            }
+        )*
+
+        impl DispatchRequest {
+            fn handle<O: Output>(self, out: &O) {
+                match self {
+                $(
+                    DispatchRequest::$request_type(mut var, req, ctx) => {
+                        let Request { id, params, received, .. } = req;
+                        let fallback = var.fallback_response();
+                        let timeout = var.timeout();
+
+                        let receiver = receive_from_thread(move || {
+                            // checking timeout here can prevent starting expensive work that has
+                            // already timed out due to previous long running requests
+                            // Note: done here on the threadpool as pool scheduling may incur
+                            // a further delay
+                            if received.elapsed() >= timeout {
+                                var.fallback_response()
+                            }
+                            else {
+                                var.handle(ctx, params)
+                            }
+                        });
+
+                        match receiver.recv_timeout(timeout).unwrap_or(fallback) {
+                            Ok(response) => response.send(id, out),
+                            Err(ResponseError::Empty) => debug!("Error handling request"),
+                            Err(ResponseError::Message(code, msg)) => {
+                                out.failure_message(id, code, msg)
+                            }
+                        }
+                    }
+                )*
+                }
+            }
+        }
+    }
+}
+
+define_dispatch_request_enum!(
+    Completion,
+    Definition,
+    References,
+    WorkspaceSymbol,
+    Symbols,
+    Hover,
+    FindImpls,
+    DocumentHighlight,
+    Rename,
+    CodeAction
+);
+
+/// Provides ability to dispatch requests to a worker thread that will
+/// handle the requests sequentially, without blocking stdin.
+/// Requests dispatched this way are automatically timed out & avoid
+/// processing if have already timed out before starting.
+pub struct Dispatcher {
+    sender: mpsc::Sender<DispatchRequest>,
+}
+
+impl Dispatcher {
+    /// Creates a new `Dispatcher` starting a new thread and channel
+    pub fn new<O: Output>(out: O) -> Self {
+        let (sender, receiver) = mpsc::channel::<DispatchRequest>();
+
+        thread::Builder::new().name("dispatch-worker".into()).spawn(move || {
+            while let Ok(request) = receiver.recv() {
+                request.handle(&out)
+            }
+        }).unwrap();
+
+        Self { sender }
+    }
+
+    /// Sends a request to the dispatch-worker thread, does not block
+    pub fn dispatch<R: Into<DispatchRequest>>(&self, request: R) {
+        if let Err(err) = self.sender.send(request.into()) {
+            debug!("Failed to dispatch request: {:?}", err);
+        }
+    }
+}
+
+/// Stdin-nonblocking request logic designed to be packed into a `DispatchRequest`
+/// and handled on the `WORK_POOL` via a `Dispatcher`.
+pub trait RequestAction: Action {
+    type Response: ::serde::Serialize + fmt::Debug + Send;
+
+    /// Max duration this request should finish within, also see `fallback_response()`
+    fn timeout(&self) -> Duration {
+        *TIMEOUT
+    }
+
+    fn new() -> Self;
+
+    /// Returns a response used in timeout scenarios
+    fn fallback_response(&self) -> Result<Self::Response, ResponseError>;
+
+    /// Request processing logic
+    fn handle(
+        &mut self,
+        ctx: InitActionContext,
+        params: Self::Params,
+    ) -> Result<Self::Response, ResponseError>;
+}
+
+/// Wrapper for a response error
+pub enum ResponseError {
+    Empty,
+    Message(jsonrpc::ErrorCode, String),
+}
+
+impl From<()> for ResponseError {
+    fn from(_: ()) -> Self {
+        ResponseError::Empty
+    }
+}

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -160,8 +160,10 @@ impl Output for StdioOutput {
 
         trace!("response: {:?}", o);
 
-        print!("{}", o);
-        io::stdout().flush().unwrap();
+        let stdout = io::stdout();
+        let mut stdout_lock = stdout.lock();
+        write!(stdout_lock, "{}", o).unwrap();
+        stdout_lock.flush().unwrap();
     }
 
     fn provide_id(&self) -> u32 {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -463,7 +463,6 @@ impl<O: Output> LsService<O> {
                 InitializeRequest,
                 requests::ResolveCompletion,
                 requests::ExecuteCommand,
-                requests::Deglob,
                 requests::Formatting,
                 requests::RangeFormatting;
             requests:

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -25,14 +25,18 @@ use actions::{ActionContext, requests, notifications};
 use config::Config;
 pub use server::io::{MessageReader, Output};
 use server::io::{StdioMsgReader, StdioOutput};
+use server::dispatch::Dispatcher;
+pub use server::dispatch::{RequestAction, ResponseError};
 
 use std::fmt;
 use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
 mod io;
+mod dispatch;
 
 /// Run the Rust Language Server.
 pub fn run_server(analysis: Arc<AnalysisHost>, vfs: Arc<Vfs>) {
@@ -69,54 +73,65 @@ impl<'de> Deserialize<'de> for NoParams {
 /// A response to some request.
 pub trait Response {
     /// Send the response along the given output.
-    fn send<O: Output>(&self, id: usize, out: O);
+    fn send<O: Output>(&self, id: usize, out: &O);
 }
 
 impl Response for NoResponse {
-    fn send<O: Output>(&self, _id: usize, _out: O) {
+    fn send<O: Output>(&self, _id: usize, _out: &O) {
     }
 }
 
 impl<R: ::serde::Serialize + fmt::Debug> Response for R {
-    fn send<O: Output>(&self, id: usize, out: O) {
+    fn send<O: Output>(&self, id: usize, out: &O) {
         out.success(id, &self);
     }
 }
 
 /// An action taken by the Rust Language Server.
-pub trait Action<'a> {
+pub trait Action {
     /// Extra parameters that the action expects to receive.
-    type Params: serde::Serialize + for<'de> ::serde::Deserialize<'de>;
+    type Params: serde::Serialize + for<'de> serde::Deserialize<'de> + Send;
 
     /// The well-known language server method string that identifies this
     /// action's kind of request or notification.
     const METHOD: &'static str;
-
-    /// Construct a new instance of this action from the given language server
-    /// state.
-    fn new(state: &'a mut LsState) -> Self;
 }
 
 /// An action taken in response to some notification from the client.
-pub trait NotificationAction<'a>: Action<'a> {
+/// Blocks stdin whilst being handled.
+pub trait BlockingNotificationAction<'a>: Action {
+    fn new(state: &'a mut LsState) -> Self;
+
     /// Handle this notification.
-    fn handle<O: Output>(&mut self, params: Self::Params, ctx: &mut ActionContext, out: O) -> Result<(), ()>;
+    fn handle<O: Output>(
+        &mut self,
+        params: Self::Params,
+        ctx: &mut ActionContext,
+        out: O,
+    ) -> Result<(), ()>;
 }
 
-/// An action that implements support for handling requests from the client and
-/// replying with a corresponding response.
-pub trait RequestAction<'a>: Action<'a> {
-    /// The kind of response for this request.
+/// A request that blocks stdin whilst being handled
+pub trait BlockingRequestAction<'a>: Action {
     type Response: Response + fmt::Debug;
 
+    fn new(state: &'a mut LsState) -> Self;
+
     /// Handle request and send its response back along the given output.
-    fn handle<O: Output>(&mut self, id: usize, params: Self::Params, ctx: &mut ActionContext, out: O) -> Result<Self::Response, ()>;
+    fn handle<O: Output>(
+        &mut self,
+        id: usize,
+        params: Self::Params,
+        ctx: &mut ActionContext,
+        out: O,
+    ) -> Result<Self::Response, ()>;
 }
 
 /// A request that gets JSON serialized in the language server protocol.
-pub struct Request<'a, A: RequestAction<'a>> {
+pub struct Request<A: Action> {
     /// The unique request id.
     pub id: usize,
+    pub received: Instant,
     /// The extra action-specific parameters.
     pub params: A::Params,
     /// This request's handler action.
@@ -125,15 +140,15 @@ pub struct Request<'a, A: RequestAction<'a>> {
 
 /// A notification that gets JSON serialized in the language server protocol.
 #[derive(Debug, PartialEq)]
-pub struct Notification<'a, A: NotificationAction<'a>> {
+pub struct Notification<A: Action> {
     /// The extra action-specific parameters.
     pub params: A::Params,
     /// The action responsible for this notification.
     pub _action: PhantomData<A>,
 }
 
-impl<'a, A: RequestAction<'a>> Request<'a, A> {
-    fn dispatch<O: Output>(self, state: &'a mut LsState, ctx: &mut ActionContext, out: O) -> Result<A::Response, ()> {
+impl<'a, A: BlockingRequestAction<'a>> Request<A> {
+    fn blocking_dispatch<O: Output>(self, state: &'a mut LsState, ctx: &mut ActionContext, out: &O) -> Result<A::Response, ()> {
         let mut action = A::new(state);
         let result = action.handle(self.id, self.params, ctx, out.clone())?;
         result.send(self.id, out);
@@ -141,7 +156,7 @@ impl<'a, A: RequestAction<'a>> Request<'a, A> {
     }
 }
 
-impl<'a, A: NotificationAction<'a>> Notification<'a, A> {
+impl<'a, A: BlockingNotificationAction<'a>> Notification<A> {
     fn dispatch<O: Output>(self, state: &'a mut LsState, ctx: &mut ActionContext, out: O) -> Result<(), ()> {
         let mut action = A::new(state);
         action.handle(self.params, ctx, out)?;
@@ -149,7 +164,7 @@ impl<'a, A: NotificationAction<'a>> Notification<'a, A> {
     }
 }
 
-impl<'a, A: RequestAction<'a>> fmt::Display for Request<'a, A> {
+impl<'a, A: Action> fmt::Display for Request<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         json!({
             "jsonrpc": "2.0",
@@ -160,7 +175,7 @@ impl<'a, A: RequestAction<'a>> fmt::Display for Request<'a, A> {
     }
 }
 
-impl<'a, A: NotificationAction<'a>> fmt::Display for Notification<'a, A> {
+impl<'a, A: BlockingNotificationAction<'a>> fmt::Display for Notification<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         json!({
             "jsonrpc": "2.0",
@@ -177,6 +192,7 @@ pub struct LsService<O: Output> {
     ctx: ActionContext,
     /// The public shared state for this language server.
     pub state: LsState,
+    dispatcher: Dispatcher,
 }
 
 /// Public shared state for this language server.
@@ -193,19 +209,20 @@ pub struct ShutdownRequest<'a> {
     state: &'a mut LsState,
 }
 
-impl<'a> Action<'a> for ShutdownRequest<'a> {
+impl<'a> Action for ShutdownRequest<'a> {
     type Params = NoParams;
     const METHOD: &'static str = "shutdown";
+}
+
+impl<'a> BlockingRequestAction<'a> for ShutdownRequest<'a> {
+    type Response = Ack;
 
     fn new(state: &'a mut LsState) -> Self {
         ShutdownRequest {
             state
         }
     }
-}
 
-impl<'a> RequestAction<'a> for ShutdownRequest<'a> {
-    type Response = Ack;
     fn handle<O: Output>(&mut self, _id: usize, _params: Self::Params, _ctx: &mut ActionContext, _out: O) -> Result<Self::Response, ()> {
         self.state.shut_down.store(true, Ordering::SeqCst);
         Ok(Ack)
@@ -218,33 +235,21 @@ pub struct ExitNotification<'a> {
     state: &'a mut LsState,
 }
 
-impl<'a> Action<'a> for ExitNotification<'a> {
+impl<'a> Action for ExitNotification<'a> {
     type Params = NoParams;
     const METHOD: &'static str = "exit";
+}
 
+impl<'a> BlockingNotificationAction<'a> for ExitNotification<'a> {
     fn new(state: &'a mut LsState) -> Self {
         ExitNotification {
             state
         }
     }
-}
 
-impl<'a> NotificationAction<'a> for ExitNotification<'a> {
     fn handle<O: Output>(&mut self, _params: Self::Params, _ctx: &mut ActionContext, _out: O) -> Result<(), ()> {
         let shut_down = self.state.shut_down.load(Ordering::SeqCst);
         ::std::process::exit(if shut_down { 0 } else { 1 });
-    }
-}
-
-/// A request to initialize this server.
-pub struct InitializeRequest;
-
-impl<'a> Action<'a> for InitializeRequest {
-    type Params = InitializeParams;
-    const METHOD: &'static str = "initialize";
-
-    fn new(_: &'a mut LsState) -> Self {
-        InitializeRequest
     }
 }
 
@@ -257,8 +262,21 @@ fn get_root_path(params: &InitializeParams) -> PathBuf {
     })
 }
 
-impl<'a> RequestAction<'a> for InitializeRequest {
+/// A request to initialize this server.
+pub struct InitializeRequest;
+
+impl<'a> Action for InitializeRequest {
+    const METHOD: &'static str = "initialize";
+    type Params = InitializeParams;
+}
+
+impl<'a> BlockingRequestAction<'a> for InitializeRequest {
     type Response = NoResponse;
+
+    fn new(_: &'a mut LsState) -> Self {
+        InitializeRequest
+    }
+
     fn handle<O: Output>(&mut self, id: usize, params: Self::Params, ctx: &mut ActionContext, out: O) -> Result<NoResponse, ()> {
         let init_options: InitializationOptions = params
             .initialization_options
@@ -326,13 +344,16 @@ impl<O: Output> LsService<O> {
                reader: Box<MessageReader + Send + Sync>,
                output: O)
                -> LsService<O> {
+        let dispatcher = Dispatcher::new(output.clone());
+
         LsService {
             msg_reader: reader,
             output: output,
             ctx: ActionContext::new(analysis, vfs, config),
             state: LsState {
                 shut_down: AtomicBool::new(false),
-            }
+            },
+            dispatcher,
         }
     }
 
@@ -375,7 +396,12 @@ impl<O: Output> LsService<O> {
 
     fn dispatch_message(&mut self, msg: &RawMessage) -> Result<(), jsonrpc::Error> {
         macro_rules! match_action {
-            ($method: expr; notifications: $($n_action: ty),*; requests: $($r_action: ty),*;) => {
+            (
+                $method: expr;
+                notifications: $($n_action: ty),*;
+                blocking_requests: $($br_action: ty),*;
+                requests: $($request: ty),*;
+            ) => {
                 let mut handled = false;
                 trace!("Handling `{}`", $method);
                 $(
@@ -388,11 +414,22 @@ impl<O: Output> LsService<O> {
                     }
                 )*
                 $(
-                    if $method == <$r_action as Action>::METHOD {
-                        let request = msg.parse_as_request::<$r_action>()?;
-                        if let Err(_) = request.dispatch(&mut self.state, &mut self.ctx, self.output.clone()) {
-                            debug!("Error handling notification: {:?}", msg);
+                    if $method == <$br_action as Action>::METHOD {
+                        let request = msg.parse_as_request::<$br_action>()?;
+                        if let Err(_) = request.blocking_dispatch(
+                            &mut self.state,
+                            &mut self.ctx,
+                            &self.output
+                        ) {
+                            debug!("Error handling request: {:?}", msg);
                         }
+                        handled = true;
+                    }
+                )*
+                $(
+                    if $method == <$request as Action>::METHOD {
+                        let request = (msg.parse_as_request::<$request>()?, self.ctx.inited());
+                        self.dispatcher.dispatch(request);
                         handled = true;
                     }
                 )*
@@ -413,23 +450,25 @@ impl<O: Output> LsService<O> {
                 notifications::DidChangeConfiguration,
                 notifications::DidChangeWatchedFiles,
                 notifications::Cancel;
-            requests:
+            blocking_requests:
                 ShutdownRequest,
                 InitializeRequest,
-                requests::Definition,
-                requests::References,
-                requests::Completion,
                 requests::ResolveCompletion,
-                requests::Rename,
-                requests::DocumentHighlight,
                 requests::ExecuteCommand,
+                requests::Deglob,
+                requests::Formatting,
+                requests::RangeFormatting;
+            requests:
+                requests::Rename,
                 requests::CodeAction,
+                requests::DocumentHighlight,
                 requests::FindImpls,
                 requests::Symbols,
+                requests::Hover,
                 requests::WorkspaceSymbol,
-                requests::Formatting,
-                requests::RangeFormatting,
-                requests::Hover;
+                requests::Definition,
+                requests::References,
+                requests::Completion;
         );
         Ok(())
     }
@@ -490,8 +529,7 @@ struct RawMessage {
 }
 
 impl RawMessage {
-    fn parse_as_request<'a, T: RequestAction<'a>>(&'a self) -> Result<Request<T>, jsonrpc::Error> {
-
+    fn parse_as_request<T: Action>(&self) -> Result<Request<T>, jsonrpc::Error> {
         // FIXME: We only support numeric responses, ideally we should switch from using parsed usize
         // to using jsonrpc_core::Id
         let parsed_numeric_id = match &self.id {
@@ -511,6 +549,7 @@ impl RawMessage {
                 Ok(Request {
                     id,
                     params,
+                    received: Instant::now(),
                     _action: PhantomData,
                 })
             }
@@ -518,7 +557,7 @@ impl RawMessage {
         }
     }
 
-    fn parse_as_notification<'a, T: NotificationAction<'a>>(&'a self) -> Result<Notification<T>, jsonrpc::Error> {
+    fn parse_as_notification<T: Action>(&self) -> Result<Notification<T>, jsonrpc::Error> {
         use serde::Deserialize;
 
         let params = T::Params::deserialize(&self.params)

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -30,13 +30,14 @@ use serde_json;
 use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 use url::Url;
 
-pub fn initialize<'a>(id: usize, root_path: Option<String>) -> Request<'a, ls_server::InitializeRequest> {
+pub fn initialize<'a>(id: usize, root_path: Option<String>) -> Request<ls_server::InitializeRequest> {
      initialize_with_opts(id, root_path, None)
 }
 
-pub fn initialize_with_opts<'a>(id: usize, root_path: Option<String>, initialization_options: Option<InitializationOptions>) -> Request<'a, ls_server::InitializeRequest> {
+pub fn initialize_with_opts<'a>(id: usize, root_path: Option<String>, initialization_options: Option<InitializationOptions>) -> Request<ls_server::InitializeRequest> {
     let init_opts = initialization_options.map(|val| serde_json::to_value(val).unwrap());
     let params = InitializeParams {
         process_id: None,
@@ -53,14 +54,28 @@ pub fn initialize_with_opts<'a>(id: usize, root_path: Option<String>, initializa
     Request {
         id,
         params,
+        received: Instant::now(),
         _action: PhantomData,
     }
 }
 
-pub fn request<'a, T: ls_server::RequestAction<'a>>(id: usize, params: T::Params) -> Request<'a, T> {
+pub fn blocking_request<'a, T: ls_server::BlockingRequestAction<'a>>(id: usize, params: T::Params) -> Request<T> {
     Request {
         id,
         params,
+        received: Instant::now(),
+        _action: PhantomData,
+    }
+}
+
+pub fn request<'a, T: ls_server::RequestAction>(
+    id: usize,
+    params: T::Params
+) -> Request<T> {
+    Request {
+        id,
+        params,
+        received: Instant::now(),
         _action: PhantomData,
     }
 }
@@ -73,7 +88,7 @@ fn test_shutdown() {
 
     let messages = vec![
         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
-        request::<ShutdownRequest>(1, NoParams).to_string(),
+        blocking_request::<ShutdownRequest>(1, NoParams).to_string(),
     ];
 
     let (mut server, results) = env.mock_server(messages);
@@ -360,7 +375,7 @@ fn test_reformat() {
     let text_doc = TextDocumentIdentifier::new(url);
     let messages = vec![
         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
-        request::<requests::Formatting>(42, DocumentFormattingParams {
+        blocking_request::<requests::Formatting>(42, DocumentFormattingParams {
             text_document: text_doc,
             options: FormattingOptions {
                 tab_size: 4,
@@ -395,7 +410,7 @@ fn test_reformat_with_range() {
     let text_doc = TextDocumentIdentifier::new(url);
     let messages = vec![
         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
-        request::<requests::RangeFormatting>(42, DocumentRangeFormattingParams {
+        blocking_request::<requests::RangeFormatting>(42, DocumentRangeFormattingParams {
             text_document: text_doc,
             range: Range {
                 start: Position { line: 12, character: 0 },
@@ -698,7 +713,7 @@ fn test_find_impls() {
             position: env.cache.mk_ls_position(src(&source_file_path, 16, "Super"))
         }).to_string(),
         // Does not work on Travis
-        // request::<requests::FindImpls>(3, TextDocumentPositionParams {
+        // blocking_request::<requests::FindImpls>(3, TextDocumentPositionParams {
         //     text_document: TextDocumentIdentifier::new(url),
         //     position: env.cache.mk_ls_position(src(&source_file_path, 20, "Eq"))
         // })).to_string(),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -862,7 +862,7 @@ fn test_deglob() {
             },
         }).to_string(),
         // deglob single
-        request::<requests::ExecuteCommand>(200, ExecuteCommandParams {
+        blocking_request::<requests::ExecuteCommand>(200, ExecuteCommandParams {
             command: "rls.deglobImports".into(),
             arguments: vec![
                 serde_json::to_value(&requests::DeglobResult {
@@ -886,7 +886,7 @@ fn test_deglob() {
             },
         }).to_string(),
         // deglob two wildcards
-        request::<requests::ExecuteCommand>(1200, ExecuteCommandParams {
+        blocking_request::<requests::ExecuteCommand>(1200, ExecuteCommandParams {
             command: "rls.deglobImports".into(),
             arguments: vec![
                 serde_json::to_value(&requests::DeglobResult {


### PR DESCRIPTION
As a result of the #540 discussion I've implemented an optional off-main request handling thread mainly to handle client request spam without locking up the server for arbitrary time. (This PR includes/builds on #552).

# Code impact
This change does add complexity to the life of a request. However, it actually simplifies the implementation of these requests, as the new `Dispatcher` provides running on the `WORK_POOL`, timing out & checking the request is outdated without these needing to be implemented per-request _(as timeouts used to be)_. As such the `fn handle(...)` of the requests I adapted to be non-blocking are now simpler.

# The problem & solution
Currently we essentially have a single thread that
* reads stdin
* parse request
* processes request
* sends response on stdout

This is simple and provides order correctness. However, testing on atom I found its quite easy for a client to lock up the server with some accidental request spam.

This PR allows the main thread to:
* read stdin
* parse request
* send request to `dispatch-worker`

And this flow is essentially non-blocking, _at least when only handling the subset of the requests that have been adapted_.

The `dispatch-worker` is a single thread that:
* waits for requests from the main thread
* processes request
* sends response on stdout

# Observed impact
To demonstrate the advantage of the added complexity, these are the logs of version f4ee8eaa6ee150fdc23dc8e1665f67a96c877ac2 running **10 Completion requests** manually requested in short order on my game project.
```
# Rls f4ee8ea
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion received (3028ms) [Object]
Rust (RLS) rpc.sendRequest textDocument/completion received (5849ms) [Object]
Rust (RLS) rpc.sendRequest textDocument/completion received (8681ms) [Object]
Rust (RLS) rpc.sendRequest textDocument/completion received (11504ms) [Object]
Rust (RLS) rpc.sendRequest textDocument/completion received (14323ms) [Object]
Rust (RLS) rpc.sendRequest textDocument/completion received (17141ms) [Object]
Rust (RLS) rpc.sendRequest textDocument/completion received (19961ms) [Object]
Rust (RLS) rpc.sendRequest textDocument/completion received (22777ms) [Object]
Rust (RLS) rpc.sendRequest textDocument/completion received (25586ms) [Object]
Rust (RLS) rpc.sendRequest textDocument/completion received (28400ms) [Object]
```

We can see the spam handling problem clearly here I think. We can also see that the 1.5s timeout doesn't work, hence #552. _Note timeouts alone won't be enough here, they simply reduce the total lock out to the timeout * number-of-requests_.

Now the same test against dual-thread rls in this PR.
```
# Rls PR
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion sending Object {textDocument: Object, position: Object}
Rust (RLS) rpc.sendRequest textDocument/completion received (1500ms) []
Rust (RLS) rpc.sendRequest textDocument/completion received (2856ms) []
Rust (RLS) rpc.sendRequest textDocument/completion received (2704ms) []
Rust (RLS) rpc.sendRequest textDocument/completion received (2556ms) []
Rust (RLS) rpc.sendRequest textDocument/completion received (2401ms) []
Rust (RLS) rpc.sendRequest textDocument/completion received (2249ms) []
Rust (RLS) rpc.sendRequest textDocument/completion received (2098ms) []
Rust (RLS) rpc.sendRequest textDocument/completion received (1950ms) []
Rust (RLS) rpc.sendRequest textDocument/completion received (1790ms) []
Rust (RLS) rpc.sendRequest textDocument/completion received (1643ms) []
```

Firstly the requests can actually timeout. On top of this the unblocked main thread can accurately timestamp each request allowing the `dispatch-worker` to use this to immediately respond a fallback result on old requests. In this way Rls can handle arbitrary request spam bursts without becoming unresponsive for longer than ~`2 * TIMEOUT`.

closes #552
resolves #540