### PR TITLE
Add nonblocking Formatting, RangeFormatting, ResolveCompletion

### DIFF
--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -76,7 +76,10 @@ define_dispatch_request_enum!(
     FindImpls,
     DocumentHighlight,
     Rename,
-    CodeAction
+    CodeAction,
+    ResolveCompletion,
+    Formatting,
+    RangeFormatting
 );
 
 /// Provides ability to dispatch requests to a worker thread that will
@@ -163,6 +166,7 @@ pub trait RequestAction: Action {
 }
 
 /// Wrapper for a response error
+#[derive(Debug)]
 pub enum ResponseError {
     /// Error with no special response to the client
     Empty,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -501,11 +501,11 @@ impl<O: Output> LsService<O> {
             blocking_requests:
                 ShutdownRequest,
                 InitializeRequest,
-                requests::ResolveCompletion,
-                requests::ExecuteCommand,
-                requests::Formatting,
-                requests::RangeFormatting;
+                requests::ExecuteCommand;
             requests:
+                requests::Formatting,
+                requests::RangeFormatting,
+                requests::ResolveCompletion,
                 requests::Rename,
                 requests::CodeAction,
                 requests::DocumentHighlight,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -552,7 +552,7 @@ fn test_reformat() {
     let text_doc = TextDocumentIdentifier::new(url);
     let messages = vec![
         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
-        blocking_request::<requests::Formatting>(
+        request::<requests::Formatting>(
             42,
             DocumentFormattingParams {
                 text_document: text_doc,
@@ -600,7 +600,7 @@ fn test_reformat_with_range() {
     let text_doc = TextDocumentIdentifier::new(url);
     let messages = vec![
         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
-        blocking_request::<requests::RangeFormatting>(
+        request::<requests::RangeFormatting>(
             42,
             DocumentRangeFormattingParams {
                 text_document: text_doc,


### PR DESCRIPTION
Move these requests to no longer block stdin (following #565), as we benefit from have all requests not block stdin.

* Formatting
* RangeFormatting
* ResolveCompletion

These requests will now be subject to the default timeout. 

As timeouts are feasible for any request (as they can be caused by the previous requests timing out), I'm not sure if I got the `fallback_response` impl right by returning an error. Perhaps in some cases we'd prefer to silently timeout?

```rust
Err(ResponseError::Message(
    ErrorCode::InternalError,
    "Reformat failed to complete successfully".into(),
))
```