### PR TITLE
Add a "group" field to Diagnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "languageserver-types"
-version = "0.27.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1010,7 +1010,7 @@ dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "languageserver-types 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "languageserver-types 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1705,7 +1705,7 @@ dependencies = [
 "checksum json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9ad0485404155f45cce53a40d4b2d6ac356418300daed05273d9e26f91c390be"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum languageserver-types 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a2036fc8576a22689b7e3171c07eb8e8f700678d7a8a53f6f65abbeb35261e1"
+"checksum languageserver-types 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1541f9b22687f060511d213036e1f058797c48e3501e177f01cb6e88de802f5b"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cargo = { git = "https://github.com/rust-lang/cargo", rev = "1d6dfea44f97199d5d5
 env_logger = "0.5"
 failure = "0.1.1"
 jsonrpc-core = "8.0.1"
-languageserver-types = "0.27"
+languageserver-types = "0.30"
 lazy_static = "1"
 log = "0.4"
 racer = "2.0.12"

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -379,7 +379,7 @@ mod diagnostic_message_test {
     /// Returns (primary message, secondary messages)
     fn parsed_message(compiler_message: &str) -> (String, Vec<String>) {
         let _ = ::env_logger::try_init();
-        let parsed = parse_diagnostics(compiler_message)
+        let parsed = parse_diagnostics(compiler_message, 0)
             .expect("failed to parse compiler message");
         (parsed.diagnostic.message, parsed.secondaries.into_iter().map(|s| s.message).collect())
     }

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -100,15 +100,13 @@ impl PostBuildHandler {
             v.clear();
         }
 
-        let mut group = 0;
-
-        for msg in messages {
+        for (group, msg) in messages.iter().enumerate() {
             if let Some(FileDiagnostic {
                 file_path,
                 diagnostic,
                 secondaries,
                 suggestions,
-            }) = parse_diagnostics(msg, group) {
+            }) = parse_diagnostics(msg, group as u64) {
                 let entry = results
                     .entry(cwd.join(file_path))
                     .or_insert_with(Vec::new);
@@ -117,7 +115,6 @@ impl PostBuildHandler {
                 for secondary in secondaries {
                     entry.push((secondary, vec![]));
                 }
-                group += 1;
             }
         }
 


### PR DESCRIPTION
With https://github.com/rust-lang-nursery/rls/pull/664, clients now receive secondary labels as a single [diagnostic](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#diagnostic).

The issue is that clients don't know to which error belong all the secondary diagnostics.
Adding a `group` field solves this problem.
I intentionally made the minimum and simple changes to the code. Clients are free to ignore the field

I worked a bit with my editor to display the labels and it renders like this:
![peek 24-01-2018 02-44](https://user-images.githubusercontent.com/5273820/35316205-b0355bc2-00d0-11e8-88ca-4affcd4bb548.gif)

If this is accepted I will make a PR to [languageserver-types](https://github.com/gluon-lang/languageserver-types)

cc @Xanewok @alexheretic 