### PR TITLE
Update languageserver-types and clean up a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,8 +572,8 @@ dependencies = [
 
 [[package]]
 name = "languageserver-types"
-version = "0.17.0"
-source = "git+https://github.com/Xanewok/languageserver-types?branch=backport-0.17-fix-params-types#94aea90bb2056fdb9a96799d8614dee0277be57c"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -917,7 +917,7 @@ dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "languageserver-types 0.17.0 (git+https://github.com/Xanewok/languageserver-types?branch=backport-0.17-fix-params-types)",
+ "languageserver-types 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1569,7 +1569,7 @@ dependencies = [
 "checksum json 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)" = "39ebf0fac977ee3a4a3242b6446004ff64514889e3e2730bbd4f764a67a2e483"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum languageserver-types 0.17.0 (git+https://github.com/Xanewok/languageserver-types?branch=backport-0.17-fix-params-types)" = "<none>"
+"checksum languageserver-types 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a2036fc8576a22689b7e3171c07eb8e8f700678d7a8a53f6f65abbeb35261e1"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ cargo = { git = "https://github.com/rust-lang/cargo" }
 env_logger = "0.4"
 failure = "0.1.1"
 jsonrpc-core = "8.0.1"
-languageserver-types = { git = "https://github.com/Xanewok/languageserver-types", branch = "backport-0.17-fix-params-types" }
+languageserver-types = "0.27"
 lazy_static = "0.2"
 log = "0.3"
 racer = "2.0.12"

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -21,8 +21,6 @@ use Span;
 
 use build::*;
 use lsp_data::*;
-use lsp_data::request::Request as LSPRequest;
-use lsp_data::notification::Notification as LSPNotification;
 use lsp_data::request::{RangeFormatting, RegisterCapability, UnregisterCapability};
 use server::Request;
 

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -111,7 +111,7 @@ impl BlockingNotificationAction for DidChangeTextDocument {
             .expect("error committing to VFS");
         if !changes.is_empty() {
             ctx.build_queue
-                .mark_file_dirty(file_path, params.text_document.version)
+                .mark_file_dirty(file_path, params.text_document.version.unwrap())
         }
 
         if !ctx.config.lock().unwrap().build_on_save {

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -27,9 +27,10 @@ use rayon;
 use lsp_data;
 use lsp_data::*;
 use server;
-use server::{Ack, Output, RequestAction, ResponseError};
+use server::{Ack, Output, Request, RequestAction, ResponseError};
 use jsonrpc_core::types::ErrorCode;
 
+use lsp_data::request::ApplyWorkspaceEdit;
 pub use lsp_data::request::{
     WorkspaceSymbol,
     DocumentSymbol as Symbols,
@@ -438,14 +439,13 @@ impl server::Response for ExecuteCommandResponse {
         // FIXME should handle the client's responses
         match *self {
             ExecuteCommandResponse::ApplyEdit(ref params) => {
-                let output = serde_json::to_string(&RequestMessage::new(
-                    out.provide_id(),
-                    "workspace/applyEdit".to_owned(),
-                    ApplyWorkspaceEditParams {
+                let id = out.provide_id() as usize;
+                let params = ApplyWorkspaceEditParams {
                         edit: params.edit.clone(),
-                    },
-                )).unwrap();
-                out.response(output);
+                };
+
+                let request = Request::<ApplyWorkspaceEdit>::new(id, params);
+                out.request(request);
             }
         }
 

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -370,7 +370,8 @@ impl RequestAction for Rename {
 
     fn fallback_response() -> Result<Self::Response, ResponseError> {
         Ok(WorkspaceEdit {
-            changes: HashMap::new(),
+            changes: None,
+            document_changes: None,
         })
     }
 
@@ -422,7 +423,7 @@ impl RequestAction for Rename {
                 });
         }
 
-        Ok(WorkspaceEdit { changes: edits })
+        Ok(WorkspaceEdit { changes: Some(edits), document_changes: None })
     }
 }
 
@@ -515,11 +516,15 @@ fn apply_deglobs(args: Vec<serde_json::Value>) -> Result<ApplyWorkspaceEditParam
             }
         })
         .collect();
-    let mut edit = WorkspaceEdit {
-        changes: HashMap::new(),
-    };
     // all deglob results will share the same URI
