### PR TITLE
Use message traits from languageserver-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "languageserver-types"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -881,7 +881,7 @@ dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "languageserver-types 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "languageserver-types 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1455,7 +1455,7 @@ dependencies = [
 "checksum json 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)" = "39ebf0fac977ee3a4a3242b6446004ff64514889e3e2730bbd4f764a67a2e483"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum languageserver-types 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "773e175c945800aeea4c21c04090bcb9db987b1a566ad9c6f569972299950e3e"
+"checksum languageserver-types 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15a4c0850f6ddf7298201ccabdcad644f14fa607302a04ccb91540fce4ad101d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ cargo = { git = "https://github.com/rust-lang/cargo" }
 env_logger = "0.4"
 failure = "0.1.1"
 jsonrpc-core = "8.0.1"
-languageserver-types = "0.16"
+languageserver-types = "0.17"
 lazy_static = "0.2"
 log = "0.3"
 racer = "2.0.12"

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -41,11 +41,7 @@ use std::thread;
 impl BlockingNotificationAction for Initialized {
     // Respond to the `initialized` notification. We take this opportunity to
     // dynamically register some options.
-    fn handle<O: Output>(
-        _params: Self::Params,
-        ctx: &mut ActionContext,
-        out: O,
-    ) -> Result<(), ()> {
+    fn handle<O: Output>(_params: Self::Params, ctx: &mut ActionContext, out: O) -> Result<(), ()> {
         const WATCH_ID: &'static str = "rls-watch";
 
         let ctx = ctx.inited();
@@ -70,11 +66,7 @@ impl BlockingNotificationAction for Initialized {
 }
 
 impl BlockingNotificationAction for DidOpenTextDocument {
-    fn handle<O: Output>(
-        params: Self::Params,
-        ctx: &mut ActionContext,
-        _out: O,
-    ) -> Result<(), ()> {
+    fn handle<O: Output>(params: Self::Params, ctx: &mut ActionContext, _out: O) -> Result<(), ()> {
         trace!("on_open: {:?}", params.text_document.uri);
         let ctx = ctx.inited();
         let file_path = parse_file_path!(&params.text_document.uri, "on_open")?;
@@ -85,11 +77,7 @@ impl BlockingNotificationAction for DidOpenTextDocument {
 }
 
 impl BlockingNotificationAction for DidChangeTextDocument {
-    fn handle<O: Output>(
-        params: Self::Params,
-        ctx: &mut ActionContext,
-        out: O,
-    ) -> Result<(), ()> {
+    fn handle<O: Output>(params: Self::Params, ctx: &mut ActionContext, out: O) -> Result<(), ()> {
         trace!(
             "on_change: {:?}, thread: {:?}",
             params,

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -21,28 +21,27 @@ use Span;
 
 use build::*;
 use lsp_data::*;
-use server::{Action, BlockingNotificationAction, LsState, NoParams, Output};
+use lsp_data::request::{Request, RangeFormatting};
+use lsp_data::notification::{Notification, RegisterCapability, UnregisterCapability};
+
+pub use lsp_data::notification::{
+    Initialized,
+    DidOpenTextDocument,
+    DidChangeTextDocument,
+    DidSaveTextDocument,
+    DidChangeConfiguration,
+    DidChangeWatchedFiles,
+    Cancel,
+};
+
+use server::{BlockingNotificationAction, Output};
 
 use std::thread;
 
-/// Notification from the client that it has completed initialization.
-#[derive(Debug, PartialEq)]
-pub struct Initialized;
-
-impl Action for Initialized {
-    type Params = NoParams;
-    const METHOD: &'static str = "initialized";
-}
-
-impl<'a> BlockingNotificationAction<'a> for Initialized {
-    fn new(_: &'a mut LsState) -> Self {
-        Initialized
-    }
-
+impl BlockingNotificationAction for Initialized {
     // Respond to the `initialized` notification. We take this opportunity to
     // dynamically register some options.
     fn handle<O: Output>(
-        &mut self,
         _params: Self::Params,
         ctx: &mut ActionContext,
         out: O,
@@ -54,12 +53,12 @@ impl<'a> BlockingNotificationAction<'a> for Initialized {
         let options = FileWatch::new(&ctx).watchers_config();
         let output = serde_json::to_string(&RequestMessage::new(
             out.provide_id(),
-            NOTIFICATION__RegisterCapability.to_owned(),
+            <RegisterCapability as Notification>::METHOD.to_owned(),
             RegistrationParams {
                 registrations: vec![
                     Registration {
                         id: WATCH_ID.to_owned(),
-                        method: NOTIFICATION__DidChangeWatchedFiles.to_owned(),
+                        method: <DidChangeWatchedFiles as Notification>::METHOD.to_owned(),
                         register_options: options,
                     },
                 ],
@@ -70,23 +69,8 @@ impl<'a> BlockingNotificationAction<'a> for Initialized {
     }
 }
 
-/// Notification from the client that the given text document has been
-/// opened. The client is responsible for managing its clean up.
-#[derive(Debug)]
-pub struct DidOpen;
-
-impl Action for DidOpen {
-    type Params = DidOpenTextDocumentParams;
-    const METHOD: &'static str = "textDocument/didOpen";
-}
-
-impl<'a> BlockingNotificationAction<'a> for DidOpen {
-    fn new(_: &'a mut LsState) -> Self {
-        DidOpen
-    }
-
+impl BlockingNotificationAction for DidOpenTextDocument {
     fn handle<O: Output>(
-        &mut self,
         params: Self::Params,
         ctx: &mut ActionContext,
         _out: O,
@@ -100,22 +84,8 @@ impl<'a> BlockingNotificationAction<'a> for DidOpen {
     }
 }
 
-/// Notification from the client that the given document changed.
-#[derive(Debug)]
-pub struct DidChange;
-
-impl Action for DidChange {
-    type Params = DidChangeTextDocumentParams;
-    const METHOD: &'static str = "textDocument/didChange";
-}
-
-impl<'a> BlockingNotificationAction<'a> for DidChange {
-    fn new(_: &'a mut LsState) -> Self {
-        DidChange
-    }
-
+impl BlockingNotificationAction for DidChangeTextDocument {
     fn handle<O: Output>(
-        &mut self,
         params: Self::Params,
         ctx: &mut ActionContext,
         out: O,
@@ -163,22 +133,8 @@ impl<'a> BlockingNotificationAction<'a> for DidChange {
     }
 }
 
-/// Notification from the client that they've canceled their previous request.
-#[derive(Debug)]
-pub struct Cancel;
-
-impl Action for Cancel {
-    type Params = CancelParams;
-    const METHOD: &'static str = "$/cancelRequest";
-}
-
-impl<'a> BlockingNotificationAction<'a> for Cancel {
-    fn new(_: &'a mut LsState) -> Self {
-        Cancel
-    }
-
+impl BlockingNotificationAction for Cancel {
     fn handle<O: Output>(
-        &mut self,
         _params: CancelParams,
         _ctx: &mut ActionContext,
         _out: O,
@@ -188,23 +144,8 @@ impl<'a> BlockingNotificationAction<'a> for Cancel {
     }
 }
 
-/// Notification from the client that the workspace's configuration settings
-/// changed.
-#[derive(Debug)]
-pub struct DidChangeConfiguration;
-
-impl Action for DidChangeConfiguration {
-    type Params = DidChangeConfigurationParams;
-    const METHOD: &'static str = "workspace/didChangeConfiguration";
-}
-
-impl<'a> BlockingNotificationAction<'a> for DidChangeConfiguration {
-    fn new(_: &'a mut LsState) -> Self {
-        DidChangeConfiguration
-    }
-
+impl BlockingNotificationAction for DidChangeConfiguration {
     fn handle<O: Output>(
-        &mut self,
         params: DidChangeConfigurationParams,
         ctx: &mut ActionContext,
         out: O,
@@ -272,12 +213,12 @@ impl<'a> BlockingNotificationAction<'a> for DidChangeConfiguration {
         if unstable_features {
             let output = serde_json::to_string(&RequestMessage::new(
                 out.provide_id(),
-                NOTIFICATION__RegisterCapability.to_owned(),
+                <RegisterCapability as Notification>::METHOD.to_owned(),
                 RegistrationParams {
                     registrations: vec![
                         Registration {
                             id: RANGE_FORMATTING_ID.to_owned(),
-                            method: REQUEST__RangeFormatting.to_owned(),
+                            method: <RangeFormatting as Request>::METHOD.to_owned(),
                             register_options: serde_json::Value::Null,
                         },
                     ],
@@ -287,12 +228,12 @@ impl<'a> BlockingNotificationAction<'a> for DidChangeConfiguration {
         } else {
             let output = serde_json::to_string(&RequestMessage::new(
                 out.provide_id(),
-                NOTIFICATION__UnregisterCapability.to_owned(),
+                <UnregisterCapability as Notification>::METHOD.to_owned(),
                 UnregistrationParams {
                     unregisterations: vec![
                         Unregistration {
                             id: RANGE_FORMATTING_ID.to_owned(),
-                            method: REQUEST__RangeFormatting.to_owned(),
+                            method: <RangeFormatting as Request>::METHOD.to_owned(),
                         },
                     ],
                 },
@@ -303,22 +244,8 @@ impl<'a> BlockingNotificationAction<'a> for DidChangeConfiguration {
     }
 }
 
-/// Notification from the client that the given text document was saved.
-#[derive(Debug)]
-pub struct DidSave;
-
-impl Action for DidSave {
-    type Params = DidSaveTextDocumentParams;
-    const METHOD: &'static str = "textDocument/didSave";
-}
-
-impl<'a> BlockingNotificationAction<'a> for DidSave {
-    fn new(_: &'a mut LsState) -> Self {
-        DidSave
-    }
-
+impl BlockingNotificationAction for DidSaveTextDocument {
     fn handle<O: Output>(
-        &mut self,
         params: DidSaveTextDocumentParams,
         ctx: &mut ActionContext,
         out: O,
@@ -336,23 +263,8 @@ impl<'a> BlockingNotificationAction<'a> for DidSave {
     }
 }
 
-/// Notification from the client that there were changes to files that are being
-/// watched.
-#[derive(Debug)]
-pub struct DidChangeWatchedFiles;
-
-impl Action for DidChangeWatchedFiles {
-    type Params = DidChangeWatchedFilesParams;
-    const METHOD: &'static str = "workspace/didChangeWatchedFiles";
-}
-
-impl<'a> BlockingNotificationAction<'a> for DidChangeWatchedFiles {
-    fn new(_: &'a mut LsState) -> Self {
-        DidChangeWatchedFiles
-    }
-
+impl BlockingNotificationAction for DidChangeWatchedFiles {
     fn handle<O: Output>(
-        &mut self,
         params: DidChangeWatchedFilesParams,
         ctx: &mut ActionContext,
         out: O,
@@ -368,55 +280,4 @@ impl<'a> BlockingNotificationAction<'a> for DidChangeWatchedFiles {
 
         Ok(())
     }
-}
-
-/// Notification sent to client, used to publish file diagnostics
-/// (warnings, errors) from the server.
-#[derive(Debug)]
-pub struct PublishDiagnostics;
-
-impl Action for PublishDiagnostics {
-    type Params = PublishDiagnosticsParams;
-    const METHOD: &'static str = NOTIFICATION__PublishDiagnostics;
-}
-
-/// Notification sent to client, asking to show a specified message with a given type.
-#[derive(Debug)]
-pub struct ShowMessage;
-
-impl Action for ShowMessage {
-    type Params = ShowMessageParams;
-    const METHOD: &'static str = NOTIFICATION__ShowMessage;
-}
-
-/// Custom LSP notification sent to client indicating that the server is currently
-/// processing data and may publish new diagnostics on `rustDocument/diagnosticsEnd`.
-#[derive(Debug)]
-pub struct DiagnosticsBegin;
-
-impl Action for DiagnosticsBegin {
-    type Params = NoParams;
-    const METHOD: &'static str = "rustDocument/diagnosticsBegin";
-}
-
-/// Custom LSP notification sent to client indicating that data processing started
-/// by a `rustDocument`/diagnosticsBegin` has ended.
-/// For each `diagnosticsBegin` message, there is a single `diagnosticsEnd` message.
-/// This means that for multiple active `diagnosticsBegin` messages, there will
-/// be sent multiple `diagnosticsEnd` notifications.
-#[derive(Debug)]
-pub struct DiagnosticsEnd;
-
-impl Action for DiagnosticsEnd {
-    type Params = NoParams;
-    const METHOD: &'static str = "rustDocument/diagnosticsEnd";
-}
-
-/// Custom LSP notification sent to client indicating that a build process has begun.
-#[derive(Debug)]
-pub struct BeginBuild;
-
-impl Action for BeginBuild {
-    type Params = NoParams;
-    const METHOD: &'static str = "rustDocument/beginBuild";
 }

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -27,8 +27,24 @@ use rayon;
 use lsp_data;
 use lsp_data::*;
 use server;
-use server::{Ack, Action, Output, RequestAction, ResponseError};
+use server::{Ack, Output, RequestAction, ResponseError};
 use jsonrpc_core::types::ErrorCode;
+
+use ls_types;
+pub use ls_types::request::WorkspaceSymbol;
+pub use ls_types::request::DocumentSymbol as Symbols;
+pub use ls_types::request::HoverRequest as Hover;
+pub use ls_types::request::GotoDefinition as Definition;
+pub use ls_types::request::References;
+pub use ls_types::request::Completion;
+pub use ls_types::request::DocumentHighlightRequest as DocumentHighlight;
+pub use ls_types::request::Rename;
+pub use ls_types::request::ExecuteCommand;
+pub use ls_types::request::CodeActionRequest as CodeAction;
+pub use ls_types::request::Formatting;
+pub use ls_types::request::RangeFormatting;
+pub use ls_types::request::ResolveCompletionItem as ResolveCompletion;
+pub use lsp_data::FindImpls;
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -46,27 +62,14 @@ pub struct DeglobResult {
     pub new_text: String,
 }
 
-/// A request for information about a symbol in this workspace.
-pub struct WorkspaceSymbol;
-
-impl Action for WorkspaceSymbol {
-    type Params = lsp_data::WorkspaceSymbolParams;
-    const METHOD: &'static str = "workspace/symbol";
-}
-
 impl RequestAction for WorkspaceSymbol {
     type Response = Vec<SymbolInformation>;
 
-    fn new() -> Self {
-        WorkspaceSymbol
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Ok(vec![])
     }
 
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -91,27 +94,14 @@ impl RequestAction for WorkspaceSymbol {
     }
 }
 
-/// A request for a flat list of all symbols found in a given text document.
-pub struct Symbols;
-
-impl Action for Symbols {
-    type Params = DocumentSymbolParams;
-    const METHOD: &'static str = "textDocument/documentSymbol";
-}
-
 impl RequestAction for Symbols {
     type Response = Vec<SymbolInformation>;
 
-    fn new() -> Self {
-        Symbols
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Ok(vec![])
     }
 
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -135,22 +125,10 @@ impl RequestAction for Symbols {
     }
 }
 
-/// Handles requests for hover information at a given point.
-pub struct Hover;
-
-impl Action for Hover {
-    type Params = TextDocumentPositionParams;
-    const METHOD: &'static str = "textDocument/hover";
-}
-
 impl RequestAction for Hover {
     type Response = lsp_data::Hover;
 
-    fn new() -> Self {
-        Hover
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Ok(lsp_data::Hover {
             contents: HoverContents::Array(vec![]),
             range: None,
@@ -158,7 +136,6 @@ impl RequestAction for Hover {
     }
 
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -189,27 +166,14 @@ impl RequestAction for Hover {
     }
 }
 
-/// Find all the implementations of a given trait.
-pub struct FindImpls;
-
-impl Action for FindImpls {
-    type Params = TextDocumentPositionParams;
-    const METHOD: &'static str = "rustDocument/implementations";
-}
-
 impl RequestAction for FindImpls {
     type Response = Vec<Location>;
 
-    fn new() -> Self {
-        FindImpls
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Ok(vec![])
     }
 
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -236,27 +200,14 @@ impl RequestAction for FindImpls {
     }
 }
 
-/// Get a list of definitions for item at the given point or identifier.
-pub struct Definition;
-
-impl Action for Definition {
-    type Params = TextDocumentPositionParams;
-    const METHOD: &'static str = "textDocument/definition";
-}
-
 impl RequestAction for Definition {
     type Response = Vec<Location>;
 
-    fn new() -> Self {
-        Definition
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Ok(vec![])
     }
 
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -298,35 +249,22 @@ impl RequestAction for Definition {
                         trace!("goto_def (Racer): None");
                         return Ok(vec![]);
                     }
-                    _ => self.fallback_response(),
+                    _ => Self::fallback_response(),
                 },
-                _ => self.fallback_response(),
+                _ => Self::fallback_response(),
             },
         }
     }
 }
 
-/// Find references to the symbol at the given point throughout the project.
-pub struct References;
-
-impl Action for References {
-    type Params = ReferenceParams;
-    const METHOD: &'static str = "textDocument/references";
-}
-
 impl RequestAction for References {
     type Response = Vec<Location>;
 
-    fn new() -> Self {
-        References
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Ok(vec![])
     }
 
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -349,27 +287,14 @@ impl RequestAction for References {
     }
 }
 
-/// Get a list of possible completions at the given location.
-pub struct Completion;
-
-impl Action for Completion {
-    type Params = TextDocumentPositionParams;
-    const METHOD: &'static str = "textDocument/completion";
-}
-
 impl RequestAction for Completion {
     type Response = Vec<CompletionItem>;
 
-    fn new() -> Self {
-        Completion
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Ok(vec![])
     }
 
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -403,29 +328,14 @@ impl RequestAction for Completion {
     }
 }
 
-/// Find all references to the thing at the given location within this document,
-/// so they can be highlighted in the editor. In practice, this is very similar
-/// to `References`.
-pub struct DocumentHighlight;
-
-impl Action for DocumentHighlight {
-    type Params = TextDocumentPositionParams;
-    const METHOD: &'static str = "textDocument/documentHighlight";
-}
-
 impl RequestAction for DocumentHighlight {
     type Response = Vec<lsp_data::DocumentHighlight>;
 
-    fn new() -> Self {
-        DocumentHighlight
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Ok(vec![])
     }
 
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -454,29 +364,16 @@ impl RequestAction for DocumentHighlight {
     }
 }
 
-/// Rename the given symbol within the whole project.
-pub struct Rename;
-
-impl Action for Rename {
-    type Params = RenameParams;
-    const METHOD: &'static str = "textDocument/rename";
-}
-
 impl RequestAction for Rename {
     type Response = WorkspaceEdit;
 
-    fn new() -> Self {
-        Rename
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Ok(WorkspaceEdit {
             changes: HashMap::new(),
         })
     }
 
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -494,7 +391,7 @@ impl RequestAction for Rename {
                 match $e {
                     Ok(e) => e,
                     Err(_) => {
-                        return self.fallback_response();
+                        return Self::fallback_response();
                     }
                 }
             }
@@ -506,7 +403,7 @@ impl RequestAction for Rename {
             // FIXME(#578)
             || def.kind == data::DefKind::Mod
         {
-            return self.fallback_response();
+            return Self::fallback_response();
         }
 
         let result = unwrap_or_fallback!(analysis.find_all_refs(&span, true, true));
@@ -528,21 +425,11 @@ impl RequestAction for Rename {
     }
 }
 
-/// Execute a command within the workspace.
-///
-/// These are *not* shell commands, but commands given by the client and
-/// performed by the RLS.
-///
-/// Currently supports "rls.applySuggestion", "rls.deglobImports".
-pub struct ExecuteCommand;
-
-///
 #[derive(Debug)]
 pub enum ExecuteCommandResponse {
     /// Response/client request containing workspace edits.
     ApplyEdit(ApplyWorkspaceEditParams),
 }
-
 
 impl server::Response for ExecuteCommandResponse {
     fn send<O: Output>(&self, id: usize, out: &O) {
@@ -566,24 +453,16 @@ impl server::Response for ExecuteCommandResponse {
     }
 }
 
-impl Action for ExecuteCommand {
-    type Params = ExecuteCommandParams;
-    const METHOD: &'static str = "workspace/executeCommand";
-}
 
 impl RequestAction for ExecuteCommand {
     type Response = ExecuteCommandResponse;
 
-    fn new() -> Self {
-        ExecuteCommand
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Err(ResponseError::Empty)
     }
 
+    /// Currently supports "rls.applySuggestion", "rls.deglobImports".
     fn handle(
-        &mut self,
         _: InitActionContext,
         params: ExecuteCommandParams,
     ) -> Result<Self::Response, ResponseError> {
@@ -645,124 +524,108 @@ fn apply_deglobs(args: Vec<serde_json::Value>) -> Result<ApplyWorkspaceEditParam
     Ok(ApplyWorkspaceEditParams { edit })
 }
 
-/// Get a list of actions that can be performed on a specific document and range
-/// of text by the server.
-pub struct CodeAction;
-
-impl CodeAction {
-    /// Create CodeActions for fixes suggested by the compiler
-    /// the results are appended to `code_actions_result`
-    fn make_suggestion_fix_actions(
-        params: &<Self as Action>::Params,
-        file_path: &Path,
-        ctx: &InitActionContext,
-        code_actions_result: &mut <Self as RequestAction>::Response,
-    ) {
-        // search for compiler suggestions
-        if let Some(diagnostics) = ctx.previous_build_results.lock().unwrap().get(file_path) {
-            let suggestions = diagnostics
-                .iter()
-                .filter(|&&(ref d, _)| d.range.overlaps(&params.range))
-                .flat_map(|&(_, ref ss)| ss.iter());
-            for s in suggestions {
-                let span = Location {
-                    uri: params.text_document.uri.clone(),
-                    range: s.range,
-                };
-                let span = serde_json::to_value(&span).unwrap();
-                let new_text = serde_json::to_value(&s.new_text).unwrap();
-                let cmd = Command {
-                    title: s.label.clone(),
-                    command: "rls.applySuggestion".to_owned(),
-                    arguments: Some(vec![span, new_text]),
-                };
-                code_actions_result.push(cmd);
-            }
+/// Create CodeActions for fixes suggested by the compiler
+/// the results are appended to `code_actions_result`
+fn make_suggestion_fix_actions(
+    params: &<CodeAction as ls_types::request::Request>::Params,
+    file_path: &Path,
+    ctx: &InitActionContext,
+    code_actions_result: &mut <CodeAction as RequestAction>::Response,
+) {
+    // search for compiler suggestions
+    if let Some(diagnostics) = ctx.previous_build_results.lock().unwrap().get(file_path) {
+        let suggestions = diagnostics
+            .iter()
+            .filter(|&&(ref d, _)| d.range.overlaps(&params.range))
+            .flat_map(|&(_, ref ss)| ss.iter());
+        for s in suggestions {
+            let span = Location {
+                uri: params.text_document.uri.clone(),
+                range: s.range,
+            };
+            let span = serde_json::to_value(&span).unwrap();
+            let new_text = serde_json::to_value(&s.new_text).unwrap();
+            let cmd = Command {
+                title: s.label.clone(),
+                command: "rls.applySuggestion".to_owned(),
+                arguments: Some(vec![span, new_text]),
+            };
+            code_actions_result.push(cmd);
         }
-    }
-
-    /// Create CodeActions for performing deglobbing when a wildcard import is found
-    /// the results are appended to `code_actions_result`
-    fn make_deglob_actions(
-        params: &<Self as Action>::Params,
-        file_path: &Path,
-        ctx: &InitActionContext,
-        code_actions_result: &mut <Self as RequestAction>::Response,
-    ) {
-        // search for a glob in the line
-        if let Ok(line) = ctx.vfs
-            .load_line(file_path, ls_util::range_to_rls(params.range).row_start)
-        {
-            let span = Location::new(params.text_document.uri.clone(), params.range);
-
-            // for all indices which are a `*`
-            // check if we can deglob them
-            // this handles badly formated text containing multiple "use"s in one line
-            let deglob_results: Vec<_> = line.char_indices()
-                .filter(|&(_, chr)| chr == '*')
-                .filter_map(|(index, _)| {
-                    // map the indices to `Span`s
-                    let mut span = ls_util::location_to_rls(span.clone()).unwrap();
-                    span.range.col_start = span::Column::new_zero_indexed(index as u32);
-                    span.range.col_end = span::Column::new_zero_indexed(index as u32 + 1);
-
-                    // load the deglob type information
-                    ctx.analysis.show_type(&span)
-                    // remove all errors
-                    .ok()
-                    .map(|ty| (ty, span))
-                })
-                .map(|(mut deglob_str, span)| {
-                    // Handle multiple imports from one *
-                    if deglob_str.contains(',') {
-                        deglob_str = format!("{{{}}}", deglob_str);
-                    }
-
-                    // build result
-                    let deglob_result = DeglobResult {
-                        location: ls_util::rls_to_location(&span),
-                        new_text: deglob_str,
-                    };
-
-                    // convert to json
-                    serde_json::to_value(&deglob_result).unwrap()
-                })
-                .collect();
-
-            if !deglob_results.is_empty() {
-                // extend result list
-                let cmd = Command {
-                    title: format!(
-                        "Deglob Import{}",
-                        if deglob_results.len() > 1 { "s" } else { "" }
-                    ),
-                    command: "rls.deglobImports".to_owned(),
-                    arguments: Some(deglob_results),
-                };
-                code_actions_result.push(cmd);
-            }
-        };
     }
 }
 
-impl Action for CodeAction {
-    type Params = CodeActionParams;
-    const METHOD: &'static str = "textDocument/codeAction";
+/// Create CodeActions for performing deglobbing when a wildcard import is found
+/// the results are appended to `code_actions_result`
+fn make_deglob_actions(
+    params: &<CodeAction as ls_types::request::Request>::Params,
+    file_path: &Path,
+    ctx: &InitActionContext,
+    code_actions_result: &mut <CodeAction as RequestAction>::Response,
+) {
+    // search for a glob in the line
+    if let Ok(line) = ctx.vfs
+        .load_line(file_path, ls_util::range_to_rls(params.range).row_start)
+    {
+        let span = Location::new(params.text_document.uri.clone(), params.range);
+
+        // for all indices which are a `*`
+        // check if we can deglob them
+        // this handles badly formated text containing multiple "use"s in one line
+        let deglob_results: Vec<_> = line.char_indices()
+            .filter(|&(_, chr)| chr == '*')
+            .filter_map(|(index, _)| {
+                // map the indices to `Span`s
+                let mut span = ls_util::location_to_rls(span.clone()).unwrap();
+                span.range.col_start = span::Column::new_zero_indexed(index as u32);
+                span.range.col_end = span::Column::new_zero_indexed(index as u32 + 1);
+
+                // load the deglob type information
+                ctx.analysis.show_type(&span)
+                // remove all errors
+                .ok()
+                .map(|ty| (ty, span))
+            })
+            .map(|(mut deglob_str, span)| {
+                // Handle multiple imports from one *
+                if deglob_str.contains(',') {
+                    deglob_str = format!("{{{}}}", deglob_str);
+                }
+
+                // build result
+                let deglob_result = DeglobResult {
+                    location: ls_util::rls_to_location(&span),
+                    new_text: deglob_str,
+                };
+
+                // convert to json
+                serde_json::to_value(&deglob_result).unwrap()
+            })
+            .collect();
+
+        if !deglob_results.is_empty() {
+            // extend result list
+            let cmd = Command {
+                title: format!(
+                    "Deglob Import{}",
+                    if deglob_results.len() > 1 { "s" } else { "" }
+                ),
+                command: "rls.deglobImports".to_owned(),
+                arguments: Some(deglob_results),
+            };
+            code_actions_result.push(cmd);
+        }
+    };
 }
 
 impl RequestAction for CodeAction {
     type Response = Vec<Command>;
 
-    fn new() -> Self {
-        CodeAction
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Ok(vec![])
     }
 
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -772,31 +635,19 @@ impl RequestAction for CodeAction {
 
         let mut cmds = vec![];
         if ctx.build_ready() {
-            Self::make_suggestion_fix_actions(&params, &file_path, &ctx, &mut cmds);
+            make_suggestion_fix_actions(&params, &file_path, &ctx, &mut cmds);
         }
         if ctx.analysis_ready() {
-            Self::make_deglob_actions(&params, &file_path, &ctx, &mut cmds);
+            make_deglob_actions(&params, &file_path, &ctx, &mut cmds);
         }
         Ok(cmds)
     }
 }
 
-/// Pretty print the given document.
-pub struct Formatting;
-
-impl Action for Formatting {
-    type Params = DocumentFormattingParams;
-    const METHOD: &'static str = "textDocument/formatting";
-}
-
 impl RequestAction for Formatting {
     type Response = [TextEdit; 1];
 
-    fn new() -> Self {
-        Formatting
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Err(ResponseError::Message(
             ErrorCode::InternalError,
             "Reformat failed to complete successfully".into(),
@@ -805,7 +656,6 @@ impl RequestAction for Formatting {
 
     #[cfg(feature = "rustfmt")]
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -814,7 +664,6 @@ impl RequestAction for Formatting {
 
     #[cfg(not(feature = "rustfmt"))]
     fn handle(
-        &mut self,
         _: InitActionContext,
         _: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -825,22 +674,10 @@ impl RequestAction for Formatting {
     }
 }
 
-/// Pretty print the source within the given location range.
-pub struct RangeFormatting;
-
-impl Action for RangeFormatting {
-    type Params = DocumentRangeFormattingParams;
-    const METHOD: &'static str = "textDocument/rangeFormatting";
-}
-
 impl RequestAction for RangeFormatting {
     type Response = [TextEdit; 1];
 
-    fn new() -> Self {
-        RangeFormatting
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Err(ResponseError::Message(
             ErrorCode::InternalError,
             "Reformat failed to complete successfully".into(),
@@ -849,7 +686,6 @@ impl RequestAction for RangeFormatting {
 
     #[cfg(feature = "rustfmt")]
     fn handle(
-        &mut self,
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -862,7 +698,6 @@ impl RequestAction for RangeFormatting {
     }
     #[cfg(not(feature = "rustfmt"))]
     fn handle(
-        &mut self,
         _: InitActionContext,
         _: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
@@ -968,30 +803,14 @@ fn reformat(
     }
 }
 
-/// Resolve additional information about the given completion item
-/// suggestion. This allows completion items to be yielded as quickly as
-/// possible, with more details (which are presumably more expensive to compute)
-/// filled in after the initial completion's presentation.
-pub struct ResolveCompletion;
-
-impl Action for ResolveCompletion {
-    type Params = CompletionItem;
-    const METHOD: &'static str = "completionItem/resolve";
-}
-
 impl RequestAction for ResolveCompletion {
     type Response = CompletionItem;
 
-    fn new() -> Self {
-        ResolveCompletion
-    }
-
-    fn fallback_response(&self) -> Result<Self::Response, ResponseError> {
+    fn fallback_response() -> Result<Self::Response, ResponseError> {
         Err(ResponseError::Empty)
     }
 
     fn handle(
-        &mut self,
         _: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -30,20 +30,21 @@ use server;
 use server::{Ack, Output, RequestAction, ResponseError};
 use jsonrpc_core::types::ErrorCode;
 
-use ls_types;
-pub use ls_types::request::WorkspaceSymbol;
-pub use ls_types::request::DocumentSymbol as Symbols;
-pub use ls_types::request::HoverRequest as Hover;
-pub use ls_types::request::GotoDefinition as Definition;
-pub use ls_types::request::References;
-pub use ls_types::request::Completion;
-pub use ls_types::request::DocumentHighlightRequest as DocumentHighlight;
-pub use ls_types::request::Rename;
-pub use ls_types::request::ExecuteCommand;
-pub use ls_types::request::CodeActionRequest as CodeAction;
-pub use ls_types::request::Formatting;
-pub use ls_types::request::RangeFormatting;
-pub use ls_types::request::ResolveCompletionItem as ResolveCompletion;
+pub use lsp_data::request::{
+    WorkspaceSymbol,
+    DocumentSymbol as Symbols,
+    HoverRequest as Hover,
+    GotoDefinition as Definition,
+    References,
+    Completion,
+    DocumentHighlightRequest as DocumentHighlight,
+    Rename,
+    ExecuteCommand,
+    CodeActionRequest as CodeAction,
+    Formatting,
+    RangeFormatting,
+    ResolveCompletionItem as ResolveCompletion,
+};
 pub use lsp_data::FindImpls;
 
 use std::collections::HashMap;
@@ -453,7 +454,6 @@ impl server::Response for ExecuteCommandResponse {
     }
 }
 
-
 impl RequestAction for ExecuteCommand {
     type Response = ExecuteCommandResponse;
 
@@ -527,7 +527,7 @@ fn apply_deglobs(args: Vec<serde_json::Value>) -> Result<ApplyWorkspaceEditParam
 /// Create CodeActions for fixes suggested by the compiler
 /// the results are appended to `code_actions_result`
 fn make_suggestion_fix_actions(
-    params: &<CodeAction as ls_types::request::Request>::Params,
+    params: &<CodeAction as lsp_data::request::Request>::Params,
     file_path: &Path,
     ctx: &InitActionContext,
     code_actions_result: &mut <CodeAction as RequestAction>::Response,
@@ -558,7 +558,7 @@ fn make_suggestion_fix_actions(
 /// Create CodeActions for performing deglobbing when a wildcard import is found
 /// the results are appended to `code_actions_result`
 fn make_deglob_actions(
-    params: &<CodeAction as ls_types::request::Request>::Params,
+    params: &<CodeAction as lsp_data::request::Request>::Params,
     file_path: &Path,
     ctx: &InitActionContext,
     code_actions_result: &mut <CodeAction as RequestAction>::Response,
@@ -663,10 +663,7 @@ impl RequestAction for Formatting {
     }
 
     #[cfg(not(feature = "rustfmt"))]
-    fn handle(
-        _: InitActionContext,
-        _: Self::Params,
-    ) -> Result<Self::Response, ResponseError> {
+    fn handle(_: InitActionContext, _: Self::Params) -> Result<Self::Response, ResponseError> {
         Err(ResponseError::Message(
             ErrorCode::InternalError,
             "rustfmt was not distributed with this rls release".into(),
@@ -697,10 +694,7 @@ impl RequestAction for RangeFormatting {
         )
     }
     #[cfg(not(feature = "rustfmt"))]
-    fn handle(
-        _: InitActionContext,
-        _: Self::Params,
-    ) -> Result<Self::Response, ResponseError> {
+    fn handle(_: InitActionContext, _: Self::Params) -> Result<Self::Response, ResponseError> {
         Err(ResponseError::Message(
             ErrorCode::InternalError,
             "rustfmt was not distributed with this rls release".into(),
@@ -810,17 +804,13 @@ impl RequestAction for ResolveCompletion {
         Err(ResponseError::Empty)
     }
 
-    fn handle(
-        _: InitActionContext,
-        params: Self::Params,
-    ) -> Result<Self::Response, ResponseError> {
+    fn handle(_: InitActionContext, params: Self::Params) -> Result<Self::Response, ResponseError> {
         // currently, we safely ignore this as a pass-through since we fully handle
         // textDocument/completion.  In the future, we may want to use this method as a
         // way to more lazily fill out completion information
         Ok(params.into())
     }
 }
-
 
 fn racer_coord(
     line: span::Row<span::OneIndexed>,

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -15,7 +15,7 @@
 use actions::requests;
 use analysis::{AnalysisHost, Target};
 use config::Config;
-use server::{self, LsService, NoParams, Notification, Request};
+use server::{self, LsService, Notification, Request};
 use vfs::Vfs;
 
 use ls_types::{ClientCapabilities, CodeActionContext, CodeActionParams, DocumentFormattingParams,
@@ -325,18 +325,18 @@ fn code_action(
     }
 }
 
-fn shutdown<'a>() -> Request<server::ShutdownRequest<'a>> {
+fn shutdown() -> Request<server::ShutdownRequest> {
     Request {
         id: next_id(),
-        params: NoParams {},
+        params: (),
         received: Instant::now(),
         _action: PhantomData,
     }
 }
 
-fn exit<'a>() -> Notification<server::ExitNotification<'a>> {
+fn exit() -> Notification<server::ExitNotification> {
     Notification {
-        params: NoParams {},
+        params: (),
         _action: PhantomData,
     }
 }

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -369,3 +369,4 @@ impl request::Request for FindImpls {
     type Result = Vec<Location>;
     const METHOD: &'static str = "rustDocument/implementations";
 }
+

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -323,3 +323,49 @@ where
         }
     }
 }
+
+/* --------------- Custom JSON-RPC notifications -------------- */
+
+/// Custom LSP notification sent to client indicating that the server is currently
+/// processing data and may publish new diagnostics on `rustDocument/diagnosticsEnd`.
+#[derive(Debug)]
+pub enum DiagnosticsBegin { }
+
+impl notification::Notification for DiagnosticsBegin {
+    type Params = ();
+    const METHOD: &'static str = "rustDocument/diagnosticsBegin";
+}
+
+/// Custom LSP notification sent to client indicating that data processing started
+/// by a `rustDocument`/diagnosticsBegin` has ended.
+/// For each `diagnosticsBegin` message, there is a single `diagnosticsEnd` message.
+/// This means that for multiple active `diagnosticsBegin` messages, there will
+/// be sent multiple `diagnosticsEnd` notifications.
+#[derive(Debug)]
+pub enum DiagnosticsEnd { }
+
+impl notification::Notification for DiagnosticsEnd {
+    type Params = ();
+    const METHOD: &'static str = "rustDocument/diagnosticsEnd";
+}
+
+/// Custom LSP notification sent to client indicating that a build process has begun.
+#[derive(Debug)]
+pub enum BeginBuild { }
+
+impl notification::Notification for BeginBuild {
+    type Params = ();
+    const METHOD: &'static str = "rustDocument/beginBuild";
+}
+
+/* ------------------ Custom JSON-RPC requests ---------------- */
+
+/// Find all the implementations of a given trait.
+#[derive(Debug)]
+pub enum FindImpls { }
+
+impl request::Request for FindImpls {
+    type Params = TextDocumentPositionParams;
+    type Result = Vec<Location>;
+    const METHOD: &'static str = "rustDocument/implementations";
+}

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -18,7 +18,6 @@ use ls_types::request::Request as LSPRequest;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
-use std::marker::PhantomData;
 
 lazy_static! {
     static ref TIMEOUT: Duration = Duration::from_millis(::COMPILER_TIMEOUT);
@@ -29,14 +28,14 @@ macro_rules! define_dispatch_request_enum {
     ($($request_type:ident),*) => {
         pub enum DispatchRequest {
             $(
-                $request_type(PhantomData<$request_type>, Request<$request_type>, InitActionContext),
+                $request_type(Request<$request_type>, InitActionContext),
             )*
         }
 
         $(
             impl From<(Request<$request_type>, InitActionContext)> for DispatchRequest {
                 fn from((req, ctx): (Request<$request_type>, InitActionContext)) -> Self {
-                    DispatchRequest::$request_type(PhantomData, req, ctx)
+                    DispatchRequest::$request_type(req, ctx)
                 }
             }
         )*
@@ -45,7 +44,7 @@ macro_rules! define_dispatch_request_enum {
             fn handle<O: Output>(self, out: &O) {
                 match self {
                 $(
-                    DispatchRequest::$request_type(_, req, ctx) => {
+                    DispatchRequest::$request_type(req, ctx) => {
                         let Request { id, params, received, .. } = req;
                         let timeout = $request_type::timeout();
 

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -14,10 +14,11 @@ use server;
 use server::{Request, Response};
 use server::io::Output;
 use actions::InitActionContext;
+use ls_types::request::Request as LSPRequest;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
-use ls_types;
+use std::marker::PhantomData;
 
 lazy_static! {
     static ref TIMEOUT: Duration = Duration::from_millis(::COMPILER_TIMEOUT);
@@ -28,14 +29,14 @@ macro_rules! define_dispatch_request_enum {
     ($($request_type:ident),*) => {
         pub enum DispatchRequest {
             $(
-                $request_type(::std::marker::PhantomData<$request_type>, Request<$request_type>, InitActionContext),
+                $request_type(PhantomData<$request_type>, Request<$request_type>, InitActionContext),
             )*
         }
 
         $(
             impl From<(Request<$request_type>, InitActionContext)> for DispatchRequest {
                 fn from((req, ctx): (Request<$request_type>, InitActionContext)) -> Self {
-                    DispatchRequest::$request_type(::std::marker::PhantomData, req, ctx)
+                    DispatchRequest::$request_type(PhantomData, req, ctx)
                 }
             }
         )*
@@ -154,7 +155,7 @@ impl Dispatcher {
 
 /// Stdin-nonblocking request logic designed to be packed into a `DispatchRequest`
 /// and handled on the `WORK_POOL` via a `Dispatcher`.
-pub trait RequestAction: ls_types::request::Request {
+pub trait RequestAction: LSPRequest {
     /// Serializable response type
     type Response: server::Response + Send;
 

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -8,9 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use serde;
 use serde_json;
 
-use super::{Action, Notification};
+use super::{Notification};
+use ls_types;
 
 use std::fmt;
 use std::io::{self, Read, Write};
@@ -143,7 +145,10 @@ pub trait Output: Sync + Send + Clone + 'static {
     }
 
     /// Send a notification along the output.
-    fn notify<A: Action>(&self, notification: Notification<A>) {
+    fn notify<A, P>(&self, notification: Notification<A>)
+    where
+        A: ls_types::notification::Notification<Params=P>,
+        P: serde::Serialize {
         self.response(format!("{}", notification));
     }
 }

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -11,8 +11,8 @@
 use serde;
 use serde_json;
 
-use super::{Notification};
-use ls_types;
+use super::Notification;
+use ls_types::notification::Notification as LSPNotification;
 
 use std::fmt;
 use std::io::{self, Read, Write};
@@ -147,8 +147,9 @@ pub trait Output: Sync + Send + Clone + 'static {
     /// Send a notification along the output.
     fn notify<A, P>(&self, notification: Notification<A>)
     where
-        A: ls_types::notification::Notification<Params=P>,
-        P: serde::Serialize {
+        A: LSPNotification<Params = P>,
+        P: serde::Serialize,
+    {
         self.response(format!("{}", notification));
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -19,7 +19,7 @@ mod harness;
 use analysis;
 use actions::requests;
 use config::{Config, Inferrable};
-use server::{self as ls_server, NoParams, Request, ShutdownRequest};
+use server::{self as ls_server, Request, ShutdownRequest};
 use jsonrpc_core;
 use vfs;
 
@@ -69,7 +69,7 @@ pub fn initialize_with_opts<'a>(
     }
 }
 
-pub fn blocking_request<'a, T: ls_server::BlockingRequestAction<'a>>(
+pub fn blocking_request<T: ls_server::BlockingRequestAction>(
     id: usize,
     params: T::Params,
 ) -> Request<T> {
@@ -98,7 +98,7 @@ fn test_shutdown() {
 
     let messages = vec![
         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
-        blocking_request::<ShutdownRequest>(1, NoParams).to_string(),
+        blocking_request::<ShutdownRequest>(1, ()).to_string(),
     ];
 
     let (mut server, results) = env.mock_server(messages);


### PR DESCRIPTION
https://github.com/gluon-lang/languageserver-types/pull/29 codifies method name and param types in the type system in the same manner as our `Action` trait. This tries to merge those and prepare to update languageserver-types to newer versions.

Most notably this changes implementation from stateful message traits with single-value enums to stateless traits, using uninhabited enums (like in languageserver-types).

Additionally moved back `shut_down` to action context to simplify code and since it makes sense only when server is initialized.

r? @nrc