### PR TITLE
Add formatted compiler message labels & children to diagnostics

### DIFF
--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -353,7 +353,7 @@ mod diagnostic_message_test {
     use super::*;
 
     fn parsed_message(compiler_message: &str) -> String {
-        let _ = ::env_logger::init();
+        let _ = ::env_logger::try_init();
         parse_diagnostics(compiler_message)
             .expect("failed to parse compiler message")
             .diagnostic

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -206,24 +206,19 @@ fn parse_diagnostics(message: &str) -> Option<FileDiagnostic> {
         return None;
     }
 
+    let diagnostic_msg = format!("{}\n", message.message);
     let primary_span = message.spans.iter().find(|s| s.is_primary).unwrap();
     let rls_span = primary_span.rls_span().zero_indexed();
     let suggestions = make_suggestions(&message.children, &rls_span.file);
 
-    let primary_message = {
-        let mut primary_message = message.message.clone();
-        if let Some(ref primary_label) = primary_span.label {
-            primary_message.push_str(&format!(": {}", primary_label));
-        }
-        primary_message
-    };
-
     let diagnostic = {
-        let mut primary_message = primary_message.clone();
+        let mut primary_message = diagnostic_msg.clone();
+        if let Some(ref primary_label) = primary_span.label {
+            primary_message.push_str(&format!("\n{}", primary_label));
+        }
 
         if let Some(notes) = format_notes(&message.children, primary_span) {
-            primary_message.push('\n');
-            primary_message.push_str(&notes);
+            primary_message.push_str(&format!("\n{}", notes));
         }
 
         Diagnostic {
@@ -246,11 +241,10 @@ fn parse_diagnostics(message: &str) -> Option<FileDiagnostic> {
     .iter()
     .filter(|x| !x.is_primary)
     .map(|secondary_span| {
-        let mut secondary_message = primary_message.clone();
+        let mut secondary_message = diagnostic_msg.clone();
 
         if let Some(ref secondary_label) = secondary_span.label {
-            secondary_message.push_str("\n");
-            secondary_message.push_str(secondary_label);
+            secondary_message.push_str(&format!("\n{}", secondary_label));
         }
         let rls_span = secondary_span.rls_span().zero_indexed();
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -541,7 +541,7 @@ fn test_borrow_error() {
             ExpectedMessage::new(None).expect_contains("beginBuild"),
             ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
             ExpectedMessage::new(None).expect_contains(
-                r#""message":"cannot borrow `x` as mutable more than once at a time""#,
+                r#""message":"cannot borrow `x` as mutable more than once at a time"#,
             ),
             ExpectedMessage::new(None).expect_contains("diagnosticsEnd"),
         ],
@@ -1181,7 +1181,7 @@ fn test_features() {
             ExpectedMessage::new(None).expect_contains("beginBuild"),
             ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
             ExpectedMessage::new(None).expect_contains(
-                r#""message":"cannot find struct, variant or union type `Bar` in this scope""#,
+                r#""message":"cannot find struct, variant or union type `Bar` in this scope"#,
             ),
             ExpectedMessage::new(None).expect_contains("diagnosticsEnd"),
         ],
@@ -1241,7 +1241,7 @@ fn test_no_default_features() {
             ExpectedMessage::new(None).expect_contains("beginBuild"),
             ExpectedMessage::new(None).expect_contains("diagnosticsBegin"),
             ExpectedMessage::new(None).expect_contains(
-                r#""message":"cannot find struct, variant or union type `Baz` in this scope""#,
+                r#""message":"cannot find struct, variant or union type `Baz` in this scope"#,
             ),
             ExpectedMessage::new(None).expect_contains("diagnosticsEnd"),
         ],

--- a/test_data/compiler_message/consider-borrowing.json
+++ b/test_data/compiler_message/consider-borrowing.json
@@ -1,0 +1,59 @@
+{
+  "children": [{
+    "children": [],
+    "code": null,
+    "level": "note",
+    "message": "expected type `&str`\n   found type `std::string::String`",
+    "rendered": null,
+    "spans": []
+  }, {
+    "children": [],
+    "code": null,
+    "level": "help",
+    "message": "consider borrowing here",
+    "rendered": null,
+    "spans": [{
+      "byte_end": 4144,
+      "byte_start": 4138,
+      "column_end": 25,
+      "column_start": 19,
+      "expansion": null,
+      "file_name": "src/lib.rs",
+      "is_primary": true,
+      "label": null,
+      "line_end": 135,
+      "line_start": 135,
+      "suggested_replacement": "&string",
+      "text": [{
+        "highlight_end": 25,
+        "highlight_start": 19,
+        "text": "        takes_ref(string);"
+      }]
+    }]
+  }],
+  "code": {
+    "code": "E0308",
+    "explanation": "\nThis error occurs when the compiler was unable to infer the concrete type of a\nvariable. It can occur for several cases, the most common of which is a\nmismatch in the expected type that the compiler inferred for a variable's\ninitializing expression, and the actual type explicitly assigned to the\nvariable.\n\nFor example:\n\n```compile_fail,E0308\nlet x: i32 = \"I am not a number!\";\n//     ~~~   ~~~~~~~~~~~~~~~~~~~~\n//      |             |\n//      |    initializing expression;\n//      |    compiler infers type `&str`\n//      |\n//    type `i32` assigned to variable `x`\n```\n"
+  },
+  "level": "error",
+  "message": "mismatched types",
+  "rendered": "error[E0308]: mismatched types\n   --> src/lib.rs:135:19\n    |\n135 |         takes_ref(string);\n    |                   ^^^^^^\n    |                   |\n    |                   expected &str, found struct `std::string::String`\n    |                   help: consider borrowing here: `&string`\n    |\n    = note: expected type `&str`\n               found type `std::string::String`\n\n",
+  "spans": [{
+    "byte_end": 4144,
+    "byte_start": 4138,
+    "column_end": 25,
+    "column_start": 19,
+    "expansion": null,
+    "file_name": "src/lib.rs",
+    "is_primary": true,
+    "label": "expected &str, found struct `std::string::String`",
+    "line_end": 135,
+    "line_start": 135,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 25,
+      "highlight_start": 19,
+      "text": "        takes_ref(string);"
+    }]
+  }]
+}

--- a/test_data/compiler_message/mismatched-types.json
+++ b/test_data/compiler_message/mismatched-types.json
@@ -1,0 +1,45 @@
+{
+  "children": [],
+  "code": {
+    "code": "E0308",
+    "explanation": "\nThis error occurs when the compiler was unable to infer the concrete type of a\nvariable. It can occur for several cases, the most common of which is a\nmismatch in the expected type that the compiler inferred for a variable's\ninitializing expression, and the actual type explicitly assigned to the\nvariable.\n\nFor example:\n\n```compile_fail,E0308\nlet x: i32 = \"I am not a number!\";\n//     ~~~   ~~~~~~~~~~~~~~~~~~~~\n//      |             |\n//      |    initializing expression;\n//      |    compiler infers type `&str`\n//      |\n//    type `i32` assigned to variable `x`\n```\n"
+  },
+  "level": "error",
+  "message": "mismatched types",
+  "rendered": "error[E0308]: mismatched types\n   --> src/lib.rs:137:9\n    |\n136 |     fn mismatched_types() -> usize {\n    |                              ----- expected `usize` because of return type\n137 |         123_i32\n    |         ^^^^^^^ expected usize, found i32\n\n",
+  "spans": [{
+    "byte_end": 4140,
+    "byte_start": 4133,
+    "column_end": 16,
+    "column_start": 9,
+    "expansion": null,
+    "file_name": "src/lib.rs",
+    "is_primary": true,
+    "label": "expected usize, found i32",
+    "line_end": 137,
+    "line_start": 137,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 16,
+      "highlight_start": 9,
+      "text": "        123_i32"
+    }]
+  }, {
+    "byte_end": 4122,
+    "byte_start": 4117,
+    "column_end": 35,
+    "column_start": 30,
+    "expansion": null,
+    "file_name": "src/lib.rs",
+    "is_primary": false,
+    "label": "expected `usize` because of return type",
+    "line_end": 136,
+    "line_start": 136,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 35,
+      "highlight_start": 30,
+      "text": "    fn mismatched_types() -> usize {"
+    }]
+  }]
+}

--- a/test_data/compiler_message/move-out-of-borrow.json
+++ b/test_data/compiler_message/move-out-of-borrow.json
@@ -1,0 +1,45 @@
+{
+  "children": [],
+  "code": {
+    "code": "E0507",
+    "explanation": "\nYou tried to move out of a value which was borrowed. Erroneous code example:\n\n```compile_fail,E0507\nuse std::cell::RefCell;\n\nstruct TheDarkKnight;\n\nimpl TheDarkKnight {\n    fn nothing_is_true(self) {}\n}\n\nfn main() {\n    let x = RefCell::new(TheDarkKnight);\n\n    x.borrow().nothing_is_true(); // error: cannot move out of borrowed content\n}\n```\n\nHere, the `nothing_is_true` method takes the ownership of `self`. However,\n`self` cannot be moved because `.borrow()` only provides an `&TheDarkKnight`,\nwhich is a borrow of the content owned by the `RefCell`. To fix this error,\nyou have three choices:\n\n* Try to avoid moving the variable.\n* Somehow reclaim the ownership.\n* Implement the `Copy` trait on the type.\n\nExamples:\n\n```\nuse std::cell::RefCell;\n\nstruct TheDarkKnight;\n\nimpl TheDarkKnight {\n    fn nothing_is_true(&self) {} // First case, we don't take ownership\n}\n\nfn main() {\n    let x = RefCell::new(TheDarkKnight);\n\n    x.borrow().nothing_is_true(); // ok!\n}\n```\n\nOr:\n\n```\nuse std::cell::RefCell;\n\nstruct TheDarkKnight;\n\nimpl TheDarkKnight {\n    fn nothing_is_true(self) {}\n}\n\nfn main() {\n    let x = RefCell::new(TheDarkKnight);\n    let x = x.into_inner(); // we get back ownership\n\n    x.nothing_is_true(); // ok!\n}\n```\n\nOr:\n\n```\nuse std::cell::RefCell;\n\n#[derive(Clone, Copy)] // we implement the Copy trait\nstruct TheDarkKnight;\n\nimpl TheDarkKnight {\n    fn nothing_is_true(self) {}\n}\n\nfn main() {\n    let x = RefCell::new(TheDarkKnight);\n\n    x.borrow().nothing_is_true(); // ok!\n}\n```\n\nMoving a member out of a mutably borrowed struct will also cause E0507 error:\n\n```compile_fail,E0507\nstruct TheDarkKnight;\n\nimpl TheDarkKnight {\n    fn nothing_is_true(self) {}\n}\n\nstruct Batcave {\n    knight: TheDarkKnight\n}\n\nfn main() {\n    let mut cave = Batcave {\n        knight: TheDarkKnight\n    };\n    let borrowed = &mut cave;\n\n    borrowed.knight.nothing_is_true(); // E0507\n}\n```\n\nIt is fine only if you put something back. `mem::replace` can be used for that:\n\n```\n# struct TheDarkKnight;\n# impl TheDarkKnight { fn nothing_is_true(self) {} }\n# struct Batcave { knight: TheDarkKnight }\nuse std::mem;\n\nlet mut cave = Batcave {\n    knight: TheDarkKnight\n};\nlet borrowed = &mut cave;\n\nmem::replace(&mut borrowed.knight, TheDarkKnight).nothing_is_true(); // ok!\n```\n\nYou can find more information about borrowing in the rust-book:\nhttp://doc.rust-lang.org/book/first-edition/references-and-borrowing.html\n"
+  },
+  "level": "error",
+  "message": "cannot move out of borrowed content",
+  "rendered": "error[E0507]: cannot move out of borrowed content\n  --> src/main.rs:18:9\n   |\n18 |         &Some(string) => takes_borrow(&string),\n   |         ^^^^^^------^\n   |         |     |\n   |         |     hint: to prevent move, use `ref string` or `ref mut string`\n   |         cannot move out of borrowed content\n\n",
+  "spans": [{
+    "byte_end": 567,
+    "byte_start": 554,
+    "column_end": 22,
+    "column_start": 9,
+    "expansion": null,
+    "file_name": "src/main.rs",
+    "is_primary": true,
+    "label": "cannot move out of borrowed content",
+    "line_end": 18,
+    "line_start": 18,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 22,
+      "highlight_start": 9,
+      "text": "        &Some(string) => takes_borrow(&string),"
+    }]
+  }, {
+    "byte_end": 566,
+    "byte_start": 560,
+    "column_end": 21,
+    "column_start": 15,
+    "expansion": null,
+    "file_name": "src/main.rs",
+    "is_primary": false,
+    "label": "hint: to prevent move, use `ref string` or `ref mut string`",
+    "line_end": 18,
+    "line_start": 18,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 21,
+      "highlight_start": 15,
+      "text": "        &Some(string) => takes_borrow(&string),"
+    }]
+  }]
+}

