### PR TITLE
Fix clippy suggestions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,7 @@
 
 #![allow(unknown_lints)]
 #![warn(clippy)]
-#![allow(cyclomatic_complexity)]
-#![allow(needless_pass_by_value)]
+#![allow(cyclomatic_complexity, needless_pass_by_value, too_many_arguments)]
 
 extern crate cargo;
 extern crate cargo_metadata;

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -390,8 +390,8 @@ mod test {
         let deser: serde_json::Value = serde_json::from_str(&raw).unwrap();
 
         assert!(match deser.get("params") {
-            Some(&serde_json::Value::Array(ref arr)) if arr.len() == 0 => true,
-            Some(&serde_json::Value::Object(ref map)) if map.len() == 0 => true,
+            Some(&serde_json::Value::Array(ref arr)) if arr.is_empty() => true,
+            Some(&serde_json::Value::Object(ref map)) if map.is_empty() => true,
             None => true,
             _ => false,
         });

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -36,14 +36,14 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use url::Url;
 
-pub fn initialize<'a>(
+pub fn initialize(
     id: usize,
     root_path: Option<String>,
 ) -> Request<ls_server::InitializeRequest> {
     initialize_with_opts(id, root_path, None)
 }
 
-pub fn initialize_with_opts<'a>(
+pub fn initialize_with_opts(
     id: usize,
     root_path: Option<String>,
     initialization_options: Option<InitializationOptions>,
@@ -81,7 +81,7 @@ pub fn blocking_request<T: ls_server::BlockingRequestAction>(
     }
 }
 
-pub fn request<'a, T: ls_server::RequestAction>(id: usize, params: T::Params) -> Request<T> {
+pub fn request<T: ls_server::RequestAction>(id: usize, params: T::Params) -> Request<T> {
     Request {
         id,
         params,
@@ -90,7 +90,7 @@ pub fn request<'a, T: ls_server::RequestAction>(id: usize, params: T::Params) ->
     }
 }
 
-fn notification<'a, A: ls_server::BlockingNotificationAction>(params: A::Params) -> Notification<A> {
+fn notification<A: ls_server::BlockingNotificationAction>(params: A::Params) -> Notification<A> {
     Notification {
         params,
         _action: PhantomData,


### PR DESCRIPTION
Also allow _too_many_arguments_

This pr is in honour of rls-clippy actually working with this morning's new rust release.