### PR TITLE
The last of the masters

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,4 @@
+status = [
+  "continuous-integration/travis-ci/push",
+  "continuous-integration/appveyor/branch",
+]


### PR DESCRIPTION
Hi! What do you feel about adding https://bors.tech/, an as-a-service version of Rust's bors?

I think it can help a little with timezones challenges and reduce the number of sun round trips required to merge a PR. For example, https://github.com/rust-lang-nursery/rls/pull/919#issuecomment-401238615 perhaps could've made use of `bors delegate+` feature to implement "changes look good to me, but there's a trivial merge conflict. Feel free to self-r+ once the the conflict is fixed".

bors.tech is being used by [crates.io](https://github.com/rust-lang/crates.io) and [IntelliJ Rust](https://github.com/intellij-rust/intellij-rust).


Oh, and the not rocket science rule is good in and of itself :D
