### PR TITLE
Avoid triple-newline in diagnostic messages

### DIFF
--- a/test_data/compiler_message/unused-use.json
+++ b/test_data/compiler_message/unused-use.json
@@ -1,0 +1,35 @@
+{
+  "children": [{
+    "children": [],
+    "code": null,
+    "level": "note",
+    "message": "#[warn(unused_imports)] on by default",
+    "rendered": null,
+    "spans": []
+  }],
+  "code": {
+    "code": "unused_imports",
+    "explanation": null
+  },
+  "level": "warning",
+  "message": "unused import: `std::borrow::Cow`",
+  "rendered": "warning: unused import: `std::borrow::Cow`\n  --> src/main.rs:54:5\n   |\n54 | use std::borrow::Cow;\n   |     ^^^^^^^^^^^^^^^^\n   |\n   = note: #[warn(unused_imports)] on by default\n\n",
+  "spans": [{
+    "byte_end": 1053,
+    "byte_start": 1037,
+    "column_end": 21,
+    "column_start": 5,
+    "expansion": null,
+    "file_name": "src/main.rs",
+    "is_primary": true,
+    "label": null,
+    "line_end": 54,
+    "line_start": 54,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 21,
+      "highlight_start": 5,
+      "text": "use std::borrow::Cow;"
+    }]
+  }]
+}


### PR DESCRIPTION
Moved the usage of `\n\n` together in the diagnostic messages to avoid cases where they can join together in unexpected ways. Added a regression test for unused `use`.

## Before
![3x-newline](https://user-images.githubusercontent.com/2331607/35684905-2a741ec4-0760-11e8-9d7e-85271cffabfa.png)

## After
![2x-newline](https://user-images.githubusercontent.com/2331607/35684916-2edfc4cc-0760-11e8-8a3f-c3790495efe0.png)
