### PR TITLE
Detect clippy diagnostic source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.185"
+version = "0.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1005,7 +1005,7 @@ name = "rls"
 version = "0.125.0"
 dependencies = [
  "cargo 0.26.0 (git+https://github.com/rust-lang/cargo?rev=1d6dfea44f97199d5d5c177c7dadcde393eaff9a)",
- "clippy_lints 0.0.185 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy_lints 0.0.186 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1653,7 +1653,7 @@ dependencies = [
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4151c5790817c7d21bbdc6c3530811f798172915f93258244948b93ba19604a6"
-"checksum clippy_lints 0.0.185 (registry+https://github.com/rust-lang/crates.io-index)" = "bbfbc6e9b0760ca6b338ae1014a331698a783a1cc996716f5f2db8ba8b1368a5"
+"checksum clippy_lints 0.0.186 (registry+https://github.com/rust-lang/crates.io-index)" = "a3864104a4e6092e644b985dd7543e5f24e99aa7262f5ee400bcb17cfeec1bf5"
 "checksum cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "56d741ea7a69e577f6d06b36b7dff4738f680593dc27a701ffa8506b73ce28bb"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rls-rustc = "0.2.1"
 rls-span = { version = "0.4", features = ["serialize-serde"] }
 rls-vfs = { version = "0.4", features = ["racer-impls"] }
 rustfmt-nightly = { version = "0.3.8", optional = true }
-clippy_lints = { version = "0.0.185", optional = true }
+clippy_lints = { version = "0.0.186", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/test_data/compiler_message/clippy-identity-op.json
+++ b/test_data/compiler_message/clippy-identity-op.json
@@ -1,0 +1,66 @@
+{
+  "children": [{
+    "children": [],
+    "code": null,
+    "level": "note",
+    "message": "lint level defined here",
+    "rendered": null,
+    "spans": [{
+      "byte_end": 39,
+      "byte_start": 33,
+      "column_end": 15,
+      "column_start": 9,
+      "expansion": null,
+      "file_name": "src/main.rs",
+      "is_primary": true,
+      "label": null,
+      "line_end": 2,
+      "line_start": 2,
+      "suggested_replacement": null,
+      "text": [{
+        "highlight_end": 15,
+        "highlight_start": 9,
+        "text": "#![warn(clippy)]"
+      }]
+    }]
+  }, {
+    "children": [],
+    "code": null,
+    "level": "note",
+    "message": "#[warn(identity_op)] implied by #[warn(clippy)]",
+    "rendered": null,
+    "spans": []
+  }, {
+    "children": [],
+    "code": null,
+    "level": "help",
+    "message": "for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.186/index.html#identity_op",
+    "rendered": null,
+    "spans": []
+  }],
+  "code": {
+    "code": "identity_op",
+    "explanation": null
+  },
+  "level": "warning",
+  "message": "the operation is ineffective. Consider reducing it to `1`",
+  "rendered": "warning: the operation is ineffective. Consider reducing it to `1`\n --> src/main.rs:5:14\n  |\n5 |     let _s = 1 / 1;\n  |              ^^^^^\n  |\nnote: lint level defined here\n --> src/main.rs:2:9\n  |\n2 | #![warn(clippy)]\n  |         ^^^^^^\n  = note: #[warn(identity_op)] implied by #[warn(clippy)]\n  = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.186/index.html#identity_op\n\n",
+  "spans": [{
+    "byte_end": 73,
+    "byte_start": 68,
+    "column_end": 19,
+    "column_start": 14,
+    "expansion": null,
+    "file_name": "src/main.rs",
+    "is_primary": true,
+    "label": null,
+    "line_end": 5,
+    "line_start": 5,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 19,
+      "highlight_start": 14,
+      "text": "    let _s = 1 / 1;"
+    }]
+  }]
+}


### PR DESCRIPTION
Adds source **clippy**, rather than **rustc**, when compiler messages include `"rust-clippy"` (the project name part of the clippy more info links).

While this method is fairly crude the chance of labelling an actual **rustc** error as **clippy** seems very low. As such this is definitely an improvement to what we have with little downside. Also since there isn't much code to it we can switch to a better source-detection method easily when one appears.

I've reworked the diagnostic message tests a little to aid source testing along with the new clippy diagnostic formatting regression test.

![](https://user-images.githubusercontent.com/2331607/35863303-31a9c79a-0b46-11e8-93b7-26607af45ff0.png)