### PR TITLE
Update rustfmt dependency on the pathbuf branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rls-data = { version = "0.13", features = ["serialize-serde"] }
 rls-rustc = "0.1"
 rls-span = { version = "0.4", features = ["serialize-serde"] }
 rls-vfs = { version = "0.4", features = ["racer-impls"] }
-rustfmt-nightly = { version = "0.2.17", optional = true }
+rustfmt-nightly = { version = "0.3.0", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
merging with github with the `rebase` strategy (to not have a merge commit) should allow you to not have to manually push around commits on the command line.