--- a/test_data/compiler_message/not-mut.json
+++ b/test_data/compiler_message/not-mut.json
@@ -1,0 +1,45 @@
+{
+  "children": [],
+  "code": {
+    "code": "E0596",
+    "explanation": "\nThis error occurs because you tried to mutably borrow a non-mutable variable.\n\nExample of erroneous code:\n\n```compile_fail,E0596\nlet x = 1;\nlet y = &mut x; // error: cannot borrow mutably\n```\n\nIn here, `x` isn't mutable, so when we try to mutably borrow it in `y`, it\nfails. To fix this error, you need to make `x` mutable:\n\n```\nlet mut x = 1;\nlet y = &mut x; // ok!\n```\n"
+  },
+  "level": "error",
+  "message": "cannot borrow immutable local variable `string` as mutable",
+  "rendered": "error[E0596]: cannot borrow immutable local variable `string` as mutable\n   --> src/lib.rs:134:24\n    |\n133 |         let string = String::new();\n    |             ------ consider changing this to `mut string`\n134 |         let _s1 = &mut string;\n    |                        ^^^^^^ cannot borrow mutably\n\n",
+  "spans": [{
+    "byte_end": 4108,
+    "byte_start": 4102,
+    "column_end": 30,
+    "column_start": 24,
+    "expansion": null,
+    "file_name": "src/lib.rs",
+    "is_primary": true,
+    "label": "cannot borrow mutably",
+    "line_end": 134,
+    "line_start": 134,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 30,
+      "highlight_start": 24,
+      "text": "        let _s1 = &mut string;"
+    }]
+  }, {
+    "byte_end": 4061,
+    "byte_start": 4055,
+    "column_end": 19,
+    "column_start": 13,
+    "expansion": null,
+    "file_name": "src/lib.rs",
+    "is_primary": false,
+    "label": "consider changing this to `mut string`",
+    "line_end": 133,
+    "line_start": 133,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 19,
+      "highlight_start": 13,
+      "text": "        let string = String::new();"
+    }]
+  }]
+}

