### PR TITLE
Improve diagnostic formatting: Don't add empty notes

### DIFF
--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -281,12 +281,11 @@ fn format_notes(children: &[CompilerMessage], primary: &DiagnosticSpan) -> Optio
     if !children.is_empty() {
         let mut notes = String::new();
         for &CompilerMessage { ref message, ref level, ref spans, .. } in children {
-            notes.push_str(&format!("\n{}: ", level));
 
             macro_rules! add_message_to_notes {
                 ($msg:expr) => {{
                     let mut lines = message.lines();
-                    notes.push_str(lines.next().unwrap());
+                    notes.push_str(&format!("\n{}: {}", level, lines.next().unwrap()));
                     for line in lines {
                         notes.push_str(&format!(
                             "\n{:indent$}{line}",
@@ -526,6 +525,17 @@ help: consider borrowing here: `&string`"#,
         );
         assert_eq!(msg, "unused import: `std::borrow::Cow`\n\n\
                          note: #[warn(unused_imports)] on by default");
+
+        assert!(others.is_empty(), "{:?}", others);
+    }
+
+    #[test]
+    fn message_cannot_find_type() {
+        let (msg, others) = parsed_message(
+            include_str!("../../test_data/compiler_message/cannot-find-type.json")
+        );
+        assert_eq!(msg, "cannot find type `HashSet` in this scope\n\n\
+                         not found in this scope");
 
         assert!(others.is_empty(), "{:?}", others);
     }

--- a/test_data/compiler_message/cannot-find-type.json
+++ b/test_data/compiler_message/cannot-find-type.json
@@ -1,0 +1,69 @@
+{
+  "children": [{
+    "children": [],
+    "code": null,
+    "level": "help",
+    "message": "possible candidates are found in other modules, you can import them into scope",
+    "rendered": null,
+    "spans": [{
+      "byte_end": 528,
+      "byte_start": 528,
+      "column_end": 1,
+      "column_start": 1,
+      "expansion": null,
+      "file_name": "src/actions/post_build.rs",
+      "is_primary": true,
+      "label": null,
+      "line_end": 15,
+      "line_start": 15,
+      "suggested_replacement": "use std::collections::HashSet;\n",
+      "text": [{
+        "highlight_end": 1,
+        "highlight_start": 1,
+        "text": "use std::collections::HashMap;"
+      }]
+    }, {
+      "byte_end": 528,
+      "byte_start": 528,
+      "column_end": 1,
+      "column_start": 1,
+      "expansion": null,
+      "file_name": "src/actions/post_build.rs",
+      "is_primary": true,
+      "label": null,
+      "line_end": 15,
+      "line_start": 15,
+      "suggested_replacement": "use std::collections::hash_set::HashSet;\n",
+      "text": [{
+        "highlight_end": 1,
+        "highlight_start": 1,
+        "text": "use std::collections::HashMap;"
+      }]
+    }]
+  }],
+  "code": {
+    "code": "E0412",
+    "explanation": "\nThe type name used is not in scope.\n\nErroneous code examples:\n\n```compile_fail,E0412\nimpl Something {} // error: type name `Something` is not in scope\n\n// or:\n\ntrait Foo {\n    fn bar(N); // error: type name `N` is not in scope\n}\n\n// or:\n\nfn foo(x: T) {} // type name `T` is not in scope\n```\n\nTo fix this error, please verify you didn't misspell the type name, you did\ndeclare it or imported it into the scope. Examples:\n\n```\nstruct Something;\n\nimpl Something {} // ok!\n\n// or:\n\ntrait Foo {\n    type N;\n\n    fn bar(_: Self::N); // ok!\n}\n\n// or:\n\nfn foo<T>(x: T) {} // ok!\n```\n\nAnother case that causes this error is when a type is imported into a parent\nmodule. To fix this, you can follow the suggestion and use File directly or\n`use super::File;` which will import the types from the parent namespace. An\nexample that causes this error is below:\n\n```compile_fail,E0412\nuse std::fs::File;\n\nmod foo {\n    fn some_function(f: File) {}\n}\n```\n\n```\nuse std::fs::File;\n\nmod foo {\n    // either\n    use super::File;\n    // or\n    // use std::fs::File;\n    fn foo(f: File) {}\n}\n# fn main() {} // don't insert it for us; that'll break imports\n```\n"
+  },
+  "level": "error",
+  "message": "cannot find type `HashSet` in this scope",
+  "rendered": "error[E0412]: cannot find type `HashSet` in this scope\n   --> src/actions/post_build.rs:158:32\n    |\n158 |                     .collect::<HashSet>()\n    |                                ^^^^^^^ not found in this scope\nhelp: possible candidates are found in other modules, you can import them into scope\n    |\n15  | use std::collections::HashSet;\n    |\n15  | use std::collections::hash_set::HashSet;\n    |\n\n",
+  "spans": [{
+    "byte_end": 5500,
+    "byte_start": 5493,
+    "column_end": 39,
+    "column_start": 32,
+    "expansion": null,
+    "file_name": "src/actions/post_build.rs",
+    "is_primary": true,
+    "label": "not found in this scope",
+    "line_end": 158,
+    "line_start": 158,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 39,
+      "highlight_start": 32,
+      "text": "                    .collect::<HashSet>()"
+    }]
+  }]
+}


### PR DESCRIPTION
This pr avoids adding notes without content to diagnostic messages.

### Before
![before-cannot-find](https://user-images.githubusercontent.com/2331607/35801874-d2e719fa-0a65-11e8-9e8b-2a779b87cda0.png)
Note: the _'possible candidates are found in other modules, you can import them into scope'_ help doesn't appear here as it refers to a different span (at the top of the file). We should consider these primary & different span messages, but they shouldn't go into this diagnostic anyway.

### After
![after-cannot-find](https://user-images.githubusercontent.com/2331607/35801875-d7c4e9f2-0a65-11e8-8234-59a6d81f9bdd.png)
