### PR TITLE
Update to rustc master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,7 +1000,7 @@ dependencies = [
  "rls-analysis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-blacklist 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-rustc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-rustc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-vfs 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt-nightly 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "rls-rustc"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1690,7 +1690,7 @@ dependencies = [
 "checksum rls-analysis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da9794cd1f80f2cb888c00641a32f9855d0226c954ee31cef145784914c7142e"
 "checksum rls-blacklist 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e4a9cc2545ccb7e05b355bfe047b8039a6ec12270d5f3c996b766b340a50f7d2"
 "checksum rls-data 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd20763e1c60ae8945384c8a8fa4ac44f8afa7b0a817511f5e8927e5d24f988"
-"checksum rls-rustc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "885f66b92757420572cbb02e033d4a9558c7413ca9b7ac206f28fd58ffdb44ea"
+"checksum rls-rustc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ed5342b2bbbe8663c04600af506c8902b6b4d3e627b006eb1bd65aa14805f4d"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rls-vfs 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "be231e1e559c315bc60ced5ad2cc2d7a9c208ed7d4e2c126500149836fda19bb"
 "checksum rustc-ap-rustc_cratesio_shim 128.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7374a2b466e6e3ce489e045302e304849355faf7fd033d4d95e6e86e48c313b4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rayon = "1"
 rls-analysis = "0.13"
 rls-blacklist = "0.1.2"
 rls-data = { version = "0.16", features = ["serialize-serde"] }
-rls-rustc = "0.2.1"
+rls-rustc = "0.3.0"
 rls-span = { version = "0.4", features = ["serialize-serde"] }
 rls-vfs = { version = "0.4.5", features = ["racer-impls"] }
 rustfmt-nightly = "0.7"

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -15,7 +15,7 @@ extern crate rustc_plugin;
 extern crate rustc_errors as errors;
 extern crate rustc_resolve;
 extern crate rustc_save_analysis;
-extern crate rustc_trans_utils;
+extern crate rustc_codegen_utils;
 #[cfg(feature = "clippy")]
 extern crate clippy_lints;
 extern crate syntax;
@@ -27,7 +27,7 @@ use self::rustc_driver::{run, run_compiler, Compilation, CompilerCalls, RustcDef
 use self::rustc_driver::driver::{CompileController};
 use self::rustc_save_analysis as save;
 use self::rustc_save_analysis::CallbackHandler;
-use self::rustc_trans_utils::trans_crate::TransCrate;
+use self::rustc_codegen_utils::codegen_backend::CodegenBackend;
 use self::syntax::ast;
 use self::syntax::codemap::{FileLoader, RealFileLoader};
 
@@ -215,7 +215,7 @@ impl<'a> CompilerCalls<'a> for RlsRustcCalls {
 
     fn late_callback(
         &mut self,
-        trans_crate: &TransCrate,
+        codegen_backend: &CodegenBackend,
         matches: &getopts::Matches,
         sess: &Session,
         cstore: &CrateStore,
@@ -224,7 +224,7 @@ impl<'a> CompilerCalls<'a> for RlsRustcCalls {
         ofile: &Option<PathBuf>,
     ) -> Compilation {
         self.default_calls
-            .late_callback(trans_crate, matches, sess, cstore, input, odir, ofile)
+            .late_callback(codegen_backend, matches, sess, cstore, input, odir, ofile)
     }
 
     fn build_controller(


### PR DESCRIPTION
RLS is broken by https://github.com/rust-lang/rust/pull/50615 and https://github.com/nrc/rls-rustc/pull/8 is also required to merge this