--- a/test_data/compiler_message/type-annotations-needed.json
+++ b/test_data/compiler_message/type-annotations-needed.json
@@ -1,0 +1,45 @@
+{
+  "children": [],
+  "code": {
+    "code": "E0282",
+    "explanation": "\nThis error indicates that type inference did not result in one unique possible\ntype, and extra information is required. In most cases this can be provided\nby adding a type annotation. Sometimes you need to specify a generic type\nparameter manually.\n\nA common example is the `collect` method on `Iterator`. It has a generic type\nparameter with a `FromIterator` bound, which for a `char` iterator is\nimplemented by `Vec` and `String` among others. Consider the following snippet\nthat reverses the characters of a string:\n\n```compile_fail,E0282\nlet x = \"hello\".chars().rev().collect();\n```\n\nIn this case, the compiler cannot infer what the type of `x` should be:\n`Vec<char>` and `String` are both suitable candidates. To specify which type to\nuse, you can use a type annotation on `x`:\n\n```\nlet x: Vec<char> = \"hello\".chars().rev().collect();\n```\n\nIt is not necessary to annotate the full type. Once the ambiguity is resolved,\nthe compiler can infer the rest:\n\n```\nlet x: Vec<_> = \"hello\".chars().rev().collect();\n```\n\nAnother way to provide the compiler with enough information, is to specify the\ngeneric type parameter:\n\n```\nlet x = \"hello\".chars().rev().collect::<Vec<char>>();\n```\n\nAgain, you need not specify the full type if the compiler can infer it:\n\n```\nlet x = \"hello\".chars().rev().collect::<Vec<_>>();\n```\n\nApart from a method or function with a generic type parameter, this error can\noccur when a type parameter of a struct or trait cannot be inferred. In that\ncase it is not always possible to use a type annotation, because all candidates\nhave the same return type. For instance:\n\n```compile_fail,E0282\nstruct Foo<T> {\n    num: T,\n}\n\nimpl<T> Foo<T> {\n    fn bar() -> i32 {\n        0\n    }\n\n    fn baz() {\n        let number = Foo::bar();\n    }\n}\n```\n\nThis will fail because the compiler does not know which instance of `Foo` to\ncall `bar` on. Change `Foo::bar()` to `Foo::<T>::bar()` to resolve the error.\n"
+  },
+  "level": "error",
+  "message": "type annotations needed",
+  "rendered": "error[E0282]: type annotations needed\n   --> src/lib.rs:141:17\n    |\n141 |         let v = Vec::new();\n    |             -   ^^^^^^^^ cannot infer type for `T`\n    |             |\n    |             consider giving `v` a type\n\n",
+  "spans": [{
+    "byte_end": 4162,
+    "byte_start": 4154,
+    "column_end": 25,
+    "column_start": 17,
+    "expansion": null,
+    "file_name": "src/lib.rs",
+    "is_primary": true,
+    "label": "cannot infer type for `T`",
+    "line_end": 141,
+    "line_start": 141,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 25,
+      "highlight_start": 17,
+      "text": "        let v = Vec::new();"
+    }]
+  }, {
+    "byte_end": 4151,
+    "byte_start": 4150,
+    "column_end": 14,
+    "column_start": 13,
+    "expansion": null,
+    "file_name": "src/lib.rs",
+    "is_primary": false,
+    "label": "consider giving `v` a type",
+    "line_end": 141,
+    "line_start": 141,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 14,
+      "highlight_start": 13,
+      "text": "        let v = Vec::new();"
+    }]
+  }]
+}

