### PR TITLE
Fix #686: send showMessage when missing/invalid Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,9 @@ dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ rayon = "0.9"
 
 [dev-dependencies]
 json = "0.11"
+tempdir = "0.3"
+walkdir = "2"
 
 [features]
 default = ["rustfmt"]

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -83,6 +83,15 @@ impl ActionContext {
         client_capabilities: lsp_data::ClientCapabilities,
         out: O,
     ) {
+        let cargo_toml = current_project.join("Cargo.toml");
+        if !cargo_toml.is_file() {
+            let warning: Notification<ShowMessage> = Notification::new(ShowMessageParams {
+                typ: MessageType::Warning,
+                message: format!("A {:?} file is required to support all RLS features", cargo_toml)
+            });
+            out.notify(warning);
+        }
+
         let ctx = match *self {
             ActionContext::Uninit(ref uninit) => {
                 let ctx = InitActionContext::new(

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -37,6 +37,8 @@ pub struct Environment {
 }
 
 impl Environment {
+    /// constructs a new test environment around a project directory child of `./test_data`
+    /// if path is absolute will use as is
     pub fn new<P: AsRef<Path>>(project_dir: P) -> Self {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -49,16 +51,7 @@ impl Environment {
             env::set_var("RUSTC", "rustc");
         }
 
-        // Acquire the current directory, but this is changing when tests are
-        // running so we need to be sure to access it in a synchronized fashion.
-        let cur_dir = {
-            use build::environment::{EnvironmentLock, Environment};
-            let env = EnvironmentLock::get();
-            let (guard, _other) = env.lock();
-            Environment::push_with_lock(&HashMap::new(), None, guard)
-                .get_old_cwd()
-                .to_path_buf()
-        };
+        let cur_dir = current_dir();
         let project_path = {
             if project_dir.as_ref().is_absolute() {
                 project_dir.as_ref().to_path_buf()
@@ -120,6 +113,17 @@ impl Drop for Environment {
             fs::remove_dir_all(&self.target_path).expect("failed to tidy up");
         }
     }
+}
+
+// Acquire the current directory, but this is changing when tests are
+// running so we need to be sure to access it in a synchronized fashion.
+fn current_dir() -> PathBuf {
+    use build::environment::{EnvironmentLock, Environment};
+    let env = EnvironmentLock::get();
+    let (guard, _other) = env.lock();
+    Environment::push_with_lock(&HashMap::new(), None, guard)
+        .get_old_cwd()
+        .to_path_buf()
 }
 
 struct MockMsgReader {
@@ -360,15 +364,7 @@ fn char_of_byte_index(s: &str, byte: usize) -> usize {
 }
 
 pub fn test_data_to_tmp_dir<P: AsRef<Path>>(test_data_path: P) -> Result<TempDir, Box<Error>> {
-    let cur_dir = {
-        use build::environment::{EnvironmentLock, Environment};
-        let env = EnvironmentLock::get();
-        let (guard, _other) = env.lock();
-        Environment::push_with_lock(&HashMap::new(), None, guard)
-            .get_old_cwd()
-            .to_path_buf()
-    };
-
+    let cur_dir = current_dir();
     let test_data_dir = cur_dir.join(&test_data_path);
     let dir = TempDir::new(test_data_path.as_ref().to_str().unwrap_or("rls-test"))?;
 

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -8,12 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+extern crate tempdir;
+extern crate walkdir;
+
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::fs;
+use self::tempdir::TempDir;
+use self::walkdir::WalkDir;
+use std::error::Error;
 
 use analysis;
 use config::Config;
@@ -30,7 +37,7 @@ pub struct Environment {
 }
 
 impl Environment {
-    pub fn new(project_dir: &str) -> Self {
+    pub fn new<P: AsRef<Path>>(project_dir: P) -> Self {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         lazy_static! {
@@ -52,7 +59,13 @@ impl Environment {
                 .get_old_cwd()
                 .to_path_buf()
         };
-        let project_path = cur_dir.join("test_data").join(project_dir);
+        let project_path = {
+            if project_dir.as_ref().is_absolute() {
+                project_dir.as_ref().to_path_buf()
+            } else {
+                cur_dir.join("test_data").join(project_dir)
+            }
+        };
         let target_path = cur_dir
             .join("target")
             .join("tests")
@@ -193,11 +206,11 @@ impl ExpectedMessage {
 }
 
 macro_rules! wait_for_n_results {
-    ($n:expr, $results:expr) => {{
+    ($n:expr, $results:expr, timeout= $timout:expr) => {{
         use std::time::{Duration, SystemTime};
         use std::thread;
 
-        let timeout = Duration::from_secs(320);
+        let timeout = $timout; //Duration::from_secs(320);
         let start_clock = SystemTime::now();
         let mut results_count = $results.lock().unwrap().len();
         while results_count < $n {
@@ -208,6 +221,9 @@ macro_rules! wait_for_n_results {
             results_count = $results.lock().unwrap().len();
         }
     }};
+    ($n:expr, $results:expr) => {
+        wait_for_n_results!($n, $results, timeout = Duration::from_secs(320))
+    };
 }
 
 pub fn expect_messages(results: LsResultList, expected: &[&ExpectedMessage]) {
@@ -341,4 +357,26 @@ fn char_of_byte_index(s: &str, byte: usize) -> usize {
     }
 
     panic!("Couldn't find byte {} in {:?}", byte, s);
+}
+
+pub fn test_data_to_tmp_dir<P: AsRef<Path>>(test_data_path: P) -> Result<TempDir, Box<Error>> {
+    let cur_dir = {
+        use build::environment::{EnvironmentLock, Environment};
+        let env = EnvironmentLock::get();
+        let (guard, _other) = env.lock();
+        Environment::push_with_lock(&HashMap::new(), None, guard)
+            .get_old_cwd()
+            .to_path_buf()
+    };
+
+    let test_data_dir = cur_dir.join(&test_data_path);
+    let dir = TempDir::new(test_data_path.as_ref().to_str().unwrap_or("rls-test"))?;
+
+    for entry in WalkDir::new(&test_data_dir).into_iter().filter_map(|e| e.ok()) {
+        fs::copy(
+            entry.path(),
+            dir.path().join(entry.path().strip_prefix(&test_data_dir)?)
+        )?;
+    }
+    Ok(dir)
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -15,6 +15,7 @@ extern crate json;
 
 #[macro_use]
 mod harness;
+mod warnings;
 
 use analysis;
 use actions::{requests, notifications};

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -24,7 +24,8 @@ use server::{self as ls_server, Request, ShutdownRequest, Notification};
 use jsonrpc_core;
 use vfs;
 
-use self::harness::{expect_messages, src, Environment, ExpectedMessage, RecordOutput};
+use self::harness::{expect_messages, src, test_data_to_tmp_dir, Environment, ExpectedMessage,
+                    RecordOutput};
 
 use ls_types::*;
 use lsp_data::InitializationOptions;

--- a/src/test/warnings.rs
+++ b/src/test/warnings.rs
@@ -1,8 +1,12 @@
 use super::*;
 
+/// Rls should send a warning showMessage when we cannot find the project Cargo.toml
 #[test]
-fn warn_missing_root_cargo_toml() {
-    let mut env = Environment::new("no_cargo_toml");
+fn warn_if_missing_cargo_toml() {
+    // use a temp dir to avoid rls' own Cargo.toml affecting test project
+    let dir = test_data_to_tmp_dir("no_cargo_toml").unwrap();
+
+    let mut env = Environment::new(dir.path());
 
     let root_path = env.cache.abs_path(Path::new("."));
     let messages = vec![
@@ -15,20 +19,66 @@ fn warn_missing_root_cargo_toml() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    {
-        wait_for_n_results!(1, results);
+
+    // normally get 4 results back so expect a warning in the first 5 messages
+    let mut received_warning = false;
+    for m in 0..5 {
+        if m == 4 {
+            wait_for_n_results!(1, results, timeout = Duration::from_secs(5))
+        } else {
+            wait_for_n_results!(1, results)
+        };
         let response = json::parse(&results.lock().unwrap().remove(0)).unwrap();
         println!("{}", response.pretty(2));
-        assert!(response["result"]["capabilities"].is_object());
+        if response["method"] == "window/showMessage" {
+            assert_eq!(response["params"]["type"], 2, "Expected 'warning' message type");
+            let message = response["params"]["message"].as_str().unwrap();
+            assert!(message.contains("Cargo.toml"));
+            assert!(message.to_lowercase().contains("could not find"));
+            received_warning = true;
+            break;
+        }
     }
-    {
-        // showMessage warning
-        wait_for_n_results!(1, results);
+
+    assert!(received_warning);
+}
+
+/// Rls should send a warning showMessage when we find but cannot parse the project Cargo.toml
+#[test]
+fn warn_if_invalid_cargo_toml() {
+    let mut env = Environment::new("dodgy_cargo_toml");
+
+    let root_path = env.cache.abs_path(Path::new("."));
+    let messages = vec![
+        initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
+    ];
+
+    let (mut server, results) = env.mock_server(messages);
+    // Initialize and build.
+    assert_eq!(
+        ls_server::LsService::handle_message(&mut server),
+        ls_server::ServerStateChange::Continue
+    );
+
+    // normally get 4 results back so expect a warning in the first 5 messages
+    let mut received_warning = false;
+    for m in 0..5 {
+        if m == 4 {
+            wait_for_n_results!(1, results, timeout = Duration::from_secs(5))
+        } else {
+            wait_for_n_results!(1, results)
+        };
         let response = json::parse(&results.lock().unwrap().remove(0)).unwrap();
         println!("{}", response.pretty(2));
-        assert_eq!(response["method"], "window/showMessage");
-        assert_eq!(response["params"]["type"], 2, "Expected 'warning' message type");
-        let message = response["params"]["message"].as_str().unwrap();
-        assert!(message.contains("Cargo.toml"));
+        if response["method"] == "window/showMessage" {
+            assert_eq!(response["params"]["type"], 2, "Expected 'warning' message type");
+            let message = response["params"]["message"].as_str().unwrap();
+            assert!(message.contains("Cargo.toml"));
+            assert!(message.to_lowercase().contains("failed to parse"));
+            received_warning = true;
+            break;
+        }
     }
+
+    assert!(received_warning);
 }

--- a/src/test/warnings.rs
+++ b/src/test/warnings.rs
@@ -1,0 +1,34 @@
+use super::*;
+
+#[test]
+fn warn_missing_root_cargo_toml() {
+    let mut env = Environment::new("no_cargo_toml");
+
+    let root_path = env.cache.abs_path(Path::new("."));
+    let messages = vec![
+        initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
+    ];
+
+    let (mut server, results) = env.mock_server(messages);
+    // Initialize and build.
+    assert_eq!(
+        ls_server::LsService::handle_message(&mut server),
+        ls_server::ServerStateChange::Continue
+    );
+    {
+        wait_for_n_results!(1, results);
+        let response = json::parse(&results.lock().unwrap().remove(0)).unwrap();
+        println!("{}", response.pretty(2));
+        assert!(response["result"]["capabilities"].is_object());
+    }
+    {
+        // showMessage warning
+        wait_for_n_results!(1, results);
+        let response = json::parse(&results.lock().unwrap().remove(0)).unwrap();
+        println!("{}", response.pretty(2));
+        assert_eq!(response["method"], "window/showMessage");
+        assert_eq!(response["params"]["type"], 2, "Expected 'warning' message type");
+        let message = response["params"]["message"].as_str().unwrap();
+        assert!(message.contains("Cargo.toml"));
+    }
+}

--- a/test_data/dodgy_cargo_toml/Cargo.toml
+++ b/test_data/dodgy_cargo_toml/Cargo.toml
@@ -1,0 +1,9 @@
+# note: purposely invalid toml
+
+[package]
+name = "dodgy"
+version = "0.1.0"
+authors = ["Alex Butler <alexheretic@gmail.com>"]
+
+[dependencies
+something = "

--- a/test_data/dodgy_cargo_toml/src/main.rs
+++ b/test_data/dodgy_cargo_toml/src/main.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+struct Bar {
+    x: u64,
+}
+
+#[test]
+pub fn test_fn() {
+    let bar = Bar { x: 4 };
+    println!("bar: {}", bar.x);
+}
+
+pub fn main() {
+    let world = "world";
+    println!("Hello, {}!", world);
+
+    let bar2 = Bar { x: 5 };
+    println!("bar2: {}", bar2.x);
+}

--- a/test_data/no_cargo_toml/src/main.rs
+++ b/test_data/no_cargo_toml/src/main.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+struct Bar {
+    x: u64,
+}
+
+#[test]
+pub fn test_fn() {
+    let bar = Bar { x: 4 };
+    println!("bar: {}", bar.x);
+}
+
+pub fn main() {
+    let world = "world";
+    println!("Hello, {}!", world);
+
+    let bar2 = Bar { x: 5 };
+    println!("bar2: {}", bar2.x);
+}


### PR DESCRIPTION
This pr warns the client on a Cargo.toml detection/parse error by sending a _showMessage_ notification with  `A valid Cargo.toml must exist to support all RLS features: {error}`.

## Atom
**Missing Cargo.toml**
![](https://user-images.githubusercontent.com/2331607/35622489-ec372592-067f-11e8-81df-19b8e354f2af.png)


**Invalid Cargo.toml**
![](https://user-images.githubusercontent.com/2331607/35622409-ad727960-067f-11e8-82b6-553ef8829179.png)
 Cargo.toml**


## Vscode
**Missing Cargo.toml**
![screenshot from 2018-01-31 12-12-29](https://user-images.githubusercontent.com/2331607/35622524-08732206-0680-11e8-9e06-2cc79759c184.png)
Note: The server message now duplicates the client generated one, so the vscode client message should be removed for Rls versions > _the one with this change_.

**Invalid Cargo.toml**
![](https://user-images.githubusercontent.com/2331607/35622451-cb8b4e2c-067f-11e8-965b-70f794a8dd71.png)