-    edit.changes.insert(uri, text_edits);
+    let changes: HashMap<_, _> = vec![(uri, text_edits)]
+        .into_iter()
+        .collect();
+
+    let edit = WorkspaceEdit {
+        changes: Some(changes),
+        document_changes: None,
+    };
 
     Ok(ApplyWorkspaceEditParams { edit })
 }

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -10,13 +10,12 @@
 
 //! Types, helpers, and conversions to and from LSP and `racer` types.
 
-use std::fmt::{self, Debug};
+use std::fmt;
 use std::path::PathBuf;
 use std::error::Error;
 
 use analysis::DefKind;
 use url::Url;
-use serde::Serialize;
 use span;
 use racer;
 use vfs::FileContents;
@@ -288,36 +287,6 @@ impl ClientCapabilities {
 
         ClientCapabilities {
             code_completion_has_snippet_support,
-        }
-    }
-}
-
-/// A JSON language server protocol request that will have a matching response.
-#[derive(Debug, Serialize)]
-pub struct RequestMessage<T>
-where
-    T: Debug + Serialize,
-{
-    jsonrpc: &'static str,
-    /// The request id. The response will have a matching id.
-    pub id: u32,
-    /// The well-known language server protocol request method string.
-    pub method: String,
-    /// Extra request parameters.
-    pub params: T,
-}
-
-impl<T> RequestMessage<T>
-where
-    T: Debug + Serialize,
-{
-    /// Construct a new request.
-    pub fn new(id: u32, method: String, params: T) -> Self {
-        RequestMessage {
-            jsonrpc: "2.0",
-            id,
-            method: method,
-            params: params,
         }
     }
 }

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -10,7 +10,6 @@
 
 //! Types, helpers, and conversions to and from LSP and `racer` types.
 
-use std::collections::HashMap;
 use std::fmt::{self, Debug};
 use std::path::PathBuf;
 use std::error::Error;