--- a/test_data/compiler_message/use-after-move.json
+++ b/test_data/compiler_message/use-after-move.json
@@ -1,0 +1,52 @@
+{
+  "children": [{
+    "children": [],
+    "code": null,
+    "level": "note",
+    "message": "move occurs because `s` has type `std::string::String`, which does not implement the `Copy` trait",
+    "rendered": null,
+    "spans": []
+  }],
+  "code": {
+    "code": "E0382",
+    "explanation": "\nThis error occurs when an attempt is made to use a variable after its contents\nhave been moved elsewhere. For example:\n\n```compile_fail,E0382\nstruct MyStruct { s: u32 }\n\nfn main() {\n    let mut x = MyStruct{ s: 5u32 };\n    let y = x;\n    x.s = 6;\n    println!(\"{}\", x.s);\n}\n```\n\nSince `MyStruct` is a type that is not marked `Copy`, the data gets moved out\nof `x` when we set `y`. This is fundamental to Rust's ownership system: outside\nof workarounds like `Rc`, a value cannot be owned by more than one variable.\n\nSometimes we don't need to move the value. Using a reference, we can let another\nfunction borrow the value without changing its ownership. In the example below,\nwe don't actually have to move our string to `calculate_length`, we can give it\na reference to it with `&` instead.\n\n```\nfn main() {\n    let s1 = String::from(\"hello\");\n\n    let len = calculate_length(&s1);\n\n    println!(\"The length of '{}' is {}.\", s1, len);\n}\n\nfn calculate_length(s: &String) -> usize {\n    s.len()\n}\n```\n\nA mutable reference can be created with `&mut`.\n\nSometimes we don't want a reference, but a duplicate. All types marked `Clone`\ncan be duplicated by calling `.clone()`. Subsequent changes to a clone do not\naffect the original variable.\n\nMost types in the standard library are marked `Clone`. The example below\ndemonstrates using `clone()` on a string. `s1` is first set to \"many\", and then\ncopied to `s2`. Then the first character of `s1` is removed, without affecting\n`s2`. \"any many\" is printed to the console.\n\n```\nfn main() {\n    let mut s1 = String::from(\"many\");\n    let s2 = s1.clone();\n    s1.remove(0);\n    println!(\"{} {}\", s1, s2);\n}\n```\n\nIf we control the definition of a type, we can implement `Clone` on it ourselves\nwith `#[derive(Clone)]`.\n\nSome types have no ownership semantics at all and are trivial to duplicate. An\nexample is `i32` and the other number types. We don't have to call `.clone()` to\nclone them, because they are marked `Copy` in addition to `Clone`.  Implicit\ncloning is more convienient in this case. We can mark our own types `Copy` if\nall their members also are marked `Copy`.\n\nIn the example below, we implement a `Point` type. Because it only stores two\nintegers, we opt-out of ownership semantics with `Copy`. Then we can\n`let p2 = p1` without `p1` being moved.\n\n```\n#[derive(Copy, Clone)]\nstruct Point { x: i32, y: i32 }\n\nfn main() {\n    let mut p1 = Point{ x: -1, y: 2 };\n    let p2 = p1;\n    p1.x = 1;\n    println!(\"p1: {}, {}\", p1.x, p1.y);\n    println!(\"p2: {}, {}\", p2.x, p2.y);\n}\n```\n\nAlternatively, if we don't control the struct's definition, or mutable shared\nownership is truly required, we can use `Rc` and `RefCell`:\n\n```\nuse std::cell::RefCell;\nuse std::rc::Rc;\n\nstruct MyStruct { s: u32 }\n\nfn main() {\n    let mut x = Rc::new(RefCell::new(MyStruct{ s: 5u32 }));\n    let y = x.clone();\n    x.borrow_mut().s = 6;\n    println!(\"{}\", x.borrow().s);\n}\n```\n\nWith this approach, x and y share ownership of the data via the `Rc` (reference\ncount type). `RefCell` essentially performs runtime borrow checking: ensuring\nthat at most one writer or multiple readers can access the data at any one time.\n\nIf you wish to learn more about ownership in Rust, start with the chapter in the\nBook:\n\nhttps://doc.rust-lang.org/book/first-edition/ownership.html\n"
+  },
+  "level": "error",
+  "message": "use of moved value: `s`",
+  "rendered": "error[E0382]: use of moved value: `s`\n   --> src/lib.rs:147:26\n    |\n146 |         ::std::mem::drop(s);\n    |                          - value moved here\n147 |         ::std::mem::drop(s);\n    |                          ^ value used here after move\n    |\n    = note: move occurs because `s` has type `std::string::String`, which does not implement the `Copy` trait\n\n",
+  "spans": [{
+    "byte_end": 4285,
+    "byte_start": 4284,
+    "column_end": 27,
+    "column_start": 26,
+    "expansion": null,
+    "file_name": "src/lib.rs",
+    "is_primary": true,
+    "label": "value used here after move",
+    "line_end": 147,
+    "line_start": 147,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 27,
+      "highlight_start": 26,
+      "text": "        ::std::mem::drop(s);"
+    }]
+  }, {
+    "byte_end": 4256,
+    "byte_start": 4255,
+    "column_end": 27,
+    "column_start": 26,
+    "expansion": null,
+    "file_name": "src/lib.rs",
+    "is_primary": false,
+    "label": "value moved here",
+    "line_end": 146,
+    "line_start": 146,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 27,
+      "highlight_start": 26,
+      "text": "        ::std::mem::drop(s);"
+    }]
+  }]
+}


