### PR TITLE
Explain that line/column numbers are zero indexed

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -251,6 +251,7 @@ fn init() -> Sender<String> {
 // Display help message.
 fn help() {
     println!("RLS command line interface.");
+    println!("\nLine and column numbers are zero indexed");
     println!("\nSupported commands:");
     println!("    help    display this message");
     println!("    quit    exit");


### PR DESCRIPTION
It's not obvious that the line and column numbers are zero indexed. Maybe this little text will make it more obvious for the next person using it.