### PR TITLE
Support string request ids.

### DIFF
--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -45,7 +45,7 @@ impl BlockingNotificationAction for Initialized {
     fn handle<O: Output>(_params: Self::Params, ctx: &mut InitActionContext, out: O) -> Result<(), ()> {
         const WATCH_ID: &str = "rls-watch";
 
-        let id = out.provide_id() as usize;
+        let id = out.provide_id();
         let params = RegistrationParams {
             registrations: vec![
                 Registration {
@@ -208,7 +208,7 @@ impl BlockingNotificationAction for DidChangeConfiguration {
 
         const RANGE_FORMATTING_ID: &str = "rls-range-formatting";
         // FIXME should handle the response
-        let id = out.provide_id() as usize;
+        let id = out.provide_id();
         if unstable_features {
             let params = RegistrationParams {
                     registrations: vec![

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -446,11 +446,11 @@ pub enum ExecuteCommandResponse {
 }
 
 impl server::Response for ExecuteCommandResponse {
-    fn send<O: Output>(&self, id: usize, out: &O) {
+    fn send<O: Output>(&self, id: server::RequestId, out: &O) {
         // FIXME should handle the client's responses
         match *self {
             ExecuteCommandResponse::ApplyEdit(ref params) => {
-                let id = out.provide_id() as usize;
+                let id = out.provide_id();
                 let params = ApplyWorkspaceEditParams {
                         edit: params.edit.clone(),
                 };

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -15,7 +15,7 @@
 use actions::requests;
 use analysis::{AnalysisHost, Target};
 use config::Config;
-use server::{self, LsService, Notification, Request};
+use server::{self, LsService, Notification, Request, RequestId};
 use vfs::Vfs;
 
 use ls_types::{ClientCapabilities, CodeActionContext, CodeActionParams, DocumentFormattingParams,
@@ -411,11 +411,11 @@ fn url(file_name: &str) -> Url {
     Url::parse(&format!("file://{}", path)).expect("Bad file name")
 }
 
-fn next_id() -> usize {
-    static mut ID: usize = 0;
+fn next_id() -> RequestId {
+    static mut ID: u64 = 0;
     unsafe {
         ID += 1;
-        ID
+        RequestId::Num(ID)
     }
 }
 
@@ -428,11 +428,11 @@ impl server::Output for PrintlnOutput {
         println!("{}", output);
     }
 
-    fn provide_id(&self) -> u32 {
-        0
+    fn provide_id(&self) -> RequestId {
+        RequestId::Num(0)
     }
 
-    fn success<D: ::serde::Serialize + fmt::Debug>(&self, id: usize, data: &D) {
+    fn success<D: ::serde::Serialize + fmt::Debug>(&self, id: RequestId, data: &D) {
         println!("{}: {:#?}", id, data);
     }
 }

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -36,15 +36,15 @@ pub struct NoResponse;
 /// A response to some request.
 pub trait Response {
     /// Send the response along the given output.
-    fn send<O: Output>(&self, id: usize, out: &O);
+    fn send<O: Output>(&self, id: RequestId, out: &O);
 }
 
 impl Response for NoResponse {
-    fn send<O: Output>(&self, _id: usize, _out: &O) {}
+    fn send<O: Output>(&self, _id: RequestId, _out: &O) {}
 }
 
 impl<R: ::serde::Serialize + fmt::Debug> Response for R {
-    fn send<O: Output>(&self, id: usize, out: &O) {
+    fn send<O: Output>(&self, id: RequestId, out: &O) {
         out.success(id, &self);
     }
 }
@@ -77,17 +77,45 @@ pub trait BlockingRequestAction: LSPRequest {
 
     /// Handle request and return its response. Output is also provided for additional messaging.
     fn handle<O: Output>(
-        id: usize,
+        id: RequestId,
         params: Self::Params,
         ctx: &mut ActionContext,
         out: O,
     ) -> Result<Self::Response, ResponseError>;
 }
 
+/// A request ID as defined by language server protocol.
+///
+/// It only describes valid request ids - a case for notification (where id is not specified) is
+/// not included here.
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
+pub enum RequestId {
+    Str(String),
+    Num(u64),
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RequestId::Str(ref s) => write!(f, "\"{}\"", s),
+            RequestId::Num(n) => write!(f, "{}", n),
+        }
+    }
+}
+
+impl<'a> From<&'a RequestId> for Id {
+    fn from(request_id: &RequestId) -> Self {
+        match request_id {
+            RequestId::Str(ref s) => Id::Str(s.to_string()),
+            RequestId::Num(n) => Id::Num(*n),
+        }
+    }
+}
+
 /// A request that gets JSON serialized in the language server protocol.
 pub struct Request<A: LSPRequest> {
     /// The unique request id.
-    pub id: usize,
+    pub id: RequestId,
     /// The time the request was received / processed by the main stdin reading thread.
     pub received: Instant,
     /// The extra action-specific parameters.
@@ -98,7 +126,7 @@ pub struct Request<A: LSPRequest> {
 
 impl<A: LSPRequest> Request<A> {
     /// Creates a server `Request` structure with given `params`.
-    pub fn new(id: usize, params: A::Params) -> Request<A> {
+    pub fn new(id: RequestId, params: A::Params) -> Request<A> {
         Request {
             id,
             received: Instant::now(),
@@ -145,8 +173,7 @@ where
 
         RawMessage {
             method,
-            // FIXME: for now we support only numeric ids
-            id: Id::Num(request.id as u64),
+            id: Id::from(&request.id),
             params
         }
     }
@@ -234,11 +261,9 @@ impl RawMessage {
         R: LSPRequest,
         <R as LSPRequest>::Params: serde::Deserialize<'de>,
     {
-        // FIXME: We only support numeric responses, ideally we should switch from using parsed usize
-        // to using jsonrpc_core::Id
-        let parsed_numeric_id = match self.id {
-            Id::Num(n) => Some(n as usize),
-            Id::Str(ref s) => usize::from_str_radix(s, 10).ok(),
+        let parsed_id = match self.id {
+            Id::Num(n) => Some(RequestId::Num(n)),
+            Id::Str(ref s) => Some(RequestId::Str(s.to_string())),
             Id::Null => None,
         };
 
@@ -247,7 +272,7 @@ impl RawMessage {
             jsonrpc::Error::invalid_params(format!("{}", e))
         })?;
 
-        match parsed_numeric_id {
+        match parsed_id {
             Some(id) => Ok(Request {
                 id,
                 params,
@@ -363,21 +388,57 @@ mod test {
 
     // http://www.jsonrpc.org/specification#request_object
     #[test]
-    fn parse_raw_message() {
-        let raw_msg = json!({
+    fn raw_message_parses_valid_jsonrpc_request_with_string_id() {
+        let raw_json = json!({
+            "jsonrpc": "2.0",
+            "id": "abc",
+            "method": "someRpcCall",
+        }).to_string();
+
+        let expected_msg = RawMessage {
+            method: "someRpcCall".to_owned(),
+            id: Id::Str("abc".to_owned()),
+            // Internally missing parameters are represented as null
+            params: serde_json::Value::Null,
+        };
+        assert_eq!(expected_msg, RawMessage::try_parse(&raw_json).unwrap().unwrap());
+    }
+
+    #[test]
+    fn raw_message_parses_valid_jsonrpc_request_with_numeric_id() {
+        let raw_json = json!({
             "jsonrpc": "2.0",
             "id": "1",
             "method": "someRpcCall",
         }).to_string();
 
-        let str_msg = RawMessage {
+        let expected_msg = RawMessage {
             method: "someRpcCall".to_owned(),
-            // FIXME: for now we support only numeric ids
             id: Id::Num(1),
             // Internally missing parameters are represented as null
             params: serde_json::Value::Null,
         };
-        assert_eq!(str_msg, RawMessage::try_parse(&raw_msg).unwrap().unwrap());
+        assert_eq!(expected_msg, RawMessage::try_parse(&raw_json).unwrap().unwrap());
+    }
+
+    #[test]
+    fn raw_message_with_string_id_parses_into_request() {
+        #[derive(Debug)]
+        pub enum DummyRequest { }
+        impl LSPRequest for DummyRequest {
+            type Params = ();
+            type Result = ();
+            const METHOD: &'static str = "dummyRequest";
+        }
+
+        let raw_msg = RawMessage {
+            method: "dummyRequest".to_owned(),
+            id: Id::Str("abc".to_owned()),
+            params: serde_json::Value::Null,
+        };
+
+        let request: Request<DummyRequest> = raw_msg.parse_as_request().expect("RawMessage with numeric id should parse into request");
+        assert_eq!(RequestId::Str("abc".to_owned()), request.id)
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -329,7 +329,7 @@ impl<O: Output> LsService<O> {
 
         if let Err(e) = self.dispatch_message(&raw_message) {
             error!("dispatch error, {:?}", e);
-            self.output.failure(raw_message.id.unwrap_or(Id::Null), e);
+            self.output.failure(raw_message.id, e);
             return ServerStateChange::Break;
         }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -33,7 +33,7 @@ use server::io::{StdioMsgReader, StdioOutput};
 use server::message::RawMessage;
 pub use server::message::{
     Ack, BlockingNotificationAction, BlockingRequestAction, NoResponse, Notification, Request,
-    Response, ResponseError
+    Response, ResponseError, RequestId
 };
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
@@ -65,7 +65,7 @@ impl BlockingRequestAction for ShutdownRequest {
     type Response = Ack;
 
     fn handle<O: Output>(
-        _id: usize,
+        _id: RequestId,
         _params: Self::Params,
         ctx: &mut ActionContext,
         _out: O,
@@ -96,7 +96,7 @@ impl BlockingRequestAction for InitializeRequest {
     type Response = NoResponse;
 
     fn handle<O: Output>(
-        id: usize,
+        id: RequestId,
         params: Self::Params,
         ctx: &mut ActionContext,
         out: O,
@@ -198,7 +198,7 @@ impl<O: Output> LsService<O> {
                         // block until all nonblocking requests have been handled ensuring ordering
                         self.dispatcher.await_all_dispatched();
 
-                        let req_id = request.id;
+                        let req_id = request.id.clone();
                         match request.blocking_dispatch(&mut self.ctx, &self.output) {
                             Ok(res) => res.send(req_id, &self.output),
                             Err(ResponseError::Empty) => {

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -169,10 +169,10 @@ impl ls_server::Output for RecordOutput {
         records.push(output);
     }
 
-    fn provide_id(&self) -> u32 {
+    fn provide_id(&self) -> ls_server::RequestId {
         let mut id = self.output_id.lock().unwrap();
         *id += 1;
-        *id
+        ls_server::RequestId::Num(*id as u64)
     }
 }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -19,7 +19,7 @@ mod harness;
 use analysis;
 use actions::{requests, notifications};
 use config::{Config, Inferrable};
-use server::{self as ls_server, Request, ShutdownRequest, Notification};
+use server::{self as ls_server, Request, ShutdownRequest, Notification, RequestId};
 use jsonrpc_core;
 use vfs;
 
@@ -62,7 +62,7 @@ pub fn initialize_with_opts(
         trace: Some(TraceOption::Off),
     };
     Request {
-        id,
+        id: RequestId::Num(id as u64),
         params,
         received: Instant::now(),
         _action: PhantomData,
@@ -74,7 +74,7 @@ pub fn blocking_request<T: ls_server::BlockingRequestAction>(
     params: T::Params,
 ) -> Request<T> {
     Request {
-        id,
+        id: RequestId::Num(id as u64),
         params,
         received: Instant::now(),
         _action: PhantomData,
@@ -83,7 +83,7 @@ pub fn blocking_request<T: ls_server::BlockingRequestAction>(
 
 pub fn request<T: ls_server::RequestAction>(id: usize, params: T::Params) -> Request<T> {
     Request {
-        id,
+        id: RequestId::Num(id as u64),
         params,
         received: Instant::now(),
         _action: PhantomData,


### PR DESCRIPTION
This change introduces RequestId type that represents either numeric or string id, and replaces use of usize with this newly introduced type.