### PR TITLE
Propagate build errors using window/showMessage

### DIFF
--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -89,8 +89,7 @@ impl PostBuildHandler {
                     // It's not a good idea to make a long message here, the output in
                     // VSCode is one single line, and it's important to capture the
                     // root cause.
-                    // let msg = format!("There was an error trying to build, RLS features will be limited: {}", cause);
-                    self.notifier.notify_build_error_diagnostics(cause);
+                    self.notifier.notify_error_diagnostics(cause);
                 }
                 self.notifier.notify_end_diagnostics();
                 self.active_build_count.fetch_sub(1, Ordering::SeqCst);

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -86,8 +86,11 @@ impl PostBuildHandler {
                 trace!("build - Error {} when running {:?}", cause, cmd);
                 self.notifier.notify_begin_diagnostics();
                 if !self.shown_cargo_error.swap(true, Ordering::SeqCst) {
-                    let msg = format!("There was an error trying to build, RLS features will be limited: {}", cause);
-                    self.notifier.notify_error_diagnostics(&msg);
+                    // It's not a good idea to make a long message here, the output in
+                    // VSCode is one single line, and it's important to capture the
+                    // root cause.
+                    // let msg = format!("There was an error trying to build, RLS features will be limited: {}", cause);
+                    self.notifier.notify_build_error_diagnostics(cause);
                 }
                 self.notifier.notify_end_diagnostics();
                 self.active_build_count.fetch_sub(1, Ordering::SeqCst);

--- a/src/actions/progress.rs
+++ b/src/actions/progress.rs
@@ -34,8 +34,8 @@ pub enum ProgressUpdate {
 pub trait DiagnosticsNotifier: Send {
     fn notify_begin_diagnostics(&self);
     fn notify_publish_diagnostics(&self, PublishDiagnosticsParams);
+    fn notify_build_error_diagnostics(&self, msg: String);
     fn notify_end_diagnostics(&self);
-    fn notify_error_diagnostics(&self, msg: &str);
 }
 
 /// Generate a new progress params with a unique ID and the given title.
@@ -121,15 +121,15 @@ impl<O: Output> DiagnosticsNotifier for BuildDiagnosticsNotifier<O> {
     fn notify_publish_diagnostics(&self, params: PublishDiagnosticsParams) {
         self.out.notify(Notification::<PublishDiagnostics>::new(params));
     }
+    fn notify_build_error_diagnostics(&self, message: String) {
+        self.out.notify(Notification::<ShowMessage>::new(ShowMessageParams {
+             typ: MessageType::Error,
+             message: message.to_owned(),
+         }));
+    }
     fn notify_end_diagnostics(&self) {
         let mut params = self.progress_params.clone();
         params.done = Some(true);
         self.out.notify(Notification::<Progress>::new(params));
-    }
-    fn notify_error_diagnostics(&self, msg: &str) {
-        self.out.notify(Notification::<ShowMessage>::new(ShowMessageParams {
-            typ: MessageType::Error,
-            message: msg.to_owned(),
-        }));
     }
 }

--- a/src/actions/progress.rs
+++ b/src/actions/progress.rs
@@ -34,7 +34,7 @@ pub enum ProgressUpdate {
 pub trait DiagnosticsNotifier: Send {
     fn notify_begin_diagnostics(&self);
     fn notify_publish_diagnostics(&self, PublishDiagnosticsParams);
-    fn notify_build_error_diagnostics(&self, msg: String);
+    fn notify_error_diagnostics(&self, msg: String);
     fn notify_end_diagnostics(&self);
 }
 
@@ -121,7 +121,7 @@ impl<O: Output> DiagnosticsNotifier for BuildDiagnosticsNotifier<O> {
     fn notify_publish_diagnostics(&self, params: PublishDiagnosticsParams) {
         self.out.notify(Notification::<PublishDiagnostics>::new(params));
     }
-    fn notify_build_error_diagnostics(&self, message: String) {
+    fn notify_error_diagnostics(&self, message: String) {
         self.out.notify(Notification::<ShowMessage>::new(ShowMessageParams {
              typ: MessageType::Error,
              message: message.to_owned(),

--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -94,7 +94,7 @@ pub(super) fn cargo(internals: &Internals, package_arg: PackageArg, progress_sen
                 format!("({})", stdout)
             };
             let msg = format!("Cargo failed: {}{}", err, stdout_msg);
-            info!("{}", msg);
+            debug!("{}", msg);
             BuildResult::Err(msg, None)
         }
     }

--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -85,9 +85,17 @@ pub(super) fn cargo(internals: &Internals, package_arg: PackageArg, progress_sen
         }
         Ok(cwd) => BuildResult::Success(cwd, vec![], vec![], true),
         Err(err) => {
+            // This message goes like this to the UI via showMessage. In VSCode
+            // this ends up on one single line, so it's important to keep it concise.
             let stdout = String::from_utf8(out_clone.lock().unwrap().to_owned()).unwrap();
-            debug!("cargo failed\ncause: {}\nstdout: {}", err, stdout);
-            BuildResult::Err(err.to_string(), None)
+            let stdout_msg = if stdout.is_empty() {
+                "".to_string()
+            } else {
+                format!("({})", stdout)
+            };
+            let msg = format!("Cargo failed: {}{}", err, stdout_msg);
+            info!("{}", msg);
+            BuildResult::Err(msg, None)
         }
     }
 }


### PR DESCRIPTION
This is based off #653 and needs to land after that.

Currently build errors go to the logs, but does not show up in the UI. This PR fixes that so that the first encountered build error will be notified using `window/showMessage`. No further build errors will be propagated until the error state has cleared since a build attempt happens on every keystroke.

<img width="777" alt="screen shot 2018-01-14 at 12 28 20" src="https://user-images.githubusercontent.com/227204/34916000-c266cb2a-f930-11e7-8869-bd0cebb407b1.png">
