### PR TITLE
Simplify outgoing notifications, remove NoParams

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -20,14 +20,16 @@ use span;
 use Span;
 
 use actions::post_build::{BuildResults, PostBuildHandler};
+use actions::notifications::BeginBuild;
 use build::*;
 use lsp_data::*;
-use server::Output;
+use server::{Output, Notification, NoParams};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::marker::PhantomData;
 
 
 // TODO: Support non-`file` URI schemes in VFS. We're currently ignoring them because
@@ -194,7 +196,10 @@ impl InitActionContext {
             }
         };
 
-        out.notify(NotificationMessage::new(NOTIFICATION_BUILD_BEGIN, None));
+        out.notify(Notification::<BeginBuild> {
+                        params: NoParams {},
+                        _action: PhantomData,
+        });
         self.build_queue
             .request_build(project_path, priority, move |result| pbh.handle(result));
     }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -29,7 +29,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::marker::PhantomData;
 
 
 // TODO: Support non-`file` URI schemes in VFS. We're currently ignoring them because
@@ -196,10 +195,7 @@ impl InitActionContext {
             }
         };
 
-        out.notify(Notification::<BeginBuild> {
-                        params: NoParams {},
-                        _action: PhantomData,
-        });
+        out.notify(Notification::<BeginBuild>::new(NoParams {}));
         self.build_queue
             .request_build(project_path, priority, move |result| pbh.handle(result));
     }

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -369,3 +369,54 @@ impl<'a> BlockingNotificationAction<'a> for DidChangeWatchedFiles {
         Ok(())
     }
 }
+
+/// Notification sent to client, used to publish file diagnostics
+/// (warnings, errors) from the server.
+#[derive(Debug)]
+pub struct PublishDiagnostics;
+
+impl Action for PublishDiagnostics {
+    type Params = PublishDiagnosticsParams;
+    const METHOD: &'static str = NOTIFICATION__PublishDiagnostics;
+}
+
+/// Notification sent to client, asking to show a specified message with a given type.
+#[derive(Debug)]
+pub struct ShowMessage;
+
+impl Action for ShowMessage {
+    type Params = ShowMessageParams;
+    const METHOD: &'static str = NOTIFICATION__ShowMessage;
+}
+
+/// Custom LSP notification sent to client indicating that the server is currently
+/// processing data and may publish new diagnostics on `rustDocument/diagnosticsEnd`.
+#[derive(Debug)]
+pub struct DiagnosticsBegin;
+
+impl Action for DiagnosticsBegin {
+    type Params = NoParams;
+    const METHOD: &'static str = "rustDocument/diagnosticsBegin";
+}
+
+/// Custom LSP notification sent to client indicating that data processing started
+/// by a `rustDocument`/diagnosticsBegin` has ended.
+/// For each `diagnosticsBegin` message, there is a single `diagnosticsEnd` message.
+/// This means that for multiple active `diagnosticsBegin` messages, there will
+/// be sent multiple `diagnosticsEnd` notifications.
+#[derive(Debug)]
+pub struct DiagnosticsEnd;
+
+impl Action for DiagnosticsEnd {
+    type Params = NoParams;
+    const METHOD: &'static str = "rustDocument/diagnosticsEnd";
+}
+
+/// Custom LSP notification sent to client indicating that a build process has begun.
+#[derive(Debug)]
+pub struct BeginBuild;
+
+impl Action for BeginBuild {
+    type Params = NoParams;
+    const METHOD: &'static str = "rustDocument/beginBuild";
+}

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::marker::PhantomData;
 
 use build::BuildResult;
 use lsp_data::{ls_util, PublishDiagnosticsParams};
@@ -42,10 +41,7 @@ pub struct PostBuildHandler<O: Output> {
 
 impl<O: Output> PostBuildHandler<O> {
     pub fn handle(self, result: BuildResult) {
-        self.out.notify(Notification::<DiagnosticsBegin> {
-            params: NoParams {},
-            _action: PhantomData,
-        });
+        self.out.notify(Notification::<DiagnosticsBegin>::new(NoParams {}));
 
         match result {
             BuildResult::Success(messages, new_analysis) => {
@@ -63,25 +59,16 @@ impl<O: Output> PostBuildHandler<O> {
                         self.reload_analysis_from_memory(new_analysis);
                     }
 
-                    self.out.notify(Notification::<DiagnosticsEnd> {
-                    params: NoParams {},
-                    _action: PhantomData,
-                });
+                    self.out.notify(Notification::<DiagnosticsEnd>::new(NoParams{}));
                 });
             }
             BuildResult::Squashed => {
                 trace!("build - Squashed");
-                self.out.notify(Notification::<DiagnosticsEnd> {
-                    params: NoParams {},
-                    _action: PhantomData,
-                });
+                self.out.notify(Notification::<DiagnosticsEnd>::new(NoParams{}));
             }
             BuildResult::Err => {
                 trace!("build - Error");
-                self.out.notify(Notification::<DiagnosticsEnd> {
-                    params: NoParams {},
-                    _action: PhantomData,
-                });
+                self.out.notify(Notification::<DiagnosticsEnd>::new(NoParams{}));
             }
         }
     }