### PR DESCRIPTION
Related to #649, #662 this pr adds `CompilerMessage` secondary `.span` & `.children` information to diagnostics. This really helps the diagnostics in being useful.

## Atom
_before_
![atom-before](https://user-images.githubusercontent.com/2331607/35103821-f21b52c4-fc5e-11e7-88c7-2ff49bc46f5e.png)
vvv
![atom-after](https://user-images.githubusercontent.com/2331607/35103824-f3e86b6e-fc5e-11e7-8963-f22dc358bf1d.png)

## Vscode
_before_
![vscode-before](https://user-images.githubusercontent.com/2331607/35103863-0f6843a0-fc5f-11e7-84a5-95dd756cd825.png)
vvv
![vscode-after](https://user-images.githubusercontent.com/2331607/35103944-4f87f4d0-fc5f-11e7-9161-1d0296c4fd0b.png)

With vscode it cuts off the message mid-word at the max width. Atom wraps properly. I think this is the responsibility of the **client**, as wrapping isn't too arduous. Even so the messages are quite usable in vscode and I'm sure people will appreciate them even cut in half.

## Implementation notes
I've gone to some pains to avoid showing messages meant for different areas of the code by only including children-spans that are 'within' the primary span and secondary spans that are on the same line. There is some more work for generating additional diagnostics for the other spans.

## Testing
Since there will be many compiler messages to get right I've added unit tests for my cases (which are fast / can scale to many tests). The compiler output generated by cargo with `--mesage-format=json` are stored in **test_data/compiler_message/*.json** files. We can add more cases as we discover suboptimal output.