### PR TITLE
Get tests working inside a workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jsonrpc-core"
-version = "7.1.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,7 +880,7 @@ dependencies = [
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 7.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "languageserver-types 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1453,7 +1453,7 @@ dependencies = [
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum jobserver 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "931b04e5e57d88cc909528f0d701db36a870b72a052648ded8baf80f9f445e0f"
 "checksum json 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)" = "39ebf0fac977ee3a4a3242b6446004ff64514889e3e2730bbd4f764a67a2e483"
-"checksum jsonrpc-core 7.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1acd0f9934da94466d2370f36832b9b19271b4abdfdb5e69f0bcd991ebcd515"
+"checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum languageserver-types 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "773e175c945800aeea4c21c04090bcb9db987b1a566ad9c6f569972299950e3e"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 cargo = { git = "https://github.com/rust-lang/cargo" }
 env_logger = "0.4"
 failure = "0.1.1"
-jsonrpc-core = "7.0.1"
+jsonrpc-core = "8.0.1"
 languageserver-types = "0.16"
 lazy_static = "0.2"
 log = "0.3"

--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -141,9 +141,15 @@ fn run_cargo(
             trace!("Cargo compilation options:\n{:?}", opts);
             let rustflags = prepare_cargo_rustflags(&rls_config);
 
-            // Warn about invalid specified bin target or package depending on current mode
-            // TODO: Return client notifications along with diagnostics to inform the user
-            if !rls_config.workspace_mode {
+            if rls_config.workspace_mode {
+                for package in &opts.packages {
+                    if let None = ws.members().find(|x| x.name() == package) {
+                        warn!("cargo - couldn't find member package `{}` specified in `analyze_package` configuration", package);
+                    }
+                }
+            } else {
+                // Warn about invalid specified bin target or package depending on current mode
+                // TODO: Return client notifications along with diagnostics to inform the user
                 let cur_pkg_targets = ws.current()?.targets();
 
                 if let &Some(ref build_bin) = rls_config.build_bin.as_ref() {
@@ -152,22 +158,16 @@ fn run_cargo(
                         warn!("cargo - couldn't find binary `{}` specified in `build_bin` configuration", build_bin);
                     }
                 }
-            } else {
-                for package in &opts.package {
-                    if let None = ws.members().find(|x| x.name() == package) {
-                        warn!("cargo - couldn't find member package `{}` specified in `analyze_package` configuration", package);
-                    }
-                }
             }
 
             (opts, rustflags, rls_config.clear_env_rust_log)
         };
 
-    let spec = Packages::from_flags(opts.all, &opts.exclude, &opts.package)?;
+    let spec = Packages::from_flags(false, &[], &opts.packages)?;
 
     let compile_opts = CompileOptions {
         target: opts.target.as_ref().map(|t| &t[..]),
-        spec: spec,
+        spec,
         filter: CompileFilter::new(
             opts.lib,
             &opts.bin,
@@ -504,13 +504,11 @@ impl Executor for RlsExecutor {
 
 #[derive(Debug)]
 struct CargoOptions {
-    package: Vec<String>,
+    packages: Vec<String>,
     target: Option<String>,
     lib: bool,
     bin: Vec<String>,
     bins: bool,
-    all: bool,
-    exclude: Vec<String>,
     all_features: bool,
     no_default_features: bool,
     features: Vec<String>,
@@ -520,13 +518,11 @@ struct CargoOptions {
 impl Default for CargoOptions {
     fn default() -> CargoOptions {
         CargoOptions {
-            package: vec![],
+            packages: vec![],
             target: None,
             lib: false,
             bin: vec![],
             bins: false,
-            all: false,
-            exclude: vec![],
             all_features: false,
             no_default_features: false,
             features: vec![],
@@ -538,14 +534,14 @@ impl Default for CargoOptions {
 impl CargoOptions {
     fn new(config: &Config) -> CargoOptions {
         if config.workspace_mode {
-            let (package, all) = match config.analyze_package {
+            // If packages is empty, then we check the entire workspace.
+            let (packages, _all) = match config.analyze_package {
                 Some(ref pkg_name) => (vec![pkg_name.clone()], false),
-                None => (vec![], true),
+                None => (vec![], false),
             };
 
             CargoOptions {
-                package,
-                all,
+                packages,
                 target: config.target.clone(),
                 features: config.features.clone(),
                 all_features: config.all_features,

--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -141,13 +141,7 @@ fn run_cargo(
             trace!("Cargo compilation options:\n{:?}", opts);
             let rustflags = prepare_cargo_rustflags(&rls_config);
 
-            if rls_config.workspace_mode {
-                for package in &opts.packages {
-                    if let None = ws.members().find(|x| x.name() == package) {
-                        warn!("cargo - couldn't find member package `{}` specified in `analyze_package` configuration", package);
-                    }
-                }
-            } else {
+            if !rls_config.workspace_mode {
                 // Warn about invalid specified bin target or package depending on current mode
                 // TODO: Return client notifications along with diagnostics to inform the user
                 let cur_pkg_targets = ws.current()?.targets();
@@ -163,7 +157,7 @@ fn run_cargo(
             (opts, rustflags, rls_config.clear_env_rust_log)
         };
 
-    let spec = Packages::from_flags(false, &[], &opts.packages)?;
+    let spec = Packages::from_flags(false, &[], &[])?;
 
     let compile_opts = CompileOptions {
         target: opts.target.as_ref().map(|t| &t[..]),
@@ -504,7 +498,6 @@ impl Executor for RlsExecutor {
 
 #[derive(Debug)]
 struct CargoOptions {
-    packages: Vec<String>,
     target: Option<String>,
     lib: bool,
     bin: Vec<String>,
@@ -518,7 +511,6 @@ struct CargoOptions {
 impl Default for CargoOptions {
     fn default() -> CargoOptions {
         CargoOptions {
-            packages: vec![],
             target: None,
             lib: false,
             bin: vec![],
@@ -534,14 +526,7 @@ impl Default for CargoOptions {
 impl CargoOptions {
     fn new(config: &Config) -> CargoOptions {
         if config.workspace_mode {
-            // If packages is empty, then we check the entire workspace.
-            let (packages, _all) = match config.analyze_package {
-                Some(ref pkg_name) => (vec![pkg_name.clone()], false),
-                None => (vec![], false),
-            };
-
             CargoOptions {
-                packages,
                 target: config.target.clone(),
                 features: config.features.clone(),
                 all_features: config.all_features,

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,7 +120,6 @@ pub struct Config {
     pub show_warnings: bool,
     pub goto_def_racer_fallback: bool,
     pub workspace_mode: bool,
-    pub analyze_package: Option<String>,
     /// Clear the RUST_LOG env variable before calling rustc/cargo? Default: true
     pub clear_env_rust_log: bool,
     /// Build the project only when a file got saved and not on file change. Default: false
@@ -149,7 +148,6 @@ impl Default for Config {
             show_warnings: true,
             goto_def_racer_fallback: false,
             workspace_mode: true,
-            analyze_package: None,
             clear_env_rust_log: true,
             build_on_save: false,
             use_crate_blacklist: true,
@@ -214,26 +212,9 @@ impl Config {
 
         let ws = Workspace::new(&manifest_path, &cargo_config)?;
 
-        // Auto-detect --lib/--bin switch if working under single package mode
-        // or under workspace mode with `analyze_package` specified
+        // Auto-detect --lib/--bin switch if working under single package mode.
         let package = match self.workspace_mode {
-            true => {
-                let package_name = match self.analyze_package {
-                    // No package specified, nothing to do
-                    None => {
-                        return Ok(());
-                    }
-                    Some(ref package) => package,
-                };
-
-                ws.members()
-                    .find(move |x| x.name() == package_name)
-                    .ok_or(format_err!(
-                        "Couldn't find specified `{}` package via \
-                         `analyze_package` in the workspace",
-                        package_name
-                    ))?
-            }
+            true => return Ok(()),
             false => ws.current()?,
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,7 +148,7 @@ impl Default for Config {
             wait_to_build: DEFAULT_WAIT_TO_BUILD,
             show_warnings: true,
             goto_def_racer_fallback: false,
-            workspace_mode: false,
+            workspace_mode: true,
             analyze_package: None,
             clear_env_rust_log: true,
             build_on_save: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@
 #![feature(type_ascription)]
 #![feature(integer_atomics)]
 #![feature(fnbox)]
-#![deny(missing_docs)]
 
 extern crate cargo;
 extern crate env_logger;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -679,7 +679,7 @@ fn test_multiple_binaries() {
             ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
             // These messages should be about bin_name1 and bin_name2, but the order is
             // not deterministic FIXME(#606)
-            // ExpectedMessage::new(None).expect_contains("unused variable: `bin_name"),
+            ExpectedMessage::new(None).expect_contains("unused variable: `bin_name"),
             ExpectedMessage::new(None).expect_contains("unused variable: `bin_name"),
             ExpectedMessage::new(None).expect_contains("diagnosticsEnd"),
         ],


### PR DESCRIPTION
This should allow us to have workspaces on by default inside the Rust repo.

r? @Xanewok 

The significant change here is that we no longer specify a package to Cargo and trust that it will do the right thing - when in the workspace root it will build everything and when in a sub-crate, just build that crate (and its deps). This was pretty easy because of changes to Cargo since the original work.