### PR TITLE
Add `racer_completion` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Currently we accept the following options:
 * `all_targets` (`bool`, defaults to `false`) checks the project as if you were
   running `cargo check --all-targets`. I.e., check all targets and integration
   tests too.
-
+* `racer_completion` (`bool`, defaults to `true`) enables/disables code
+  completion using racer.
 
 ## Troubleshooting
 

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -302,6 +302,10 @@ impl RequestAction for Completion {
         ctx: InitActionContext,
         params: Self::Params,
     ) -> Result<Self::Response, ResponseError> {
+        if !ctx.config.lock().unwrap().racer_completion {
+            return Self::fallback_response();
+        }
+
         let vfs = ctx.vfs;
         let file_path = parse_file_path!(&params.text_document.uri, "complete")?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,8 @@ pub struct Config {
     pub no_default_features: bool,
     pub jobs: Option<u32>,
     pub all_targets: bool,
+    /// Enable use of racer for `textDocument/completion` requests
+    pub racer_completion: bool,
 }
 
 impl Default for Config {
@@ -159,6 +161,7 @@ impl Default for Config {
             no_default_features: false,
             jobs: None,
             all_targets: false,
+            racer_completion: true,
         };
         result.normalise();
         result


### PR DESCRIPTION
Provides manual workaround for #688. Justification is in that thread.

As the default is `true` this change requires manual user configuration to change current behaviour.

I chose `racer_completion` rather than `autocomplete` as the current use case for disabling it is when you care about racer performance edge cases, rather than you don't want autocomplete. But we can rename if something else is better.