### PR TITLE
Use `--cli` to start the cli

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,8 @@ pub fn main() {
         match first_arg.as_str() {
             "--version" | "-V" => println!("rls-preview {}", version()),
             "--help" | "-h" => println!("{}", help()),
-            _ => cmd::run(),
+            "--cli" => cmd::run(),
+            unknown => println!("Unknown argument '{}'. Supported arguments:\n{}", unknown, help()),
         }
         return;
     }
@@ -110,7 +111,7 @@ fn help() -> &'static str {
     r#"
     --version or -V to print the version and commit info
     --help or -h for this message
-    Other input starts the RLS in command line mode
+    --cli starts the RLS in command line mode
     No input starts the RLS as a language server
     "#
 }


### PR DESCRIPTION
This is instead of an arbitrary argument. See
https://github.com/rust-lang-nursery/rls/issues/507

(This replaces #568 with a rebase instead of a merge)