@@ -64,11 +63,7 @@ pub fn parse_file_path(uri: &Url) -> Result<PathBuf, UrlFileParseError> {
 
 /// Create an edit for the given location and text.
 pub fn make_workspace_edit(location: Location, new_text: String) -> WorkspaceEdit {
-    let mut edit = WorkspaceEdit {
-        changes: HashMap::new(),
-    };
-
-    edit.changes.insert(
+    let changes = vec![(
         location.uri,
         vec![
             TextEdit {
@@ -76,9 +71,12 @@ pub fn make_workspace_edit(location: Location, new_text: String) -> WorkspaceEdi
                 new_text,
             },
         ],
-    );
+    )].into_iter().collect();
 
-    edit
+    WorkspaceEdit {
+        changes: Some(changes),
+        document_changes: None,
+    }
 }
 
 /// Utilities for working with the language server protocol.

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -22,6 +22,8 @@ use vfs::FileContents;
 use ls_types;
 
 pub use ls_types::*;
+pub use ls_types::request::Request as LSPRequest;
+pub use ls_types::notification::Notification as LSPNotification;
 
 /// Errors that can occur when parsing a file URI.
 #[derive(Debug)]
@@ -298,7 +300,7 @@ impl ClientCapabilities {
 #[derive(Debug)]
 pub enum DiagnosticsBegin { }
 
-impl notification::Notification for DiagnosticsBegin {
+impl LSPNotification for DiagnosticsBegin {
     type Params = ();
     const METHOD: &'static str = "rustDocument/diagnosticsBegin";
 }
@@ -311,7 +313,7 @@ impl notification::Notification for DiagnosticsBegin {
 #[derive(Debug)]
 pub enum DiagnosticsEnd { }
 
-impl notification::Notification for DiagnosticsEnd {
+impl LSPNotification for DiagnosticsEnd {
     type Params = ();
     const METHOD: &'static str = "rustDocument/diagnosticsEnd";
 }
@@ -320,7 +322,7 @@ impl notification::Notification for DiagnosticsEnd {
 #[derive(Debug)]
 pub enum BeginBuild { }
 
-impl notification::Notification for BeginBuild {
+impl LSPNotification for BeginBuild {
     type Params = ();
     const METHOD: &'static str = "rustDocument/beginBuild";
 }
@@ -331,9 +333,8 @@ impl notification::Notification for BeginBuild {
 #[derive(Debug)]
 pub enum FindImpls { }
 
-impl request::Request for FindImpls {
+impl LSPRequest for FindImpls {
     type Params = TextDocumentPositionParams;
     type Result = Vec<Location>;
     const METHOD: &'static str = "rustDocument/implementations";
 }
-

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -14,7 +14,7 @@ use server;
 use server::{Request, Response};
 use server::io::Output;
 use actions::InitActionContext;
-use ls_types::request::Request as LSPRequest;
+use lsp_data::LSPRequest;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -11,8 +11,9 @@
 use serde;
 use serde_json;
 
-use super::Notification;
+use super::{Notification, Request};
 use ls_types::notification::Notification as LSPNotification;
+use ls_types::request::Request as LSPRequest;
 
 use std::fmt;
 use std::io::{self, Read, Write};
@@ -145,12 +146,22 @@ pub trait Output: Sync + Send + Clone + 'static {
     }
 
     /// Send a notification along the output.
-    fn notify<A, P>(&self, notification: Notification<A>)
+    fn notify<A>(&self, notification: Notification<A>)
     where
-        A: LSPNotification<Params = P>,
-        P: serde::Serialize,
+        A: LSPNotification,
+        <A as LSPNotification>::Params: serde::Serialize,
     {
         self.response(format!("{}", notification));
+    }
+
+    /// Send a one-shot request along the output.
+    /// Ignores any response associated with the request.
+    fn request<A>(&self, request: Request<A>)
+    where
+        A: LSPRequest,
+        <A as LSPRequest>::Params: serde::Serialize,
+    {
+        self.response(format!("{}", request));
     }
 }
 

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -12,8 +12,7 @@ use serde;
 use serde_json;
 
 use super::{Notification, Request};
-use ls_types::notification::Notification as LSPNotification;
-use ls_types::request::Request as LSPRequest;
+use lsp_data::{LSPNotification, LSPRequest};
 
 use std::fmt;
 use std::io::{self, Read, Write};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -304,7 +304,7 @@ impl BlockingRequestAction for InitializeRequest {
 
         let result = InitializeResult {
             capabilities: ServerCapabilities {
-                text_document_sync: Some(TextDocumentSyncKind::Incremental),
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::Incremental)),
                 hover_provider: Some(true),
                 completion_provider: Some(CompletionOptions {
                     resolve_provider: Some(true),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -116,6 +116,18 @@ pub struct Request<A: LSPRequest> {
     pub _action: PhantomData<A>,
 }
 
+impl<A: LSPRequest> Request<A> {
+    /// Creates a server `Request` structure with given `params`.
+    pub fn new(id: usize, params: A::Params) -> Request<A> {
+        Request {
+            id,
+            received: Instant::now(),
+            params,
+            _action: PhantomData,
+        }
+    }
+}
+
 /// A notification that gets JSON serialized in the language server protocol.
 #[derive(Debug, PartialEq)]
 pub struct Notification<A: LSPNotification> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -30,8 +30,6 @@ use server::io::{StdioMsgReader, StdioOutput};
 use server::dispatch::Dispatcher;
 pub use server::dispatch::{RequestAction, ResponseError};
 
-use ls_types::notification::Notification as LSPNotification;
-use ls_types::request::Request as LSPRequest;
 pub use ls_types::request::Shutdown as ShutdownRequest;
 pub use ls_types::request::Initialize as InitializeRequest;
 pub use ls_types::notification::Exit as ExitNotification;
@@ -728,7 +726,7 @@ mod test {
         #[derive(Debug)]
         pub enum DummyNotification { }
 
-        impl notification::Notification for DummyNotification {
+        impl LSPNotification for DummyNotification {
             type Params = ();
             const METHOD: &'static str = "dummyNotification";
         }
@@ -754,7 +752,7 @@ mod test {
         #[derive(Serialize)]
         pub struct EmptyParams {}
 
-        impl notification::Notification for DummyNotification {
+        impl LSPNotification for DummyNotification {
             type Params = EmptyParams;
             const METHOD: &'static str = "dummyNotification";
         }


### PR DESCRIPTION
A small followup to #644.

Most notably:
* Uses newly introduced LS types
* Removes `serde_json::to_string(&RequestMessage...` machinery in favor of using new LS traits
*  Consistently uses renamed `Request`, `Notification` as `LSPRequest` and `LSPNotification` to distinguish from our `server::{Request, Notification}` types

r? @nrc