### PR TITLE
Handle panics better in command tests

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -19,7 +19,7 @@ use std::str;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
-
+use std::panic;
 
 use support::paths::TestPathExt;
 
@@ -27,30 +27,42 @@ pub mod paths;
 
 /// Executes `func` and panics if it takes longer than `dur`.
 pub fn timeout<F>(dur: Duration, func: F)
-    where F: FnOnce() + Send + 'static {
-    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    where F: FnOnce() + Send + 'static + panic::UnwindSafe {
+    let pair = Arc::new((Mutex::new(TestState::Running), Condvar::new()));
     let pair2 = pair.clone();
 
     thread::spawn(move|| {
         let &(ref lock, ref cvar) = &*pair2;
-        func();
-        let mut finished = lock.lock().unwrap();
-        *finished = true;
+        match panic::catch_unwind(|| func()) {
+            Ok(_) => *lock.lock().unwrap() = TestState::Success,
+            Err(_) => *lock.lock().unwrap() = TestState::Fail,
+        }
+
         // We notify the condvar that the value has changed.
         cvar.notify_one();
     });
 
     // Wait for the test to finish.
     let &(ref lock, ref cvar) = &*pair;
-    let mut finished = lock.lock().unwrap();
+    let mut test_state = lock.lock().unwrap();
     // As long as the value inside the `Mutex` is false, we wait.
-    while !*finished {
-        let result = cvar.wait_timeout(finished, dur).unwrap();
+    while *test_state == TestState::Running {
+        let result = cvar.wait_timeout(test_state, dur).unwrap();
         if result.1.timed_out() {
             panic!("Timed out")
         }
-        finished = result.0
+        if *result.0 == TestState::Fail {
+            panic!("failed");
+        }
+        test_state = result.0
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum TestState {
+    Running,
+    Success,
+    Fail,
 }
 
 #[derive(Clone, Debug)]
@@ -194,7 +206,7 @@ impl RlsHandle {
 
         let ecode = self.child.wait()
             .expect("failed to wait on child rls process");
-        
+
         assert!(ecode.success());
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -21,7 +21,7 @@ use support::{ExpectedMessage, RlsHandle, basic_bin_manifest, project, timeout};
 const TIME_LIMIT_SECS: u64 = 300;
 
 #[test]
-fn test_infer_bin() {
+fn cmd_test_infer_bin() {
     timeout(Duration::from_secs(TIME_LIMIT_SECS), ||{
         let p = project("simple_workspace")
             .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -55,7 +55,7 @@ fn test_infer_bin() {
 }
 
 #[test]
-fn test_simple_workspace() {
+fn cmd_test_simple_workspace() {
     timeout(Duration::from_secs(300), ||{
         let p = project("simple_workspace")
             .file("Cargo.toml", r#"


### PR DESCRIPTION
Will avoid timeouts when command tests panic, see https://github.com/rust-lang-nursery/rls/issues/665#issuecomment-358708965