### PR TITLE
Switch to standard implementation method.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "languageserver-types"
 version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/dgriffen/languageserver-types?branch=server-capabilities-3.6#03da5a14ba3fcb5af6bb276c97cca43e3a075912"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1017,7 +1017,7 @@ dependencies = [
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "languageserver-types 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "languageserver-types 0.44.0 (git+https://github.com/dgriffen/languageserver-types?branch=server-capabilities-3.6)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1722,7 +1722,7 @@ dependencies = [
 "checksum json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9ad0485404155f45cce53a40d4b2d6ac356418300daed05273d9e26f91c390be"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum languageserver-types 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "967ee31e22d81605bb42c93fc7e0fa363c0adc560506e78d3508a2d20b508b74"
+"checksum languageserver-types 0.44.0 (git+https://github.com/dgriffen/languageserver-types?branch=server-capabilities-3.6)" = "<none>"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,8 +613,8 @@ dependencies = [
 
 [[package]]
 name = "languageserver-types"
-version = "0.44.0"
-source = "git+https://github.com/dgriffen/languageserver-types?branch=server-capabilities-3.6#03da5a14ba3fcb5af6bb276c97cca43e3a075912"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1017,7 +1017,7 @@ dependencies = [
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "languageserver-types 0.44.0 (git+https://github.com/dgriffen/languageserver-types?branch=server-capabilities-3.6)",
+ "languageserver-types 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1722,7 +1722,7 @@ dependencies = [
 "checksum json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9ad0485404155f45cce53a40d4b2d6ac356418300daed05273d9e26f91c390be"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum languageserver-types 0.44.0 (git+https://github.com/dgriffen/languageserver-types?branch=server-capabilities-3.6)" = "<none>"
+"checksum languageserver-types 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d91d91d1c23db74187096d191967cb49f49bb175ad6d855fa9229d16ef2c982"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ json = "0.11"
 [features]
 default = []
 clippy = ["clippy_lints"]
+
+[patch.crates-io]
+languageserver-types = { git = 'https://github.com/dgriffen/languageserver-types', branch = 'server-capabilities-3.6' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ env_logger = "0.5"
 failure = "0.1.1"
 itertools = "0.7.3"
 jsonrpc-core = "8.0.1"
-languageserver-types = "0.44"
+languageserver-types = "0.45"
 lazy_static = "1"
 log = "0.4"
 num_cpus = "1"
@@ -44,6 +44,3 @@ json = "0.11"
 [features]
 default = []
 clippy = ["clippy_lints"]
-
-[patch.crates-io]
-languageserver-types = { git = 'https://github.com/dgriffen/languageserver-types', branch = 'server-capabilities-3.6' }

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -35,6 +35,7 @@ pub use lsp_data::request::{
     DocumentSymbol as Symbols,
     HoverRequest as Hover,
     GotoDefinition as Definition,
+    GotoImplementation as Implementation,
     References,
     Completion,
     DocumentHighlightRequest as DocumentHighlight,
@@ -46,7 +47,6 @@ pub use lsp_data::request::{
     ResolveCompletionItem as ResolveCompletion,
     CodeLensRequest,
 };
-pub use lsp_data::FindImpls;
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -174,7 +174,7 @@ impl RequestAction for Hover {
     }
 }
 
-impl RequestAction for FindImpls {
+impl RequestAction for Implementation {
     type Response = Vec<Location>;
 
     fn fallback_response() -> Result<Self::Response, ResponseError> {

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -350,18 +350,6 @@ impl LSPNotification for BeginBuild {
     const METHOD: &'static str = "rustDocument/beginBuild";
 }
 
-/* ------------------ Custom JSON-RPC requests ---------------- */
-
-/// Find all the implementations of a given trait.
-#[derive(Debug)]
-pub enum FindImpls { }
-
-impl LSPRequest for FindImpls {
-    type Params = TextDocumentPositionParams;
-    type Result = Vec<Location>;
-    const METHOD: &'static str = "rustDocument/implementations";
-}
-
 /* ----------  Temporary LSP type until window/progress proposal is done --------- */
 
 // Notification from server to client for build progress.

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -95,7 +95,7 @@ define_dispatch_request_enum!(
     WorkspaceSymbol,
     Symbols,
     Hover,
-    FindImpls,
+    Implementation,
     DocumentHighlight,
     Rename,
     CodeAction,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -20,8 +20,8 @@ pub use ls_types::notification::Exit as ExitNotification;
 pub use ls_types::request::Initialize as InitializeRequest;
 pub use ls_types::request::Shutdown as ShutdownRequest;
 use ls_types::{
-    CompletionOptions, ExecuteCommandOptions, InitializeParams, InitializeResult,
-    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, CodeLensOptions
+    CompletionOptions, ExecuteCommandOptions, ImplementationProviderCapability, InitializeParams, InitializeResult,
+    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, CodeLensOptions,
 };
 use lsp_data;
 use lsp_data::{InitializationOptions, LSPNotification, LSPRequest};
@@ -270,7 +270,7 @@ impl<O: Output> LsService<O> {
                 requests::Rename,
                 requests::CodeAction,
                 requests::DocumentHighlight,
-                requests::FindImpls,
+                requests::Implementation,
                 requests::Symbols,
                 requests::Hover,
                 requests::WorkspaceSymbol,
@@ -360,6 +360,8 @@ fn server_caps(ctx: &ActionContext) -> ServerCapabilities {
             trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
         }),
         definition_provider: Some(true),
+        type_definition_provider: None,
+        implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
         references_provider: Some(true),
         document_highlight_provider: Some(true),
         document_symbol_provider: Some(true),
@@ -376,6 +378,8 @@ fn server_caps(ctx: &ActionContext) -> ServerCapabilities {
             ],
         }),
         rename_provider: Some(true),
+        color_provider: None,
+
         // These are supported if the `unstable_features` option is set.
         // We'll update these capabilities dynamically when we get config
         // info from the client.

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1148,14 +1148,14 @@ fn test_find_impls() {
 
     let messages = vec![
         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
-        request::<requests::FindImpls>(
+        request::<requests::Implementation>(
             1,
             TextDocumentPositionParams {
                 text_document: TextDocumentIdentifier::new(url.clone()),
                 position: env.cache.mk_ls_position(src(&source_file_path, 13, "Bar")),
             },
         ).to_string(),
-        request::<requests::FindImpls>(
+        request::<requests::Implementation>(
             2,
             TextDocumentPositionParams {
                 text_document: TextDocumentIdentifier::new(url.clone()),
@@ -1164,7 +1164,7 @@ fn test_find_impls() {
             },
         ).to_string(),
         // FIXME Does not work on Travis
-        // request::<requests::FindImpls>(
+        // request::<requests::Implementation>(
         //     3,
         //     TextDocumentPositionParams {
         //         text_document: TextDocumentIdentifier::new(url),


### PR DESCRIPTION
This PR removes the custom `FindImpls` method and replaces it with the standard `GotoImplementation` method from version [3.6.0](https://microsoft.github.io/language-server-protocol/specification#version_3_6_0) of the LSP.