### PR TITLE
Add missing dev openssl package in contributing.md.

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -30,8 +30,8 @@ via `rustup`, which is the currently preferred method. See the
 On Linux, you will need [cmake](https://cmake.org/), [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
 and [zlib](http://zlib.net/):
 
-- On Ubuntu run: `sudo apt-get install cmake pkg-config zlib1g-dev`
-- On Fedora run: `sudo dnf install cmake pkgconfig zlib-devel`
+- On Ubuntu run: `sudo apt-get install cmake pkg-config zlib1g-dev libssl-dev`
+- On Fedora run: `sudo dnf install cmake pkgconfig zlib-devel openssl-devel`
 
 On Windows, you will need to have [cmake](https://cmake.org/) installed.
 


### PR DESCRIPTION
I tried building rls project on new ubuntu 16.04 (ubuntu/xenial64
vagrant), but it failed with a message::

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

After installing this package using apt-get, `cargo build --release`
finished successfully.

Full error message below:

error: failed to run custom build command for `openssl-sys v0.9.31`
process didn't exit successfully: `/home/vagrant/rls/target/release/build/openssl-sys-71380b530539df2a/build-script-main` (exit code: 101)
--- stdout
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR
cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR
cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR
cargo:rerun-if-env-changed=OPENSSL_DIR
run pkg_config fail: "`\"pkg-config\" \"--libs\" \"--cflags\" \"openssl\"` did not exit successfully: exit code: 1\n--- stderr\nPackage openssl was not found in the pkg-config search path.\nPerhaps you should add the directory containing `openssl.pc\'\nto the PKG_CONFIG_PATH environment variable\nNo package \'openssl\' found\n"

--- stderr
thread 'main' panicked at '

Could not find directory of OpenSSL installation, and this `-sys` crate cannot
proceed without this knowledge. If OpenSSL is installed and this crate had
trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
compilation process.

Make sure you also have the development packages of openssl installed.
For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

If you're in a situation where you think the directory *should* be found
automatically, please open a bug at https://github.com/sfackler/rust-openssl
and include information about your system as well as this message.

    $HOST = x86_64-unknown-linux-gnu
    $TARGET = x86_64-unknown-linux-gnu
    openssl-sys = 0.9.31

', /home/vagrant/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.31/build/main.rs:232:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed
exit 101
