### PR TITLE
Fix #191 check tests directory via 'all-targets' cargo flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ Currently we accept the following options:
 * `analyze_package` (`String`, defaults to `""`) When `workspace_mode` is
   enabled, analysis will be only provided for the specified package (runs as
   if `-p <analyze_package>` was passed).
+* `all_targets` (`bool`, defaults to `false`) checks the project as if you were
+  running `cargo check --all-targets`. I.e., check all targets and integration
+  tests too.
 
 
 ## Troubleshooting

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,6 +132,7 @@ pub struct Config {
     pub all_features: bool,
     pub no_default_features: bool,
     pub jobs: Option<u32>,
+    pub all_targets: bool,
 }
 
 impl Default for Config {
@@ -156,6 +157,7 @@ impl Default for Config {
             all_features: false,
             no_default_features: false,
             jobs: None,
+            all_targets: false,
         };
         result.normalise();
         result

--- a/test_data/bin_lib/tests/tests.rs
+++ b/test_data/bin_lib/tests/tests.rs
@@ -1,0 +1,5 @@
+#[test]
+fn test_some_foo() {
+    let unused_var = true;
+    assert!(true);
+}


### PR DESCRIPTION
Hello!

This PR is a timid attempt to introduce usage of `all-targets` cargo flag to analyse integration tests under `tests` directory.

Sorry about my poor English.