### PR TITLE
Implement Deglob as a CodeAction

### DIFF
--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -31,7 +31,11 @@ use std::path::Path;
 use std::time::Duration;
 use std::sync::{mpsc, Arc};
 
-#[derive(Debug)]
+/// Represent the result of a deglob action for a single wildcard import.
+///
+/// The `location` is the position of the wildcard.
+/// `new_text` is the text which should replace the wildcard.
+#[derive(Debug, Deserialize, Serialize)]
 struct DeglobResult {
     location: Location,
     new_text: String,
@@ -443,123 +447,6 @@ impl<'a> RequestAction<'a> for Rename {
     }
 }
 
-/// Turn wildcard style glob imports (`use foo::*`) into an import of each item
-/// that is actually used (`use foo::{Bar, Quux}`).
-pub struct Deglob;
-
-impl Deglob {
-    fn calculate_workspace_edit(
-        &self,
-        location: &<Self as Action>::Params,
-        ctx: &InitActionContext,
-    ) -> Result<DeglobResult, (ErrorCode, &'static str)> {
-        let span = ls_util::location_to_rls(location.clone());
-        let mut span = ignore_non_file_uri!(span, &location.uri, "deglob")
-            .map_err(|_| (ErrorCode::InvalidParams, "Not a file URL"))?;
-
-        trace!("deglob {:?}", span);
-
-        // Start by checking that the user has selected a glob import.
-        if span.range.start() == span.range.end() {
-            // search for a glob in the line
-            let vfs = ctx.vfs.clone();
-            let line = vfs.load_line(&span.file, span.range.row_start)
-                .map_err(|_| (ErrorCode::InvalidParams, "Could not retrieve line from VFS."))?;
-
-            // search for exactly one "::*;" in the line. This should work fine for formatted text, but
-            // multiple use statements could be in the same line, then it is not possible to find which
-            // one to deglob.
-            let matches: Vec<_> = line.char_indices().filter(|&(_, chr)| chr == '*').collect();
-            if matches.is_empty() {
-                return Err((ErrorCode::InvalidParams, "No glob in selection."));
-            } else if matches.len() > 1 {
-                return Err((ErrorCode::InvalidParams, "Multiple globs in selection."));
-            }
-            let index = matches[0].0 as u32;
-            span.range.col_start = span::Column::new_zero_indexed(index);
-            span.range.col_end = span::Column::new_zero_indexed(index+1);
-        }
-
-        // Save-analysis exports the deglobbed version of a glob import as its type string.
-        let vfs = ctx.vfs.clone();
-        let analysis = ctx.analysis.clone();
-        let span_ = span.clone();
-
-        let receiver = receive_from_thread(move || {
-            match vfs.load_span(span_.clone()) {
-                Ok(ref s) if s != "*" => {
-                    return Err((ErrorCode::InvalidParams, "Not a glob"));
-                }
-                Err(e) => {
-                    debug!("Deglob failed: {:?}", e);
-                    return Err((ErrorCode::InternalError, "Couldn't open file"));
-                }
-                _ => {}
-            }
-
-            let ty = analysis.show_type(&span_);
-            ty.map_err(|_| {
-                (ErrorCode::InternalError, "Couldn't get info from analysis")
-            })
-        });
-
-        let result = receiver.recv_timeout(Duration::from_millis(::COMPILER_TIMEOUT));
-        let mut deglob_str = match result {
-            Ok(Ok(s)) => s,
-            Ok(Err(e)) => return Err(e),
-            Err(_) => return Err((ErrorCode::InternalError, "Internal thread paniced")),
-        };
-
-        // Handle multiple imports.
-        if deglob_str.contains(',') {
-            deglob_str = format!("{{{}}}", deglob_str);
-        }
-
-        Ok(DeglobResult{
-            location: ls_util::rls_to_location(&span),
-            new_text: deglob_str,
-        })
-    }
-}
-
-impl<'a> Action<'a> for Deglob {
-    type Params = Location;
-    const METHOD: &'static str = "rustWorkspace/deglob";
-
-    fn new(_: &'a mut LsState) -> Self {
-        Deglob
-    }
-}
-
-impl<'a> RequestAction<'a> for Deglob {
-    type Response = Ack;
-    fn handle<O: Output>(&mut self, id: usize, location: Self::Params, ctx: &mut ActionContext, out: O) -> Result<Self::Response, ()> {
-        let ctx = ctx.inited();
-        match self.calculate_workspace_edit(&location, ctx) {
-            Ok(DeglobResult {
-                location,
-                new_text,
-            }) => {
-                // Send a workspace edit to make the actual change.
-                // FIXME should handle the response
-                let output = serde_json::to_string(
-                    &RequestMessage::new(out.provide_id(),
-                                         "workspace/applyEdit".to_owned(),
-                                         ApplyWorkspaceEditParams { edit: make_workspace_edit(location, new_text) })
-                ).unwrap();
-                out.response(output);
-
-                // Nothing to actually send in the response.
-                Ok(Ack)
-            }
-            Err((code, msg)) => {
-                out.failure_message(id, code, msg);
-                Err(())
-            }
-        }
-    }
-}
-
 /// Execute a command within the workspace.
 ///
 /// These are *not* shell commands, but commands given by the client and
