### PR TITLE
Fix Initialized message parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "languageserver-types"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/Xanewok/languageserver-types?branch=backport-0.17-fix-params-types#94aea90bb2056fdb9a96799d8614dee0277be57c"
 dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -881,7 +881,7 @@ dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "languageserver-types 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "languageserver-types 0.17.0 (git+https://github.com/Xanewok/languageserver-types?branch=backport-0.17-fix-params-types)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1455,7 +1455,7 @@ dependencies = [
 "checksum json 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)" = "39ebf0fac977ee3a4a3242b6446004ff64514889e3e2730bbd4f764a67a2e483"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum languageserver-types 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15a4c0850f6ddf7298201ccabdcad644f14fa607302a04ccb91540fce4ad101d"
+"checksum languageserver-types 0.17.0 (git+https://github.com/Xanewok/languageserver-types?branch=backport-0.17-fix-params-types)" = "<none>"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ cargo = { git = "https://github.com/rust-lang/cargo" }
 env_logger = "0.4"
 failure = "0.1.1"
 jsonrpc-core = "8.0.1"
-languageserver-types = "0.17"
+languageserver-types = { git = "https://github.com/Xanewok/languageserver-types", branch = "backport-0.17-fix-params-types" }
 lazy_static = "0.2"
 log = "0.3"
 racer = "2.0.12"


### PR DESCRIPTION
Fixes issue described at https://github.com/gluon-lang/languageserver-types/issues/46.

Currently pulls my local branch with backported fix, switching back to crate is blocked both on https://github.com/rust-lang-nursery/rls/pull/658 (updates to newest ls-types) and https://github.com/gluon-lang/languageserver-types/pull/47 (actual fix on top of 0.26).