### PR TITLE
Address work-pool DoS with long running tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ dependencies = [
  "languageserver-types 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-analysis 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 url = "1.1.0"
 rayon = "0.9"
+num_cpus = "1"
 
 [dev-dependencies]
 json = "0.11"

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -53,6 +53,7 @@ macro_rules! parse_file_path {
     }
 }
 
+pub mod work_pool;
 pub mod post_build;
 pub mod requests;
 pub mod notifications;

--- a/src/actions/work_pool.rs
+++ b/src/actions/work_pool.rs
@@ -1,0 +1,101 @@
+use rayon;
+use server::DEFAULT_REQUEST_TIMEOUT;
+use std::{fmt, panic};
+use std::time::{Duration, Instant};
+use std::sync::{mpsc, Mutex};
+
+/// Description of work on the request work pool. Equality implies two pieces of work are the same
+/// kind of thing. The `str` should be human readable for logging, ie the language server protocol
+/// request message name or similar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WorkDescription(pub &'static str);
+
+impl fmt::Display for WorkDescription {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+lazy_static! {
+    /// Maximum total concurrent working tasks
+    static ref NUM_THREADS: usize = ::num_cpus::get();
+
+    /// Maximum concurrent working tasks of the same type
+    static ref MAX_SIMILAR_CONCURRENT_WORK: usize = (*NUM_THREADS / 2).max(1);
+
+    /// Duration of work after which we should warn something is taking a long time
+    static ref WARN_TASK_DURATION: Duration = *DEFAULT_REQUEST_TIMEOUT * 5;
+
+    /// Current work descriptions active on the work pool
+    static ref WORK: Mutex<Vec<WorkDescription>> = Mutex::new(vec![]);
+
+    /// Thread pool for request execution allowing concurrent request processing.
+    static ref WORK_POOL: rayon::ThreadPool = rayon::ThreadPool::new(
+        rayon::Configuration::default()
+            .thread_name(|num| format!("request-worker-{}", num))
+            .num_threads(*NUM_THREADS)
+    ).unwrap();
+}
+
+/// Runs work in a new thread on the `WORK_POOL` returning a result `Receiver`
+///
+/// Panicking work will receive `Err(RecvError)` / `Err(RecvTimeoutError::Disconnected)`
+///
+/// If too many tasks are already running the work will not be done and the receiver will
+/// immediately return `Err(RecvTimeoutError::Disconnected)`
+pub fn receive_from_thread<T, F>(work_fn: F, description: WorkDescription) -> mpsc::Receiver<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + panic::UnwindSafe + 'static,
+{
+    let (sender, receiver) = mpsc::channel();
+
+    {
+        let mut work = WORK.lock().unwrap();
+        if work.len() >= *NUM_THREADS {
+            // there are already N ongoing tasks, that may or may not have timed out
+            // don't add yet more to the queue fail fast to allow the work pool to recover
+            warn!(
+                "Could not start `{}` as at work capacity, {:?} in progress",
+                description, *work,
+            );
+            return receiver;
+        }
+        if work.iter().filter(|desc| *desc == &description).count() >= *MAX_SIMILAR_CONCURRENT_WORK
+        {
+            // this type of work is already filling around half the work pool, so there's
+            // good reason to believe it may fill the entire pool => fail fast to allow
+            // other task-types to run
+            info!(
+                "Could not start `{}` as same work-type is filling half capacity, {:?} in progress",
+                description, *work,
+            );
+            return receiver;
+        }
+        work.push(description);
+    }
+
+    WORK_POOL.spawn(move || {
+        let start = Instant::now();
+
+        // panic details will be on stderr, otherwise ignore the work panic as it
+        // will already cause a mpsc disconnect-error & there isn't anything else to log
+        if let Ok(work_result) = panic::catch_unwind(work_fn) {
+            // an error here simply means the work took too long and the receiver has been dropped
+            let _ = sender.send(work_result);
+        }
+
+        let mut work = WORK.lock().unwrap();
+        if let Some(index) = work.iter().position(|desc| desc == &description) {
+            work.swap_remove(index);
+        }
+
+        let elapsed = start.elapsed();
+        if elapsed >= *WARN_TASK_DURATION {
+            let secs =
+                elapsed.as_secs() as f64 + f64::from(elapsed.subsec_nanos()) / 1_000_000_000_f64;
+            warn!("`{}` took {:.1}s", description, secs);
+        }
+    });
+    receiver
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ extern crate languageserver_types as ls_types;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
+extern crate num_cpus;
 extern crate racer;
 extern crate rayon;
 extern crate rls_analysis as analysis;

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -59,7 +59,7 @@ macro_rules! define_dispatch_request_enum {
                             else {
                                 $request_type::handle(ctx, params)
                             }
-                        });
+                        }, $request_type::METHOD);
 
                         match receiver.recv_timeout(timeout)
                             .unwrap_or_else(|_| $request_type::fallback_response()) {

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -20,7 +20,7 @@ use std::thread;
 use std::time::Duration;
 
 lazy_static! {
-    static ref TIMEOUT: Duration = Duration::from_millis(::COMPILER_TIMEOUT);
+    pub static ref DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(::COMPILER_TIMEOUT);
 }
 
 /// Macro enum `DispatchRequest` packing in various similar `Request` types
@@ -160,7 +160,7 @@ pub trait RequestAction: LSPRequest {
 
     /// Max duration this request should finish within, also see `fallback_response()`
     fn timeout() -> Duration {
-        *TIMEOUT
+        *DEFAULT_REQUEST_TIMEOUT
     }
 
     /// Returns a response used in timeout scenarios

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -28,7 +28,7 @@ use config::Config;
 pub use server::io::{MessageReader, Output};
 use server::io::{StdioMsgReader, StdioOutput};
 use server::dispatch::Dispatcher;
-pub use server::dispatch::{RequestAction, ResponseError};
+pub use server::dispatch::{RequestAction, ResponseError, DEFAULT_REQUEST_TIMEOUT};
 
 pub use ls_types::request::Shutdown as ShutdownRequest;
 pub use ls_types::request::Initialize as InitializeRequest;


### PR DESCRIPTION
This pr can _help_ #688 by limiting the impact of long running cpu intensive request actions _(racer)_. Currently we limit the tasks hitting the cpu with a thread pool, but work still fills up at a max rate of 1 per request-timeout. If the work can take longer than the request timeout we can build up tasks by slow steady spamming, see https://github.com/rust-lang-nursery/rls/issues/688#issuecomment-363528272. 

Note: this is _still_ possible even though we don't run tasks that have already timed out.

***Related: Really we should have a way to cancel all tasks, that way we could have a single thread that we cancel on timeout. Bosh. Perhaps we should look into _pthread_cancel_.***

### New logic
* Record tasks in progress
* Immediately fail tasks when in-progress tasks == max tasks and log-warn
* Immediately fail tasks when same type in-progress tasks == 1/2 tasks and log-warn

This should have the effect of halving the problematic usage to 50% of cores, rather than 100% and reducing the time the cores are consumed.

### Example (before)
If we take a 4 core machine as an example, currently if we receive a _textDocument/completion_ request every second for 10 seconds that takes racer 5 seconds to process:

* **0s**: receive req-1: send to pool
* **1s**: receive req-2 (dispatcher busy)
* **1.5s**: dispatcher times out req-1, but still working on pool
* **1.5s**: req-2: send to pool
* **2s**: receive req-3 (dispatcher busy)
* **3s**: dispatcher times out req-2, but still working on pool
* **3s**: req-3: send to pool
* **3s**: receive req-4 (dispatcher busy)
* **4s**: receive req-5 (dispatcher busy)
* **4.5s**: dispatcher times out req-3, but still working on pool
* **4.5s**: req-4: timed out without working
* **4.5s**: req-5: send to pool
* **5s**: receive req-6 (dispatcher busy)
* **5s**: pool finishes working on req-1

### Example (after)
* **0s-2s**: _as before_
* **3s**: dispatcher times out req-2, but still working on pool
* **3s**: req-3 **fail task as 2 tasks of same type already running**
* **3s**: receive req-4: **fail task as 2 tasks of same type already running**
* **4s**: receive req-5: **fail task as 2 tasks of same type already running**
* **5s**: receive req-6: **fail task as 2 tasks of same type already running**
* **5s**: pool finishes working on req-1

So in this way we bound a single tasks ability to fully consume the work pool, and the length that it half consumes it.

Similarly the ***Fail tasks when in-progress tasks == max tasks & warn*** functionality will prevent further tasks being added to the pool when its fully utilized allowing it to recover.

The warning logs include what's currently in progress to help us get an idea of what tasks are taking so long to start off with
```
WARN 2018-02-06T19:14:53Z: rls::actions::requests: Could not start `textDocument/completion` as same work-type is filling half capacity, ["textDocument/completion", "textDocument/completion"] in progress
```