@@ -584,7 +471,16 @@ impl<'a> RequestAction<'a> for ExecuteCommand {
             "rls.applySuggestion" => {
                 let location = serde_json::from_value(params.arguments[0].clone()).expect("Bad argument");
                 let new_text = serde_json::from_value(params.arguments[1].clone()).expect("Bad argument");
-                self.apply_suggestion(id, location, new_text, out)
+                Self::apply_suggestion(id, location, new_text, out)
+            }
+            "rls.deglobImports" => {
+                if !params.arguments.is_empty() {
+                    let deglob_results: Vec<DeglobResult> = params.arguments.into_iter().map(|res| serde_json::from_value(res).expect("Bad argument")).collect();
+                    Self::apply_deglobs(deglob_results, out)
+                } else {
+                    // without changes always successful
+                    Ok(Ack)
+                }
             }
             c => {
                 debug!("Unknown command: {}", c);
@@ -596,13 +492,43 @@ impl<'a> RequestAction<'a> for ExecuteCommand {
 }
 
 impl ExecuteCommand {
-    fn apply_suggestion<O: Output>(&self, _id: usize, location: Location, new_text: String, out: O) -> Result<Ack, ()> {
+    fn apply_suggestion<O: Output>(_id: usize, location: Location, new_text: String, out: O) -> Result<Ack, ()> {
         trace!("apply_suggestion {:?} {}", location, new_text);
         // FIXME should handle the response
         let output = serde_json::to_string(
             &RequestMessage::new(out.provide_id(),
                                  "workspace/applyEdit".to_owned(),
                                  ApplyWorkspaceEditParams { edit: make_workspace_edit(location, new_text) })
+        ).unwrap();
+        out.response(output);
+        Ok(Ack)
+    }
+
+    fn apply_deglobs<O: Output>(deglob_results: Vec<DeglobResult>, out: O) -> Result<Ack, ()> {
+        trace!("apply_deglob {:?}", deglob_results);
+
+        assert!(!deglob_results.is_empty());
+        let uri = deglob_results[0].location.uri.clone();
+
+        let text_edits: Vec<_> = deglob_results.into_iter()
+            .map(|res| {
+                TextEdit {
+                    range: res.location.range,
+                    new_text: res.new_text,
+                }
+            })
+            .collect();
+        let mut edit = WorkspaceEdit {
+            changes: HashMap::new(),
+        };
+        // all deglob results will share the same URI
+        edit.changes.insert(uri, text_edits);
+
+        // FIXME should handle the response
+        let output = serde_json::to_string(
+            &RequestMessage::new(out.provide_id(),
+                                 "workspace/applyEdit".to_owned(),
+                                 ApplyWorkspaceEditParams {edit})
         ).unwrap();
         out.response(output);
         Ok(Ack)
@@ -617,7 +543,6 @@ impl CodeAction {
     /// Create CodeActions for fixes suggested by the compiler
     /// the results are appended to `code_actions_result`
     fn make_suggestion_fix_actions(
-        &self,
         params: &<Self as Action>::Params,
         file_path: &Path,
         ctx: &InitActionContext,
@@ -646,32 +571,57 @@ impl CodeAction {
     /// Create CodeActions for performing deglobbing when a wildcard import is found
     /// the results are appended to `code_actions_result`
     fn make_deglob_actions(
-        &self,
         params: &<Self as Action>::Params,
         file_path: &Path,
         ctx: &InitActionContext,
         code_actions_result: &mut <Self as RequestAction>::Response,
     ) {
-        // search for glob imports
         // search for a glob in the line
         if let Ok(line) = ctx.vfs.load_line(file_path, ls_util::range_to_rls(params.range).row_start) {
-            if line.contains("use ") && line.contains("::*") && !line.contains("prelude::*") {
-                let location = Location::new(params.text_document.uri.clone(), params.range);
-                // call Deglob implementation in order to avoid any false positive of the `contains()`
-                // False positives could be doc comments, e.g.,
-                // ///```rust
-                // /// use std::mem::*;
-                // ///```
-                if let Ok(deglob) = Deglob.calculate_workspace_edit(&location, ctx) {
-                    let location = serde_json::to_value(&deglob.location).unwrap();
-                    let new_text = serde_json::to_value(&deglob.new_text).unwrap();
-                    let cmd = Command {
-                        title: "Deglob Import".to_owned(),
-                        command: "rls.applySuggestion".to_owned(),
-                        arguments: Some(vec![location, new_text]),
+            let span = Location::new(params.text_document.uri.clone(), params.range);
+
+            // for all indices which are a `*`
+            // check if we can deglob them
+            // this handles badly formated text containing multiple "use"s in one line
+            let deglob_results: Vec<_> = line.char_indices()
+                .filter(|&(_, chr)| chr == '*')
+                .filter_map(|(index, _)| {
+                    // map the indices to `Span`s
+                    let mut span = ls_util::location_to_rls(span.clone()).unwrap();
+                    span.range.col_start = span::Column::new_zero_indexed(index as u32);
+                    span.range.col_end = span::Column::new_zero_indexed(index as u32 + 1);
+
+                    // load the deglob type information
+                    ctx.analysis.show_type(&span)
+                    // remove all errors
+                    .ok()
+                    .map(|ty| (ty, span))
+                })
+                .map(|(mut deglob_str, span)| {
+                    // Handle multiple imports from one *
+                    if deglob_str.contains(',') {
+                        deglob_str = format!("{{{}}}", deglob_str);
+                    }
+
+                    // build result
+                    let deglob_result = DeglobResult {
+                        location: ls_util::rls_to_location(&span),
+                        new_text: deglob_str,
                     };
-                    code_actions_result.push(cmd);
-                }
+
+                    // convert to json
+                    serde_json::to_value(&deglob_result).unwrap()
+                })
+                .collect();
+
+            if !deglob_results.is_empty() {
+                // extend result list
+                let cmd = Command {
+                    title: format!("Deglob Import{}", if deglob_results.len() > 1 { "s" } else { "" }),
+                    command: "rls.deglobImports".to_owned(),
+                    arguments: Some(deglob_results),
+                };
+                code_actions_result.push(cmd);
             }
         };
     }
@@ -695,8 +645,8 @@ impl<'a> RequestAction<'a> for CodeAction {
         let file_path = parse_file_path!(&params.text_document.uri, "code_action")?;
 
         let mut cmds = vec![];
-        self.make_suggestion_fix_actions(&params, &file_path, ctx, &mut cmds);
-        self.make_deglob_actions(&params, &file_path, ctx, &mut cmds);
+        Self::make_suggestion_fix_actions(&params, &file_path, ctx, &mut cmds);
+        Self::make_deglob_actions(&params, &file_path, ctx, &mut cmds);
         Ok(cmds)
     }
 }

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -36,9 +36,11 @@ use std::sync::{mpsc, Arc};
 /// The `location` is the position of the wildcard.
 /// `new_text` is the text which should replace the wildcard.
 #[derive(Debug, Deserialize, Serialize)]
-struct DeglobResult {
-    location: Location,
-    new_text: String,
+pub struct DeglobResult {
+    /// Location of the "*" character in a wildcard import
+    pub location: Location,
+    /// Replacement text
+    pub new_text: String,
 }
 
 /// A request for information about a symbol in this workspace.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -284,7 +284,10 @@ impl<'a> RequestAction<'a> for InitializeRequest {
                 code_action_provider: Some(true),
                 document_formatting_provider: Some(true),
                 execute_command_provider: Some(ExecuteCommandOptions {
-                    commands: vec!["rls.applySuggestion".to_owned()],
+                    commands: vec![
+                        "rls.applySuggestion".to_owned(),
+                        "rls.deglobImports".to_owned(),
+                    ],
                 }),
                 rename_provider: Some(true),
                 // These are supported if the `unstable_features` option is set.
@@ -422,7 +425,6 @@ impl<O: Output> LsService<O> {
                 requests::ExecuteCommand,
                 requests::CodeAction,
                 requests::FindImpls,
-                requests::Deglob,
                 requests::Symbols,
                 requests::WorkspaceSymbol,
                 requests::Formatting,

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -240,6 +240,16 @@ impl Cache {
         ls_types::Position::new( (src.line - 1) as u64,  char_of_byte_index(&line, col) as u64)
     }
 
+    /// Create a range convering the initial position on the line
+    ///
+    /// The line number uses a 0-based index.
+    pub fn mk_ls_range_from_line(&mut self, line: u64) -> ls_types::Range {
+        ls_types::Range::new(
+            ls_types::Position::new(line, 0),
+            ls_types::Position::new(line, 0),
+        )
+    }
+
     pub fn abs_path(&self, file_name: &Path) -> PathBuf {
         let result = self.base_path.join(file_name).canonicalize().expect("Couldn't canonicalise path");
         let result = if cfg!(windows) {

--- a/test_data/deglob/Cargo.lock
+++ b/test_data/deglob/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "deglob"
+version = "0.1.0"
+

--- a/test_data/deglob/Cargo.toml
+++ b/test_data/deglob/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "deglob"
+version = "0.1.0"
+authors = ["Nick Cameron <ncameron@mozilla.com>"]
+
+[dependencies]

--- a/test_data/deglob/src/main.rs
+++ b/test_data/deglob/src/main.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// single wildcard import
+// imports two values
+use std::io::*;
+
+// multiple wildcard imports
+use std::mem::*; use std::cmp::*;
+
+pub fn main() {
+    size_of::<i32>();
+    size_of::<Stdin>();
+    size_of::<Stdout>();
+    max(1, 2);
+}


### PR DESCRIPTION
Provide code actions for deglobbing import for wildcard imports, except
for `prelude::*`. To avoid false positives (*) in the code actions, the
deglob command is run before the code action is presented to the user.

The original custom LSP extension is still in place in works. As such
the `Deglob::handle` function is split into a new
`calculate_workspace_edit`, which calculates the data for the deglob
action and is not used to the code action. The original `Deglob::handle`
just calls this function and is reponsible for sending the messages to
the client.

Addresses https://github.com/rust-lang-nursery/rls/issues/515

(*) The path in `CodeAction::handle` only checks for the existence of `use ` and `::*`. False positives could be multiline strings or doc comments.