### PR TITLE
No need for Racer installation instructions anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,6 @@ rustup component add rust-analysis --toolchain nightly
 rustup component add rust-src --toolchain nightly
 ```
 
-If you've never set up Racer before, you'll need to set up your RUST_SRC_PATH variable. To do so, 
-you can follow the [Racer configuration steps](https://github.com/phildawes/racer#configuration)
-
 ## Running
 
 Though the RLS is built to work with many IDEs and editors, we currently use


### PR DESCRIPTION
Racer can now gets the Rust stdlib source path from `rustc --print sysroot`, so the users don't need to have to bother setting it up once they have the `rust-src` component installed.