@@ -258,9 +245,6 @@ fn emit_notifications<O: Output>(build_results: &BuildResults, show_warnings: bo
                 .collect(),
         };
 
-        out.notify(Notification::<PublishDiagnostics> {
-            params,
-            _action: PhantomData
-        });
+        out.notify(Notification::<PublishDiagnostics>::new(params));
     }
 }

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -25,13 +25,6 @@ use vfs::FileContents;
 pub use ls_types::*;
 use jsonrpc_core::version;
 
-/// Notification string for beginning diagnostics.
-pub const NOTIFICATION_DIAGNOSTICS_BEGIN: &'static str = "rustDocument/diagnosticsBegin";
-/// Notification string for ending diagnostics.
-pub const NOTIFICATION_DIAGNOSTICS_END: &'static str = "rustDocument/diagnosticsEnd";
-/// Notification string for when a build begins.
-pub const NOTIFICATION_BUILD_BEGIN: &'static str = "rustDocument/beginBuild";
-
 /// Errors that can occur when parsing a file URI.
 #[derive(Debug)]
 pub enum UrlFileParseError {

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -23,7 +23,6 @@ use racer;
 use vfs::FileContents;
 
 pub use ls_types::*;
-use jsonrpc_core::version;
 
 /// Errors that can occur when parsing a file URI.
 #[derive(Debug)]
@@ -259,27 +258,6 @@ impl Default for InitializationOptions {
     fn default() -> Self {
         InitializationOptions {
             omit_init_build: false,
-        }
-    }
-}
-
-/// An event-like (no response needed) notification message.
-#[derive(Debug, Serialize)]
-pub struct NotificationMessage {
-    jsonrpc: version::Version,
-    /// The well-known language server protocol notification method string.
-    pub method: &'static str,
-    /// Extra notification parameters.
-    pub params: Option<PublishDiagnosticsParams>,
-}
-
-impl NotificationMessage {
-    /// Construct a new notification message.
-    pub fn new(method: &'static str, params: Option<PublishDiagnosticsParams>) -> Self {
-        NotificationMessage {
-            jsonrpc: version::Version::V2,
-            method,
-            params,
         }
     }
 }

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -10,7 +10,7 @@
 
 use serde_json;
 
-use lsp_data::*;
+use super::{Action, Notification};
 
 use std::fmt;
 use std::io::{self, Read, Write};
@@ -143,8 +143,8 @@ pub trait Output: Sync + Send + Clone + 'static {
     }
 
     /// Send a notification along the output.
-    fn notify(&self, notification: NotificationMessage) {
-        self.response(serde_json::to_string(&notification).unwrap());
+    fn notify<A: Action>(&self, notification: Notification<A>) {
+        self.response(format!("{}", notification));
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -153,6 +153,16 @@ pub struct Notification<A: Action> {
     pub _action: PhantomData<A>,
 }
 
+impl<A: Action> Notification<A> {
+    /// Creates a `Notification` structure with given `params`.
+    pub fn new(params: A::Params) -> Notification<A> {
+        Notification {
+            params,
+            _action: PhantomData
+        }
+    }
+}
+
 impl<'a, A: BlockingRequestAction<'a>> Request<A> {
     fn blocking_dispatch<O: Output>(
         self,
@@ -678,10 +688,7 @@ mod test {
 
         assert_eq!(
             notification,
-            Ok(Notification::<notifications::Initialized> {
-                params: NoParams {},
-                _action: PhantomData,
-            })
+            Ok(Notification::<notifications::Initialized>::new(NoParams {}))
         );
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -191,7 +191,7 @@ impl<'a, A: Action> fmt::Display for Request<A> {
     }
 }
 
-impl<'a, A: BlockingNotificationAction<'a>> fmt::Display for Notification<A> {
+impl<'a, A: Action> fmt::Display for Notification<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         json!({
             "jsonrpc": "2.0",


### PR DESCRIPTION
Work towards #602. Since I'll want use different notifications (`window/showMessage`) than the currently hardcoded PublishDiagnostics and `rustDocument/*` ones, I tried to generalize the `Output::notify`, which is now easily possibly thanks to `Action` trait (thanks @alexheretic!).
The trait is generic enough (provides method and params type) to be easily reused, but it's not as clean as it could be - per documentation implementers are messages handled by the server (so client->server), whereas I added implementation of the ones sent to the client instead.

Ideally this should be solved using https://github.com/gluon-lang/languageserver-types/issues/19 (which I didn't do yet... :cry: ).

Additionally replaced `NoParams` with `()`, as these serve the same purpose and not to introduce another custom type.

r? @nrc