### PR TITLE
Rustup to rustc 1.25.0-nightly (97520ccb1 2018-01-21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,7 +971,7 @@ dependencies = [
  "rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-analysis 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-rustc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-rustc 0.1.1 (git+https://github.com/nrc/rls-rustc)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-vfs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt-nightly 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "rls-rustc"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/nrc/rls-rustc#aaa4adad41135c216875d8703f30be4bcd208312"
 
 [[package]]
 name = "rls-span"
@@ -1673,7 +1673,7 @@ dependencies = [
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rls-analysis 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "38841e3c5271715a574ac220d9b408b59ed9e2626909c3bc54b5853b4eaadb7b"
 "checksum rls-data 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8024f1feaca72d0aa4ae1e2a8d454a31b9a33ed02f8d0e9c8559bf53c267ec3c"
-"checksum rls-rustc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b21ea952e9bf1569929abf1bb920262cde04b7b1b26d8e0260286302807299d2"
+"checksum rls-rustc 0.1.1 (git+https://github.com/nrc/rls-rustc)" = "<none>"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rls-vfs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd34691a510938bb67fe0444fb363103c73ffb31c121d1e16bc92d8945ea8ff"
 "checksum rustc-ap-rustc_cratesio_shim 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1a51c10af5abd5d698b7e3487e869e6d15f6feb04cbedb5c792e2824f9d845e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 racer = "2.0.12"
 rls-analysis = "0.10"
 rls-data = { version = "0.14", features = ["serialize-serde"] }
-rls-rustc = "0.1"
+rls-rustc = { git = "https://github.com/nrc/rls-rustc" }
 rls-span = { version = "0.4", features = ["serialize-serde"] }
 rls-vfs = { version = "0.4", features = ["racer-impls"] }
 rustfmt-nightly = { version = "0.3.6", optional = true }

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -14,6 +14,7 @@ extern crate rustc_driver;
 extern crate rustc_errors as errors;
 extern crate rustc_resolve;
 extern crate rustc_save_analysis;
+extern crate rustc_trans_utils;
 extern crate syntax;
 
 use self::rustc::middle::cstore::CrateStore;
@@ -23,6 +24,7 @@ use self::rustc_driver::{run, run_compiler, Compilation, CompilerCalls, RustcDef
 use self::rustc_driver::driver::CompileController;
 use self::rustc_save_analysis as save;
 use self::rustc_save_analysis::CallbackHandler;
+use self::rustc_trans_utils::trans_crate::TransCrate;
 use self::syntax::ast;
 use self::syntax::codemap::{FileLoader, RealFileLoader};
 
@@ -148,6 +150,7 @@ impl<'a> CompilerCalls<'a> for RlsRustcCalls {
 
     fn late_callback(
         &mut self,
+        trans_crate: &TransCrate,
         matches: &getopts::Matches,
         sess: &Session,
         cstore: &CrateStore,
@@ -156,7 +159,7 @@ impl<'a> CompilerCalls<'a> for RlsRustcCalls {
         ofile: &Option<PathBuf>,
     ) -> Compilation {
         self.default_calls
-            .late_callback(matches, sess, cstore, input, odir, ofile)
+            .late_callback(trans_crate, matches, sess, cstore, input, odir, ofile)
     }
 
     fn build_controller(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -425,7 +425,7 @@ impl<O: Output> LsService<O> {
                     if $method == <$request as LSPRequest>::METHOD {
                         let request: Request<$request> = msg.parse_as_request()?;
                         let request = (request, self.ctx.inited());
-                        self.dispatcher.dispatch((request));
+                        self.dispatcher.dispatch(request);
                         handled = true;
                     }
                 )*


### PR DESCRIPTION
Note the diff in Cargo.toml:
```diff
-rls-rustc = "0.1"
+rls-rustc = { git = "https://github.com/nrc/rls-rustc" }
```
Once the new version of rls-rustc is published, this can be restored. 

cc @nrc