### PR TITLE
Remove documentation of obsolete rustWorkspace/deglob command

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -328,6 +328,3 @@ The following request is to support Rust specific features.
 
 [`TextDocumentPositionParams`]: (https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#textdocumentpositionparams)
 [`Location`]: (https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#location)
-* `rustWorkspace/deglob`: message sent from the client to the RLS to initiate a
-  deglob refactoring.
-


### PR DESCRIPTION
I forgot about the documentation of custom RLS commands during https://github.com/rust-lang-nursery/rls/pull/567