### PR TITLE
Filter out duplicate symbols

### DIFF
--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -18,6 +18,7 @@ use racer;
 use rustfmt_nightly::{format_input, FileLines, FileName, Input as FmtInput, Range as RustfmtRange};
 use serde_json;
 use rls_span as span;
+use itertools::Itertools;
 
 use crate::actions::work_pool;
 use crate::actions::work_pool::WorkDescription;
@@ -83,6 +84,9 @@ impl RequestAction for WorkspaceSymbol {
 
         Ok(
             defs.into_iter()
+                // Sometimes analysis will return duplicate symbols
+                // for the same location, fix that up.
+                .unique_by(|d| (d.span.clone(), d.name.clone()))
                 .map(|d| {
                     SymbolInformation {
                         name: d.name,

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -243,6 +243,17 @@ crate fn expect_messages(server: &mut ls_server::LsService<RecordOutput>, result
     *results = vec![];
 }
 
+crate fn compare_json(actual: &serde_json::Value, expected: &str) {
+    let expected: serde_json::Value = serde_json::from_str(expected).unwrap();
+    if actual != &expected {
+        panic!(
+            "JSON differs\nExpected:\n{}\nActual:\n{}\n",
+            serde_json::to_string_pretty(&expected).unwrap(),
+            serde_json::to_string_pretty(actual).unwrap(),
+        );
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 crate struct Src<'a, 'b> {
     crate file_name: &'a Path,

--- a/src/test/lens.rs
+++ b/src/test/lens.rs
@@ -1,9 +1,7 @@
-use std::{
-    path::Path,
-};
+use std::path::Path;
 
-use url::Url;
 use serde_json;
+use url::Url;
 use languageserver_types::{TextDocumentIdentifier, CodeLensParams};
 
 use crate::{
@@ -12,7 +10,7 @@ use crate::{
     lsp_data::InitializationOptions,
     test::{
         request, initialize_with_opts,
-        harness::{expect_messages, Environment, ExpectedMessage},
+        harness::{expect_messages, compare_json, Environment, ExpectedMessage},
     },
 };
 
@@ -29,10 +27,14 @@ fn test_lens_run() {
         .expect("couldn't convert file path to URL");
     let text_doc = TextDocumentIdentifier::new(url.clone());
     let messages = vec![
-        initialize_with_opts(0, root_path, Some(InitializationOptions {
-            omit_init_build: false,
-            cmd_run: true,
-        })).to_string(),
+        initialize_with_opts(
+            0,
+            root_path,
+            Some(InitializationOptions {
+                omit_init_build: false,
+                cmd_run: true,
+            }),
+        ).to_string(),
         request::<requests::CodeLensRequest>(
             100,
             CodeLensParams {
@@ -51,7 +53,8 @@ fn test_lens_run() {
         &mut server,
         results.clone(),
         &[
-            ExpectedMessage::new(Some(0)).expect_contains(r#""codeLensProvider":{"resolveProvider":false}"#),
+            ExpectedMessage::new(Some(0))
+                .expect_contains(r#""codeLensProvider":{"resolveProvider":false}"#),
             ExpectedMessage::new(None).expect_contains("progress"),
             ExpectedMessage::new(None).expect_contains("progress"),
             ExpectedMessage::new(None).expect_contains("progress"),
@@ -83,17 +86,6 @@ fn test_lens_run() {
               "start": { "character": 3, "line": 14 },
               "end": { "character": 11, "line": 14 }
             }
-        }]"#
+        }]"#,
     )
-}
-
-fn compare_json(actual: &serde_json::Value, expected: &str) {
-    let expected: serde_json::Value = serde_json::from_str(expected).unwrap();
-    if actual != &expected {
-        panic!(
-            "JSON differs\nExpected:\n{}\nActual:\n{}\n",
-            serde_json::to_string_pretty(&expected).unwrap(),
-            serde_json::to_string_pretty(actual).unwrap(),
-        );
-    }
 }

--- a/test_data/workspace_symbol_duplicates/Cargo.lock
+++ b/test_data/workspace_symbol_duplicates/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "workspace_symbol_duplicates"
+version = "0.1.0"
+

--- a/test_data/workspace_symbol_duplicates/Cargo.toml
+++ b/test_data/workspace_symbol_duplicates/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "workspace_symbol_duplicates"
+version = "0.1.0"
+authors = ["Stuart Hinson <stuart.hinson@gmail.com>"]
+
+[dependencies]

--- a/test_data/workspace_symbol_duplicates/src/main.rs
+++ b/test_data/workspace_symbol_duplicates/src/main.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[path="shared.rs"]
+mod a;
+#[path="shared.rs"]
+mod b;

--- a/test_data/workspace_symbol_duplicates/src/shared.rs
+++ b/test_data/workspace_symbol_duplicates/src/shared.rs
@@ -1,0 +1,12 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[allow(unused)]
+struct Frobnicator;


### PR DESCRIPTION
Sometimes analysis returns duplicate symbols for the same location. It
can be a bug in the analysis, however in general it might be the case
that two logically different symbols correspond to the same location,
if we use `include!` or something like that.

So, let's do duplicate detection before submitting results to the user
for the time being

closes https://github.com/rust-lang-nursery/rls/issues/922

Here's an example of the problem happening in the real life, without `#[path="..."]` tricks:

![image](https://user-images.githubusercontent.com/1711539/42134491-75ce9862-7d45-11e8-92f5-f6d802ff39f0.png)


Ideally, we should fix ^ directly, but I don't know what exactly is the problem. 