### PR TITLE
Update cargo inline with 2018-04-07 nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,12 +76,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cargo"
 version = "0.27.0"
-source = "git+https://github.com/rust-lang/cargo?rev=311a5eda6f90d660bb23e97c8ee77090519b9eda#311a5eda6f90d660bb23e97c8ee77090519b9eda"
+source = "git+https://github.com/rust-lang/cargo?rev=b70ab13b31628e91b05961d55c07abf20ad49de6#b70ab13b31628e91b05961d55c07abf20ad49de6"
 dependencies = [
  "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crates-io 0.16.0 (git+https://github.com/rust-lang/cargo?rev=311a5eda6f90d660bb23e97c8ee77090519b9eda)",
+ "crates-io 0.16.0 (git+https://github.com/rust-lang/cargo?rev=b70ab13b31628e91b05961d55c07abf20ad49de6)",
  "crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-hash 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -113,7 +113,7 @@ dependencies = [
  "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -220,7 +220,7 @@ dependencies = [
 [[package]]
 name = "crates-io"
 version = "0.16.0"
-source = "git+https://github.com/rust-lang/cargo?rev=311a5eda6f90d660bb23e97c8ee77090519b9eda#311a5eda6f90d660bb23e97c8ee77090519b9eda"
+source = "git+https://github.com/rust-lang/cargo?rev=b70ab13b31628e91b05961d55c07abf20ad49de6#b70ab13b31628e91b05961d55c07abf20ad49de6"
 dependencies = [
  "curl 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -977,7 +977,7 @@ dependencies = [
 name = "rls"
 version = "0.126.0"
 dependencies = [
- "cargo 0.27.0 (git+https://github.com/rust-lang/cargo?rev=311a5eda6f90d660bb23e97c8ee77090519b9eda)",
+ "cargo 0.27.0 (git+https://github.com/rust-lang/cargo?rev=b70ab13b31628e91b05961d55c07abf20ad49de6)",
  "cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy_lints 0.0.193 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1370,12 +1370,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
+name = "tempfile"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1603,7 +1606,7 @@ dependencies = [
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
-"checksum cargo 0.27.0 (git+https://github.com/rust-lang/cargo?rev=311a5eda6f90d660bb23e97c8ee77090519b9eda)" = "<none>"
+"checksum cargo 0.27.0 (git+https://github.com/rust-lang/cargo?rev=b70ab13b31628e91b05961d55c07abf20ad49de6)" = "<none>"
 "checksum cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ebd6272a2ca4fd39dbabbd6611eb03df45c2259b3b80b39a9ff8fbdcf42a4b3"
 "checksum cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2b4911e4bdcb4100c7680e7e854ff38e23f1b34d4d9e079efae3da2801341ffc"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
@@ -1614,7 +1617,7 @@ dependencies = [
 "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
-"checksum crates-io 0.16.0 (git+https://github.com/rust-lang/cargo?rev=311a5eda6f90d660bb23e97c8ee77090519b9eda)" = "<none>"
+"checksum crates-io 0.16.0 (git+https://github.com/rust-lang/cargo?rev=b70ab13b31628e91b05961d55c07abf20ad49de6)" = "<none>"
 "checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
@@ -1744,7 +1747,7 @@ dependencies = [
 "checksum syntex_pos 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "955ef4b16af4c468e4680d1497f873ff288f557d338180649e18f915af5e15ac"
 "checksum syntex_syntax 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76a302e717e348aa372ff577791c3832395650073b8d8432f8b3cb170b34afde"
 "checksum tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1605d3388ceb50252952ffebab4b5dc43017ead7e4481b175961c283bb951195"
-"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+"checksum tempfile 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "439d9a7c00f98b1b5ee730039bf5b1f9203d508690e3c76b509e7ad59f8f7c99"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["development-tools"]
 build = "build.rs"
 
 [dependencies]
-cargo = { git = "https://github.com/rust-lang/cargo", rev = "311a5eda6f90d660bb23e97c8ee77090519b9eda" }
+cargo = { git = "https://github.com/rust-lang/cargo", rev = "b70ab13b31628e91b05961d55c07abf20ad49de6" }
 cargo_metadata = "0.5.2"
 env_logger = "0.5"
 failure = "0.1.1"


### PR DESCRIPTION
_git shortlog 311a5..b70ab_
```
Aleksey Kladov (17):
      Supply units to the context at the point of creation
      Introduce compilation files
      Restore --features args for cargo rustdoc
      Slightly better variable names
      Replace a triple with a struct for readability
      Extract target info
      Make TargetInfo.cfg private
      Rename TargetFileType -> FileFlavor
      Move filename logic to FileType
      Replace triple with struct
      Make assertion more informative
      Implement `--out-dir` option
      Feature gate `--out-dir`
      Test out-dir edge cases
      Replace home-grown create_dir_all with std::fs::create_dir_all
      Fix tests for mac
      Slightly improve InternedString

Alex Crichton (3):
      Run `rustc` for information fewer times
      Remove rustfmt from Travis
      Less aggressively poison sources on builds

Bastien Orivel (1):
      Replace tempdir by tempfile

Dirkjan Ochtman (7):
      Fix formatting issues with cargo fmt
      Move resolver::Resolve into a new resolver::resolve module
      Move utility types from resolver into resolver::types
      Move resolver::Context into new resolver::context module
      Move resolver Context initialization into a method
      Reorder code in resolver module for better readability
      Fix spelling errors in interning module

Eric Huss (1):
      locate-project: Fix help description.

Klaus Purer (4):
      docs(Z-flags): Add description for each -Z flag in cargo -Z help
      tests(help): Add test for -Z help output
      tests(help): Fix assertion by using the full line text
      chore(cli): Remove dead code in main()

Kurtis Nusbaum (1):
      rename epoch to edition

Mark Simulacrum (1):
      Remove thread local, replacing with DeserializeSeed

Orestis Floros (1):
      cargo_new: remove redundant leading new lines from ignore files

Philipp Oppermann (2):
      Canonicalize paths passed as `--target`
      Add custom target tests

gibix (5):
      fix #2773 with new precise encode
      cargo fmt
      fix typo , drop return and intermediate vector
      cargo fmt
      add precise test

rleungx (2):
      tweak error message
      address comment
```