### PR TITLE
Ensure initialize response is sent before `ctx.init`

### DIFF
--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -77,6 +77,7 @@ pub trait BlockingRequestAction: LSPRequest {
 
     /// Handle request and return its response. Output is also provided for additional messaging.
     fn handle<O: Output>(
+        id: usize,
         params: Self::Params,
         ctx: &mut ActionContext,
         out: O,
@@ -181,7 +182,7 @@ impl<A: BlockingRequestAction> Request<A> {
         ctx: &mut ActionContext,
         out: &O,
     ) -> Result<A::Response, ResponseError> {
-        A::handle(self.params, ctx, out.clone())
+        A::handle(self.id, self.params, ctx, out.clone())
     }
 }
 


### PR DESCRIPTION
Regressed in #856 where I unified/simplified `BlockingRequestAction`s to return their responses. In the `initialize` case though I missed that the early response was intended.

This functionality is restored in this pr, but keeping the improved error handling of #856 & with a comment to help avoid the same mistake.

Fixes #863