### PR TITLE
Only send snippets for completion when client supports it

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -24,6 +24,7 @@ use Span;
 use actions::post_build::{BuildResults, PostBuildHandler, Notifier};
 use actions::notifications::{BeginBuild, DiagnosticsBegin, DiagnosticsEnd, PublishDiagnostics};
 use build::*;
+use lsp_data;
 use lsp_data::*;
 use server::{Output, Notification, NoParams};
 
@@ -79,7 +80,7 @@ impl ActionContext {
         &mut self,
         current_project: PathBuf,
         init_options: &InitializationOptions,
-        client_capabilities: HandledClientCapabilities,
+        client_capabilities: lsp_data::ClientCapabilities,
         out: O,
     ) {
         let ctx = match *self {
@@ -124,7 +125,7 @@ pub struct InitActionContext {
     active_build_count: Arc<AtomicUsize>,
 
     config: Arc<Mutex<Config>>,
-    client_capabilities: Arc<HandledClientCapabilities>,
+    client_capabilities: Arc<lsp_data::ClientCapabilities>,
 }
 
 /// Persistent context shared across all requests and actions before the RLS has
@@ -154,7 +155,7 @@ impl InitActionContext {
         analysis: Arc<AnalysisHost>,
         vfs: Arc<Vfs>,
         config: Arc<Mutex<Config>>,
-        client_capabilities: HandledClientCapabilities,
+        client_capabilities: lsp_data::ClientCapabilities,
         current_project: PathBuf,
     ) -> InitActionContext {
         let build_queue = BuildQueue::new(vfs.clone(), config.clone());

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -79,6 +79,7 @@ impl ActionContext {
         &mut self,
         current_project: PathBuf,
         init_options: &InitializationOptions,
+        client_capabilities: HandledClientCapabilities,
         out: O,
     ) {
         let ctx = match *self {
@@ -87,6 +88,7 @@ impl ActionContext {
                     uninit.analysis.clone(),
                     uninit.vfs.clone(),
                     uninit.config.clone(),
+                    client_capabilities,
                     current_project,
                 );
                 ctx.init(init_options, out);
@@ -122,6 +124,7 @@ pub struct InitActionContext {
     active_build_count: Arc<AtomicUsize>,
 
     config: Arc<Mutex<Config>>,
+    client_capabilities: Arc<HandledClientCapabilities>,
 }
 
 /// Persistent context shared across all requests and actions before the RLS has
@@ -151,6 +154,7 @@ impl InitActionContext {
         analysis: Arc<AnalysisHost>,
         vfs: Arc<Vfs>,
         config: Arc<Mutex<Config>>,
+        client_capabilities: HandledClientCapabilities,
         current_project: PathBuf,
     ) -> InitActionContext {
         let build_queue = BuildQueue::new(vfs.clone(), config.clone());
@@ -162,6 +166,7 @@ impl InitActionContext {
             previous_build_results: Arc::new(Mutex::new(HashMap::new())),
             build_queue,
             active_build_count: Arc::new(AtomicUsize::new(0)),
+            client_capabilities: Arc::new(client_capabilities),
         }
     }
 

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -382,14 +382,18 @@ impl RequestAction for Completion {
         let location = pos_to_racer_location(params.position);
         let results = racer::complete_from_file(file_path, location, &session);
 
+        let has_snippet_support = ctx.client_capabilities.has_snippet_support;
+
         Ok(
             results
                 .map(|comp| {
-                    let snippet = racer::snippet_for_match(&comp, &session);
-                    let mut item = completion_item_from_racer_match(comp);
-                    if !snippet.is_empty() {
-                        item.insert_text = Some(snippet);
-                        item.insert_text_format = Some(InsertTextFormat::Snippet);
+                    let mut item = completion_item_from_racer_match(&comp);
+                    if has_snippet_support {
+                        let snippet = racer::snippet_for_match(&comp, &session);
+                        if !snippet.is_empty() {
+                            item.insert_text = Some(snippet);
+                            item.insert_text_format = Some(InsertTextFormat::Snippet);
+                        }
                     }
                     item
                 })

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -382,13 +382,14 @@ impl RequestAction for Completion {
         let location = pos_to_racer_location(params.position);
         let results = racer::complete_from_file(file_path, location, &session);
 
-        let has_snippet_support = ctx.client_capabilities.has_snippet_support;
+        let code_completion_has_snippet_support =
+            ctx.client_capabilities.code_completion_has_snippet_support;
 
         Ok(
             results
                 .map(|comp| {
                     let mut item = completion_item_from_racer_match(&comp);
-                    if has_snippet_support {
+                    if code_completion_has_snippet_support {
                         let snippet = racer::snippet_for_match(&comp, &session);
                         if !snippet.is_empty() {
                             item.insert_text = Some(snippet);

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -221,7 +221,7 @@ pub fn completion_kind_from_match_type(m: racer::MatchType) -> CompletionItemKin
 }
 
 /// Convert a racer match into an RLS completion.
-pub fn completion_item_from_racer_match(m: racer::Match) -> CompletionItem {
+pub fn completion_item_from_racer_match(m: &racer::Match) -> CompletionItem {
     let mut item = CompletionItem::new_simple(m.matchstr.clone(), m.contextstr.clone());
     item.kind = Some(completion_kind_from_match_type(m.mtype));
 
@@ -258,6 +258,22 @@ impl Default for InitializationOptions {
     fn default() -> Self {
         InitializationOptions {
             omit_init_build: false,
+        }
+    }
+}
+
+// Subset of flags from ls_types::ClientCapabilities that affects this RLS.
+// Passed in the `initialize` request under `capabilities`.
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Copy)]
+#[serde(default)]
+pub struct HandledClientCapabilities {
+    pub has_snippet_support: bool,
+}
+
+impl Default for HandledClientCapabilities {
+    fn default() -> Self {
+        HandledClientCapabilities {
+            has_snippet_support: false,
         }
     }
 }


### PR DESCRIPTION
The current behaviour is to send snippets regardless of the client
capabilities communicated in initialize. This change makes sure the
RLS only sends snippets for completion items when the language client
has specified that it supports snippets.

Fixes #629