### PR TITLE
Fix #675 travis allow_failures: osx & fast_finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,12 @@ env:
   - RUSTFMT=true
 matrix:
   include:
-    rust: nightly
+  - rust: nightly
     env: RUSTFMT=false
     os: linux
+  allow_failures:
+  - os: osx
+  fast_finish: true
 install:
     # Required for Racer autoconfiguration
     rustup component add rust-src


### PR DESCRIPTION
How about a compromise for the rarely running osx builds bemoaned in #675? 

This pr still runs osx as before, but `allow_failures` + `fast_finish` mean the travis-build is marked as success as soon as the linux builds have passed. 

So we get the speed of disabling the osx build, but can still inspect the osx build state, logs etc.