### PR TITLE
Introduce Sender trait and use it instead of Output where we can.

### DIFF
--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -20,6 +20,7 @@ use serde_json;
 use actions::ActionContext;
 use lsp_data::{LSPNotification, LSPRequest};
 use server::io::Output;
+use server::io::Sender;
 
 use std::fmt;
 use std::marker::PhantomData;
@@ -68,7 +69,7 @@ impl From<()> for ResponseError {
 /// Blocks stdin whilst being handled.
 pub trait BlockingNotificationAction: LSPNotification {
     /// Handle this notification.
-    fn handle<O: Output>(Self::Params, &mut InitActionContext, O) -> Result<(), ()>;
+    fn handle<S: Sender>(Self::Params, &mut InitActionContext, S) -> Result<(), ()>;
 }
 
 /// A request that blocks stdin whilst being handled
@@ -214,8 +215,8 @@ impl<A: BlockingRequestAction> Request<A> {
 }
 
 impl<A: BlockingNotificationAction> Notification<A> {
-    pub fn dispatch<O: Output>(self, ctx: &mut InitActionContext, out: O) -> Result<(), ()> {
-        A::handle(self.params, ctx, out)?;
+    pub fn dispatch<S: Sender>(self, ctx: &mut InitActionContext, sender: S) -> Result<(), ()> {
+        A::handle(self.params, ctx, sender)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Currently Output is used for two separate things - to send responses to
incoming requests and to send new requests and notifications. This
changelist is a first step to separate those two responsibilities, and
make it clear what objects actually use Output just for sending new
requests. It also nicely hides the need to handle the request id.

Also, Output currently only writes data to client, which means that
`Output.request` method will never be able to nicely return a response
from client. The plan with Sender is to nicely handle this case long
term.