### PR TITLE
Update clippy_lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,8 +159,8 @@ dependencies = [
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.211"
-source = "git+https://github.com/rust-lang-nursery/rust-clippy?rev=6c70013f93a18c1ca7990efa8b1464acc6e18ce7#6c70013f93a18c1ca7990efa8b1464acc6e18ce7"
+version = "0.0.212"
+source = "git+https://github.com/rust-lang-nursery/rust-clippy?rev=d914106d871050f84f465fc906b9b7b431d828ce#d914106d871050f84f465fc906b9b7b431d828ce"
 dependencies = [
  "cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1011,7 +1011,7 @@ version = "0.129.0"
 dependencies = [
  "cargo 0.30.0 (git+https://github.com/rust-lang/cargo?rev=5699afe508d62924f6b38b19dc98296ad33d1659)",
  "cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.211 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=6c70013f93a18c1ca7990efa8b1464acc6e18ce7)",
+ "clippy_lints 0.0.212 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=d914106d871050f84f465fc906b9b7b431d828ce)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1671,7 +1671,7 @@ dependencies = [
 "checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
-"checksum clippy_lints 0.0.211 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=6c70013f93a18c1ca7990efa8b1464acc6e18ce7)" = "<none>"
+"checksum clippy_lints 0.0.212 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=d914106d871050f84f465fc906b9b7b431d828ce)" = "<none>"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
 "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
 "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 [dependencies]
 cargo = { git = "https://github.com/rust-lang/cargo", rev = "5699afe508d62924f6b38b19dc98296ad33d1659" }
 cargo_metadata = "0.5.2"
-clippy_lints = { git = "https://github.com/rust-lang-nursery/rust-clippy", rev = "6c70013f93a18c1ca7990efa8b1464acc6e18ce7", optional = true }
+clippy_lints = { git = "https://github.com/rust-lang-nursery/rust-clippy", rev = "d914106d871050f84f465fc906b9b7b431d828ce", optional = true }
 env_logger = "0.5"
 failure = "0.1.1"
 itertools = "0.7.3"


### PR DESCRIPTION
Updates `clippy_lints` to the latest so that the clippy feature builds once more.