### PR TITLE
Clarify request timeout usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -975,7 +975,7 @@ dependencies = [
  "racer 2.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-analysis 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-blacklist 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-blacklist 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-rustc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "rls-blacklist"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1199,7 +1199,7 @@ dependencies = [
  "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive_internals 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1208,7 +1208,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1677,7 +1677,7 @@ dependencies = [
 "checksum regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2550876c31dc914696a6c2e01cbce8afba79a93c8ae979d2fe051c0230b3756"
 "checksum remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfc5b3ce5d5ea144bb04ebd093a9e14e9765bcfec866aecda9b6dec43b3d1e24"
 "checksum rls-analysis 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fd4b9a3a3f2345854e39768e6425d1c893855da217183d1c0b3ff6f1664b6b6d"
-"checksum rls-blacklist 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "56fb7b8e4850b988fbcf277fbdb1eff36879070d02fc1ca243b559273866973d"
+"checksum rls-blacklist 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "156cee9c1750b2e97d404dd0506c4780b7a2d615164f49874013807fb3cbfe5e"
 "checksum rls-data 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bea04462e94b5512a78499837eecb7db182ff082144cd1b4bc32ef5d43de6510"
 "checksum rls-rustc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "885f66b92757420572cbb02e033d4a9558c7413ca9b7ac206f28fd58ffdb44ea"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
@@ -1708,7 +1708,7 @@ dependencies = [
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)" = "8c5bc2d6ff27891209efa5f63e9de78648d7801f085e4653701a692ce938d6fd"
+"checksum syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c97c05b8ebc34ddd6b967994d5c6e9852fa92f8b82b3858c39451f97346dcce5"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum syntex_errors 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9e52bffe6202cfb67587784cf23e0ec5bf26d331eef4922a16d5c42e12aa1e9b"

--- a/src/actions/work_pool.rs
+++ b/src/actions/work_pool.rs
@@ -21,7 +21,7 @@ lazy_static! {
     static ref NUM_THREADS: usize = ::num_cpus::get();
 
     /// Duration of work after which we should warn something is taking a long time
-    static ref WARN_TASK_DURATION: Duration = *DEFAULT_REQUEST_TIMEOUT * 5;
+    static ref WARN_TASK_DURATION: Duration = DEFAULT_REQUEST_TIMEOUT * 5;
 
     /// Current work descriptions active on the work pool
     static ref WORK: Mutex<Vec<WorkDescription>> = Mutex::new(vec![]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,14 +67,6 @@ pub mod server;
 #[cfg(test)]
 mod test;
 
-// Timeout = 1.5s (totally arbitrary).
-#[cfg(not(test))]
-const COMPILER_TIMEOUT: u64 = 1500;
-
-// Timeout for potenially very slow CPU CI boxes
-#[cfg(test)]
-const COMPILER_TIMEOUT: u64 = 3_600_000;
-
 const RUSTC_SHIM_ENV_VAR_NAME: &str = "RLS_RUSTC_SHIM";
 
 type Span = span::Span<span::ZeroIndexed>;

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -22,9 +22,14 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-lazy_static! {
-    pub static ref DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(::COMPILER_TIMEOUT);
-}
+/// Timeout time for request responses. By default a LSP client request not
+/// responded to after this duration will return a fallback response.
+#[cfg(not(test))]
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(1500);
+
+// Timeout lengthened to "never" for potenially very slow CI boxes
+#[cfg(test)]
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(3_600_000);
 
 /// Macro enum `DispatchRequest` packing in various similar `Request` types
 macro_rules! define_dispatch_request_enum {
@@ -166,7 +171,7 @@ pub trait RequestAction: LSPRequest {
 
     /// Max duration this request should finish within, also see `fallback_response()`
     fn timeout() -> Duration {
-        *DEFAULT_REQUEST_TIMEOUT
+        DEFAULT_REQUEST_TIMEOUT
     }
 
     /// Returns a response used in timeout scenarios


### PR DESCRIPTION
Inspired by the 1.25 release including more `Duration` const fns, I thought we could clarify the usage of `COMPILER_TIMEOUT` which currently seems a little confusing. It's actually just used to define the LSP request-response timeout. Indeed, we _can't_ timeout rustc currently.

I've removed the misleading timeout and added better documentation to `DEFAULT_REQUEST_TIMEOUT`, which is now a const `Duration`.