### PR TITLE
Don't send snippets if client does not support it

### DIFF
--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -225,8 +225,7 @@ impl<'a> BlockingNotificationAction<'a> for DidChangeConfiguration {
             Err(err) => {
                 debug!(
                     "Received unactionable config: {:?} (error: {:?})",
-                    params.settings,
-                    err
+                    params.settings, err
                 );
                 return Err(());
             }

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -29,7 +29,6 @@ use serde_json;
 use span::compiler::DiagnosticSpan;
 use url::Url;
 
-
 pub type BuildResults = HashMap<PathBuf, Vec<(Diagnostic, Vec<Suggestion>)>>;
 
 pub struct PostBuildHandler {
@@ -106,7 +105,8 @@ impl PostBuildHandler {
                 file_path,
                 diagnostic,
                 suggestions,
-            }) = parse_diagnostics(msg) {
+            }) = parse_diagnostics(msg)
+            {
                 results
                     .entry(cwd.join(file_path))
                     .or_insert_with(Vec::new)
@@ -261,4 +261,3 @@ fn primary_span(message: &CompilerMessage) -> Span {
         .clone();
     primary.rls_span().zero_indexed()
 }
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,7 @@ pub struct Config {
     pub show_warnings: bool,
     pub goto_def_racer_fallback: bool,
     pub workspace_mode: bool,
+    pub has_snippet_support: bool,
     /// Clear the RUST_LOG env variable before calling rustc/cargo? Default: true
     pub clear_env_rust_log: bool,
     /// Build the project only when a file got saved and not on file change. Default: false
@@ -148,6 +149,7 @@ impl Default for Config {
             show_warnings: true,
             goto_def_racer_fallback: false,
             workspace_mode: true,
+            has_snippet_support: false,
             clear_env_rust_log: true,
             build_on_save: false,
             use_crate_blacklist: true,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -158,7 +158,7 @@ impl<A: Action> Notification<A> {
     pub fn new(params: A::Params) -> Notification<A> {
         Notification {
             params,
-            _action: PhantomData
+            _action: PhantomData,
         }
     }
 }
@@ -367,7 +367,21 @@ impl<'a> BlockingRequestAction<'a> for InitializeRequest {
         };
         out.success(id, &result);
 
-        ctx.init(get_root_path(&params), &init_options, out);
+        let has_snippet_support = params
+            .capabilities
+            .text_document
+            .as_ref()
+            .and_then(|doc| doc.completion.as_ref())
+            .and_then(|comp| comp.completion_item.as_ref())
+            .and_then(|item| item.snippet_support.as_ref())
+            .map(|support| support.to_owned())
+            .unwrap_or(false);
+        ctx.init(
+            get_root_path(&params),
+            &init_options,
+            has_snippet_support,
+            out,
+        );
 
         Ok(NoResponse)
     }


### PR DESCRIPTION
This is a fix for issue #629. (with some formatting from rustfmt)

Snippet support is send through `InitializeParams`, so I just take value in it and put in the `Config` via `ActionContext`. With that, we can access to it in each request.
  