### PR TITLE
Add travis --all-features build (clippy)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,25 @@ rust:
 matrix:
   include:
   - rust: nightly
+    env: USE_FEATURES=true
     os: linux
   allow_failures:
+  # avoid delaying prs with travis osx issues
   - os: osx
+  # clippy compilation issues are somewhat expected
+  - env: USE_FEATURES=true
   fast_finish: true
 install:
     # Required for Racer autoconfiguration
     rustup component add rust-src
 script: |
   #!/bin/bash
-  # compile #[cfg(not(test))] code
-  cargo build --verbose
-  cargo test --verbose
+  if [ -v USE_FEATURES ]; then
+    # compile #[cfg(not(test))] code
+    cargo build -v --all-features
+    cargo test -v --all-features
+  else
+    # compile #[cfg(not(test))] code
+    cargo build -v
+    cargo test -v
+  fi


### PR DESCRIPTION
Re-purpose the, currently redundant, 2nd Linux run to compile all features (ie `clippy`) + allow failures as we're not too surprised when clippy won't compile after nightly changes.

This run is useful when we're looking at clippy-related prs & tests.