### PR TITLE
Use multiple primary diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,9 +299,9 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "schannel 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -313,7 +313,7 @@ dependencies = [
  "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -392,7 +392,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -504,7 +504,7 @@ dependencies = [
  "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -684,7 +684,7 @@ dependencies = [
  "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libssh2-sys 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -696,7 +696,7 @@ dependencies = [
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -768,21 +768,19 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "net2"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -800,12 +798,12 @@ name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -825,7 +823,7 @@ dependencies = [
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -835,7 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.26"
+version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1043,10 +1041,10 @@ dependencies = [
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 2.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-analysis 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-analysis 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-blacklist 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-rustc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-rustc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-vfs 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt-nightly 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1058,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "rls-analysis"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-new 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1087,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "rls-rustc"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1312,7 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1328,7 +1326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "socket2"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1721,7 +1719,7 @@ dependencies = [
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "459d3cf58137bb02ad4adeef5036377ff59f066dbb82517b7192e3a5462a2abc"
 "checksum home 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f25ae61099d8f3fee8b483df0bd4ecccf4b2731897aad40d50eca1b641fe6db"
-"checksum humantime 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5369e01a05e3404c421b5d6dcfea6ecf7d5e65eba8a275948151358cd8282042"
+"checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
 "checksum ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb2f0238094bd1b41800fb6eb9b16fdd5e9832ed6053ed91409f0cd5bf28dcfd"
@@ -1746,15 +1744,15 @@ dependencies = [
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
+"checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
 "checksum nibble_vec 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c8d77f3db4bce033f4d04db08079b2ef1c3d02b44e86f25d08886fafa7756ffa"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-"checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
+"checksum num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3c2bd9b9d21e48e956b763c9f37134dc62d9e95da6edb3f672cacb6caf3cd3"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-"checksum openssl-sys 0.9.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5a41ce2f5f2d939c80decde8fcfcf5837c203ca6c06a553510a2fcb84fa3ef1"
+"checksum openssl-sys 0.9.27 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fdc5c4a02e69ce65046f1763a0181107038e02176233acb0b3351d7cc588f9"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd9d732f2de194336fb02fe11f9eed13d9e76f13f4315b4d88a14ca411750cd"
 "checksum parking_lot_core 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "538ef00b7317875071d5e00f603f24d16f0b474c1a5fc0ccb8b454ca72eafa79"
@@ -1777,10 +1775,10 @@ dependencies = [
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum remove_dir_all 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5d2f806b0fcdabd98acd380dc8daef485e22bcb7cddc811d1337967f2528cf5"
-"checksum rls-analysis 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39461c31c9ec26c2f15821d6aaa349216bf71e24e69550d9f8eeded78dc435e1"
+"checksum rls-analysis 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeed098e38bb5c6542e3d53de480fe4dcdcd188d6a7ebd156068053b466110c"
 "checksum rls-blacklist 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "56fb7b8e4850b988fbcf277fbdb1eff36879070d02fc1ca243b559273866973d"
 "checksum rls-data 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bea04462e94b5512a78499837eecb7db182ff082144cd1b4bc32ef5d43de6510"
-"checksum rls-rustc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "85cfb9dde19e313da3e47738008f8a472e470cc42d910b71595a9238494701f2"
+"checksum rls-rustc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "885f66b92757420572cbb02e033d4a9558c7413ca9b7ac206f28fd58ffdb44ea"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rls-vfs 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "be231e1e559c315bc60ced5ad2cc2d7a9c208ed7d4e2c126500149836fda19bb"
 "checksum rustc-ap-rustc_cratesio_shim 29.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ad5e562044ea78a6764dd75ae8afe4b21fde49f4548024b5fdf6345c21fb524"
@@ -1808,7 +1806,7 @@ dependencies = [
 "checksum serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "57781ed845b8e742fc2bf306aba8e3b408fe8c366b900e3769fbc39f49eb8b39"
 "checksum shell-escape 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dd5cc96481d54583947bfe88bf30c23d53f883c6cd0145368b69989d97b84ef8"
 "checksum smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44db0ecb22921ef790d17ae13a3f6d15784183ff5f2a01aa32098c7498d2b4b9"
-"checksum socket2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a76b792959eba82f021c9028c8ecb6396f085268d6d46af2ed96a829cc758d7c"
+"checksum socket2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "630d23c56fe67dc851155459ed2ad37c5112e3877855b666970e08e5ad08a7fb"
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -284,7 +284,7 @@ fn parse_diagnostics(message: &str, group: u64) -> Option<FileDiagnostic> {
             }
         }
         let severity = Some(if secondary_span.is_primary {
-            DiagnosticSeverity::Warning
+            severity(&message.level)
         }
         else {
             DiagnosticSeverity::Information

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -212,20 +212,21 @@ fn parse_diagnostics(message: &str, group: u64) -> Option<FileDiagnostic> {
     }
 
     let diagnostic_msg = message.message.clone();
-    let primary_span = message.spans.iter().find(|s| s.is_primary).unwrap();
-    let rls_span = primary_span.rls_span().zero_indexed();
+    let (first_primary_span_index, first_primary_span)
+        = message.spans.iter().enumerate().find(|s| s.1.is_primary).unwrap();
+    let rls_span = first_primary_span.rls_span().zero_indexed();
     let suggestions = make_suggestions(&message, &rls_span.file);
 
     let mut source = "rustc";
     let diagnostic = {
         let mut primary_message = diagnostic_msg.clone();
-        if let Some(ref primary_label) = primary_span.label {
+        if let Some(ref primary_label) = first_primary_span.label {
             if primary_label.trim() != primary_message.trim() {
                 primary_message.push_str(&format!("\n\n{}", primary_label));
             }
         }
 
-        if let Some(notes) = format_notes(&message.children, primary_span) {
+        if let Some(notes) = format_notes(&message.children, first_primary_span) {
             primary_message.push_str(&format!("\n\n{}", notes));
         }
 
@@ -258,9 +259,10 @@ fn parse_diagnostics(message: &str, group: u64) -> Option<FileDiagnostic> {
     let secondaries = message
     .spans
     .iter()
-    .filter(|x| !x.is_primary)
-    .map(|secondary_span| {
-        let mut secondary_message = if secondary_span.is_within(primary_span) {
+    .enumerate()
+    .filter(|x| x.0 != first_primary_span_index)
+    .map(|(_, secondary_span)| {
+        let mut secondary_message = if secondary_span.is_within(first_primary_span) {
             String::new()
         }
         else {
@@ -281,11 +283,17 @@ fn parse_diagnostics(message: &str, group: u64) -> Option<FileDiagnostic> {
                 secondary_message.push_str(&format!("\n\n{}", secondary_label));
             }
         }
+        let severity = Some(if secondary_span.is_primary {
+            DiagnosticSeverity::Warning
+        }
+        else {
+            DiagnosticSeverity::Information
+        });
         let rls_span = secondary_span.rls_span().zero_indexed();
 
         let diag = Diagnostic {
             range: ls_util::rls_to_range(rls_span.range),
-            severity: Some(DiagnosticSeverity::Information),
+            severity,
             code: Some(NumberOrString::String(match message.code {
                 Some(ref c) => c.code.clone(),
                 None => String::new(),
@@ -606,17 +614,27 @@ help: consider borrowing here: `&string`"#,
     }
 
     /// ```
-    /// use std::borrow::Cow;
+    /// use std::{f64, u64, u8 as Foo};
     /// ```
     #[test]
     fn message_unused_use() {
-        let (msg, others) = parse_compiler_message(
-            include_str!("../../test_data/compiler_message/unused-use.json")
-        ).to_messages();
-        assert_eq!(msg, "unused import: `std::borrow::Cow`\n\n\
-                         note: #[warn(unused_imports)] on by default");
+        let (msg, others) = parse_compiler_message(include_str!(
+            "../../test_data/compiler_message/unused-use.json"
+        )).to_messages();
+        assert_eq!(
+            msg,
+            "unused imports: `f64`, `u64`, `u8 as Foo`\n\n\
+             note: #[warn(unused_imports)] on by default"
+        );
 
-        assert!(others.is_empty(), "{:?}", others);
+        // 2 more warnings for the other two imports
+        assert_eq!(
+            others,
+            vec![
+                "unused imports: `f64`, `u64`, `u8 as Foo`",
+                "unused imports: `f64`, `u64`, `u8 as Foo`",
+            ]
+        );
     }
 
     #[test]

--- a/test_data/compiler_message/unused-use.json
+++ b/test_data/compiler_message/unused-use.json
@@ -12,24 +12,58 @@
     "explanation": null
   },
   "level": "warning",
-  "message": "unused import: `std::borrow::Cow`",
-  "rendered": "warning: unused import: `std::borrow::Cow`\n  --> src/main.rs:54:5\n   |\n54 | use std::borrow::Cow;\n   |     ^^^^^^^^^^^^^^^^\n   |\n   = note: #[warn(unused_imports)] on by default\n\n",
+  "message": "unused imports: `f64`, `u64`, `u8 as Foo`",
+  "rendered": "warning: unused imports: `f64`, `u64`, `u8 as Foo`\n --> src/main.rs:1:11\n  |\n1 | use std::{f64, u64, u8 as Foo};\n  |           ^^^  ^^^  ^^^^^^^^^\n  |\n  = note: #[warn(unused_imports)] on by default\n\n",
   "spans": [{
-    "byte_end": 1053,
-    "byte_start": 1037,
-    "column_end": 21,
-    "column_start": 5,
+    "byte_end": 13,
+    "byte_start": 10,
+    "column_end": 14,
+    "column_start": 11,
     "expansion": null,
     "file_name": "src/main.rs",
     "is_primary": true,
     "label": null,
-    "line_end": 54,
-    "line_start": 54,
+    "line_end": 1,
+    "line_start": 1,
     "suggested_replacement": null,
     "text": [{
-      "highlight_end": 21,
-      "highlight_start": 5,
-      "text": "use std::borrow::Cow;"
+      "highlight_end": 14,
+      "highlight_start": 11,
+      "text": "use std::{f64, u64, u8 as Foo};"
+    }]
+  }, {
+    "byte_end": 18,
+    "byte_start": 15,
+    "column_end": 19,
+    "column_start": 16,
+    "expansion": null,
+    "file_name": "src/main.rs",
+    "is_primary": true,
+    "label": null,
+    "line_end": 1,
+    "line_start": 1,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 19,
+      "highlight_start": 16,
+      "text": "use std::{f64, u64, u8 as Foo};"
+    }]
+  }, {
+    "byte_end": 29,
+    "byte_start": 20,
+    "column_end": 30,
+    "column_start": 21,
+    "expansion": null,
+    "file_name": "src/main.rs",
+    "is_primary": true,
+    "label": null,
+    "line_end": 1,
+    "line_start": 1,
+    "suggested_replacement": null,
+    "text": [{
+      "highlight_end": 30,
+      "highlight_start": 21,
+      "text": "use std::{f64, u64, u8 as Foo};"
     }]
   }]
 }


### PR DESCRIPTION
Currently we produce diagnostic by finding the primary span, and using non-primary spans as secondary diagnostics. However, there are cases rustc will return to us multiple primary = true spans & in these we currently ignore this information.

This pr fixes this and treats these following primary spans the same way as we treat non-primary additional diagnostics, but with the severity of `Warning`.

You can commonly see this with multiple unused imports.

**Before**
![before](https://user-images.githubusercontent.com/2331607/36913343-89f6f5cc-1e41-11e8-9b6d-5d5391b504e6.png)


**After**
![after](https://user-images.githubusercontent.com/2331607/36913296-5a0df0e0-1e41-11e8-94bb-b20c963f4e09.png)
