### PR TITLE
Fix command tests shutdown & exit messages

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -184,13 +184,13 @@ impl RlsHandle {
         }))
     }
     pub fn shutdown_exit(&mut self) {
-        self.request(99999, "shutdown", json!({})).unwrap();
+        self.request(99999, "shutdown", json!(null)).unwrap();
 
         self.expect_messages(&[
             &ExpectedMessage::new(Some(99999)),
         ]);
 
-        self.notify("exit", json!({})).unwrap();
+        self.notify("exit", json!(null)).unwrap();
 
         let ecode = self.child.wait()
             .expect("failed to wait on child rls process");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -21,7 +21,7 @@ use support::{ExpectedMessage, RlsHandle, basic_bin_manifest, project, timeout};
 const TIME_LIMIT_SECS: u64 = 300;
 
 #[test]
-fn test_infer_bin() {
+fn cmd_test_infer_bin() {
     timeout(Duration::from_secs(TIME_LIMIT_SECS), ||{
         let p = project("simple_workspace")
             .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -55,7 +55,7 @@ fn test_infer_bin() {
 }
 
 #[test]
-fn test_simple_workspace() {
+fn cmd_test_simple_workspace() {
     timeout(Duration::from_secs(300), ||{
         let p = project("simple_workspace")
             .file("Cargo.toml", r#"


### PR DESCRIPTION
Use `null` params for exit & shutdown messages as per spec (fixes tests)
Prefix command tests with `cmd_` to distinguish from other tests

Fixes #665 