### PR TITLE
Simplify BuildResult enum

### DIFF
--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -49,8 +49,7 @@ impl<O: Output> PostBuildHandler<O> {
         ));
 
         match result {
-            BuildResult::Success(messages, new_analysis)
-            | BuildResult::Failure(messages, new_analysis) => {
+            BuildResult::Success(messages, new_analysis) => {
                 thread::spawn(move || {
                     trace!("build - Success");
 

--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -476,8 +476,7 @@ impl Executor for RlsExecutor {
                 self.config.clone(),
                 env_lock,
             ) {
-                BuildResult::Success(mut messages, mut analysis)
-                | BuildResult::Failure(mut messages, mut analysis) => {
+                BuildResult::Success(mut messages, mut analysis) => {
                     self.compiler_messages.lock().unwrap().append(&mut messages);
                     self.analysis.lock().unwrap().append(&mut analysis);
                 }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -92,10 +92,9 @@ struct Internals {
 /// The result of a build request.
 #[derive(Debug)]
 pub enum BuildResult {
-    /// Build was successful, argument is warnings.
+    /// Build was performed without any internal errors. The payload
+    /// contains emitted raw diagnostics and Analysis data.
     Success(Vec<String>, Vec<Analysis>),
-    /// Build finished with errors, argument is errors and warnings.
-    Failure(Vec<String>, Vec<Analysis>),
     /// Build was coalesced with another build.
     Squashed,
     /// There was an error attempting to build.
@@ -421,7 +420,7 @@ impl Internals {
         // now. It's possible that a build was scheduled with given files, but
         // user later changed them. These should still be left as dirty (not built).
         match *&result {
-            BuildResult::Success(_, _) | BuildResult::Failure(_, _) => {
+            BuildResult::Success(_, _) => {
                 let mut dirty_files = self.dirty_files.lock().unwrap();
                 dirty_files.retain(|file, dirty_version| {
                     built_files

--- a/src/build/plan.rs
+++ b/src/build/plan.rs
@@ -361,8 +361,7 @@ impl JobQueue {
                 internals.config.clone(),
                 internals.env_lock.as_facade(),
             ) {
-                BuildResult::Success(mut messages, mut analysis)
-                | BuildResult::Failure(mut messages, mut analysis) => {
+                BuildResult::Success(mut messages, mut analysis) => {
                     compiler_messages.append(&mut messages);
                     analyses.append(&mut analysis);
                 }
@@ -370,8 +369,8 @@ impl JobQueue {
                 _ => {}
             }
         }
-        // TODO: Should we combine with ::Failure? What's the difference between those two?
-        return BuildResult::Success(compiler_messages, analyses);
+
+        BuildResult::Success(compiler_messages, analyses)
     }
 }
 


### PR DESCRIPTION
This removes the BuildResult::Failure variant. It was used
interchangeably with BuildResult::Success, and only returned in rustc()
routine when executed in-process compiler panicked or returned with a
non-zero exit code.

Since internally the compiler driver also panics on compile failure, the
BuildResult::{Failure, Success} variant distinction didn't give any
meaningful information, as the driver treats ICEs and regular compile
failures the same way. In both cases BuildResult::Failure was returned.

More correct solution would be not to panic on regular compile failure
in run_compiler, so the caller can either catch a panic and deduce that
an ICE was encountered, or receive a non-zero (101) exit code in case
errors were encountered.
Then a BuildResult::Err variant would be returned on an ICE, or
BuildResult::Success otherwise.

r? @nrc