### PR TITLE
Deduplicate diagnostics

### DIFF
--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -193,11 +193,11 @@ impl ExpectedMessage {
 }
 
 macro_rules! wait_for_n_results {
-    ($n:expr, $results:expr) => {{
+    ($n:expr, $results:expr, timeout= $timout:expr) => {{
         use std::time::{Duration, SystemTime};
         use std::thread;
 
-        let timeout = Duration::from_secs(320);
+        let timeout = $timout; //Duration::from_secs(320);
         let start_clock = SystemTime::now();
         let mut results_count = $results.lock().unwrap().len();
         while results_count < $n {
@@ -208,6 +208,9 @@ macro_rules! wait_for_n_results {
             results_count = $results.lock().unwrap().len();
         }
     }};
+    ($n:expr, $results:expr) => {
+        wait_for_n_results!($n, $results, timeout = Duration::from_secs(320))
+    };
 }
 
 pub fn expect_messages(results: LsResultList, expected: &[&ExpectedMessage]) {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1478,3 +1478,51 @@ fn test_deglob() {
         ],
     );
 }
+
+#[test]
+fn test_deduplicate_diagnostics() {
+    let mut env = Environment::new("diagnostics");
+    let root_path = env.cache.abs_path(Path::new("."));
+
+    let messages = vec![
+        initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
+    ];
+
+    let (mut server, results) = env.mock_server(messages);
+    // Initialize and build.
+    assert_eq!(
+        ls_server::LsService::handle_message(&mut server),
+        ls_server::ServerStateChange::Continue
+    );
+
+    // normally get 4 results back so expect diagnostics in the first 5 messages
+    let mut published_diagnostics = false;
+    for m in 0..5 {
+        if m == 4 {
+            wait_for_n_results!(1, results, timeout = Duration::from_secs(5))
+        } else {
+            wait_for_n_results!(1, results)
+        };
+        let response = json::parse(&results.lock().unwrap().remove(0)).unwrap();
+        println!("{}", response.pretty(2));
+        if response["method"] == "textDocument/publishDiagnostics" {
+            let diags: Vec<_> = response["params"]["diagnostics"]
+                .members()
+                .filter(|d| d["code"] == "E0596")
+                .collect();
+
+            assert_eq!(diags.len(), 6);
+            assert_eq!(diags[0]["range"]["start"]["line"], 1);
+            assert_eq!(diags[1]["range"]["start"]["line"], 2);
+            assert_eq!(diags[2]["range"]["start"]["line"], 3);
+            assert_eq!(diags[3]["range"]["start"]["line"], 4);
+            assert_eq!(diags[4]["range"]["start"]["line"], 5);
+            assert_eq!(diags[5]["range"]["start"]["line"], 6);
+
+            published_diagnostics = true;
+            break;
+        }
+    }
+
+    assert!(published_diagnostics)
+}

--- a/test_data/diagnostics/Cargo.lock
+++ b/test_data/diagnostics/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "diagnostics"
+version = "0.1.0"
+

--- a/test_data/diagnostics/Cargo.toml
+++ b/test_data/diagnostics/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "diagnostics"
+version = "0.1.0"
+authors = ["Alex Butler <alexheretic@gmail.com>"]

--- a/test_data/diagnostics/src/main.rs
+++ b/test_data/diagnostics/src/main.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let s = String::new();
+    s.push('a');
+    s.push('b');
+    s.push('c');
+    s.push('d');
+    s.push('e');
+}


### PR DESCRIPTION
Now we report secondary diagnostics, like suggestions, we have the possibility of duplicate diagnostics. These are not useful for clients. This pr deduplicates diagnostics.

### Before
![before-dedup](https://user-images.githubusercontent.com/2331607/35732795-bb6e3ff6-0812-11e8-9b77-5c5426e79002.gif)

### After
![after-dedup](https://user-images.githubusercontent.com/2331607/35732799-c0cb7130-0812-11e8-937d-b636d5dab293.gif)

### Implementation notes
De-duplication is done by `Vec::sort` `Vec::dedup`. Diagnostics are considered duplicates if they have exactly the same position & message. If we have duplicate diagnostics from different severities/sources the order is from **error/rustc** down to **unknown/unknown** _source ordering is alphabetic after rustc_. _I.e. We'll show the rustc-error instead of the clippy-hint with the same message._

As a side effect of the implementation the diagnostics now arrive in a predictable order. This helps testing & should aid debugging.

I added a de-duplication test that will also serve as a general diagnostic regression test (none existed before).
