### PR TITLE
Fix compilation with clippy feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.205"
+version = "0.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1010,7 +1010,7 @@ version = "0.128.0"
 dependencies = [
  "cargo 0.29.0 (git+https://github.com/rust-lang/cargo?rev=22c0f22f5621f1b68558d80a0966d073b9b68932)",
  "cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.205 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy_lints 0.0.207 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1665,7 +1665,7 @@ dependencies = [
 "checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
-"checksum clippy_lints 0.0.205 (registry+https://github.com/rust-lang/crates.io-index)" = "1dcb837d7510bf9e4e3b6f470c450c6d25e61116db5503a6f565bb6283860622"
+"checksum clippy_lints 0.0.207 (registry+https://github.com/rust-lang/crates.io-index)" = "722c160a3f49291c83aee07397a5eeea143f806ac2407f53780da1268d5154d3"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
 "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
 "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 [dependencies]
 cargo = { git = "https://github.com/rust-lang/cargo", rev = "22c0f22f5621f1b68558d80a0966d073b9b68932" }
 cargo_metadata = "0.5.2"
-clippy_lints = { version = "0.0.205", optional = true }
+clippy_lints = { version = "0.0.207", optional = true }
 env_logger = "0.5"
 failure = "0.1.1"
 itertools = "0.7.3"

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -233,11 +233,13 @@ impl<'a> CompilerCalls<'a> for RlsRustcCalls {
         matches: &getopts::Matches,
     ) -> CompileController<'a> {
         let analysis = self.analysis.clone();
+        #[cfg(feature = "clippy")]
+        let clippy_preference = self.clippy_preference;
         let mut result = self.default_calls.build_controller(sess, matches);
         result.keep_ast = true;
 
         #[cfg(feature = "clippy")] {
-            if self.clippy_preference != ClippyPreference::Off {
+            if clippy_preference != ClippyPreference::Off {
                 result.after_parse.callback = Box::new(clippy_after_parse_callback);
             }
         }


### PR DESCRIPTION
Compilation with the clippy feature broke probably with 7d0bc550b0899a13a56c81eb2d5064abd0bcf385.

Update clippy_lints to 0.0.207