### PR TITLE
Don't panic if we hit a cargo workspace when not in workspace mode

### DIFF
--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -142,7 +142,7 @@ fn run_cargo(
             // Warn about invalid specified bin target or package depending on current mode
             // TODO: Return client notifications along with diagnostics to inform the user
             if !rls_config.workspace_mode {
-                let cur_pkg_targets = ws.current().unwrap().targets();
+                let cur_pkg_targets = ws.current()?.targets();
 
                 if let &Some(ref build_bin) = rls_config.build_bin.as_ref() {
                     let mut bins = cur_pkg_targets.iter().filter(|x| x.is_bin());


### PR DESCRIPTION
Without this change, when RLS hits a cargo workspace, without being in workspace_mode, the following happens:

1.  ws.current() returns an error, unwrap() panics.
2.  The panic occurs while holding the rls_config lock, so the lock gets poisoned.
3.  The main thread panics the next time it attempts to lock the config.
4.  On my machine at least, this triggers Microsoft/vscode-languageserver-node#279 where the client experiences a sort of endless recursion, repeatedly trying to send a message to the server, and failing, which causes it to try again.  The vscode process eats up all of my memory, causing my machine to crawl until it finally pops up a bar saying that the extension host process was terminated.

With this change, RLS just doesn't really work when it hits a cargo workspace with workspace_mode off.  The lock never gets poisoned and the main thread never dies.

#556 seems very similar to this one, but the stack trace looks different.