### PR TITLE
fix: filter documentHighlight positions to the requested file

### DIFF
--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -421,7 +421,7 @@ impl RequestAction for DocumentHighlight {
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
         let file_path = parse_file_path!(&params.text_document.uri, "highlight")?;
-        let span = ctx.convert_pos_to_span(file_path, params.position);
+        let span = ctx.convert_pos_to_span(file_path.clone(), params.position);
 
         let result = ctx.analysis
             .find_all_refs(&span, true)
@@ -430,13 +430,17 @@ impl RequestAction for DocumentHighlight {
         Ok(
             result
                 .iter()
-                .map(|span| {
-                    lsp_data::DocumentHighlight {
-                        range: ls_util::rls_to_range(span.range),
-                        kind: Some(DocumentHighlightKind::Text),
+                .filter_map(|span| {
+                    if span.file == file_path {
+                        Some(lsp_data::DocumentHighlight {
+                            range: ls_util::rls_to_range(span.range),
+                            kind: Some(DocumentHighlightKind::Text),
+                        })
+                    } else {
+                        None
                     }
                 })
-                .collect(),
+                .collect()
         )
     }
 }


### PR DESCRIPTION
It was ignoring the requested file and could send some positions of
differents files in the project.
This commit fix this behavior and now sends only positions in the
requested file.

I could observe this behavior: 
![peek 21-11-2017 12-04](https://user-images.githubusercontent.com/5273820/33091680-1c84f13a-cef8-11e7-80dc-384e8e0a1ca5.gif)
