### PR TITLE
Make cfg_test to match `cargo check --tests`

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -899,9 +899,15 @@ fn test_bin_lib_project() {
             ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
             ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
             ExpectedMessage::new(None).expect_contains("progress").expect_contains("bin_lib"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("bin_lib"),
+            ExpectedMessage::new(None).expect_contains("progress"),
+            ExpectedMessage::new(None).expect_contains("progress"),
+            ExpectedMessage::new(None).expect_contains("progress"),
+            ExpectedMessage::new(None).expect_contains("progress"),
             ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
             ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
+            ExpectedMessage::new(None)
+                .expect_contains(r#"bin_lib/tests/tests.rs"#)
+                .expect_contains(r#"unused variable: `unused_var`"#),
             ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
         ],
     );
@@ -1557,7 +1563,6 @@ fn test_all_targets() {
             ExpectedMessage::new(None).expect_contains("progress").expect_contains("message"),
             ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
             ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-
             ExpectedMessage::new(None)
                 .expect_contains(r#"bin_lib/tests/tests.rs"#)
                 .expect_contains(r#"unused variable: `unused_var`"#),

--- a/test_data/bin_lib/src/lib.rs
+++ b/test_data/bin_lib/src/lib.rs
@@ -1,4 +1,1 @@
 pub struct LibStruct {}
-
-#[cfg(test)]
-pub struct LibCfgTestStruct {}

--- a/test_data/bin_lib/src/main.rs
+++ b/test_data/bin_lib/src/main.rs
@@ -3,6 +3,6 @@ extern crate bin_lib;
 #[allow(unused_variables)]
 fn main() {
     let a = bin_lib::LibStruct {};
-    let test = bin_lib::LibCfgTestStruct { };
+
     println!("Hello, world!");
 }


### PR DESCRIPTION
Fixes #741.
Fixes #787.

Didn't add a reasonable integration test (like in #741) since the output is very nondeterministic (e.g. sometimes it merges publishDiagnostics from integration test and main crate into a single message, sometimes not etc.).

This basically is equivalent to `cargo check --tests`, which runs the check on every unit test and integration tests.

r? @nrc