### PR TITLE
Prepare for 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
+cargo-features = ["edition"]
+
 [package]
 name = "rls"
 version = "0.129.0"
+edition = "2018"
 authors = ["Nick Cameron <ncameron@mozilla.com>", "The RLS developers"]
 description = "Rust Language Server - provides information about Rust programs to IDEs and other tools"
 license = "Apache-2.0/MIT"

--- a/src/actions/diagnostics.rs
+++ b/src/actions/diagnostics.rs
@@ -344,7 +344,7 @@ impl IsWithin for Range {
 #[cfg(test)]
 mod diagnostic_message_test {
     use super::*;
-    use ls_types::Position;
+    use languageserver_types::Position;
 
     pub(super) fn parse_compiler_message(
         compiler_message: &str,
@@ -735,7 +735,7 @@ help: consider borrowing here: `&string`"#,
 mod diagnostic_suggestion_test {
     use self::diagnostic_message_test::*;
     use super::*;
-    use ls_types::Position;
+    use languageserver_types::Position;
 
     #[test]
     fn suggest_use_when_cannot_find_type() {

--- a/src/actions/diagnostics.rs
+++ b/src/actions/diagnostics.rs
@@ -18,13 +18,13 @@ use std::collections::HashMap;
 use std::iter;
 use std::path::{Path, PathBuf};
 
-use ls_types::{DiagnosticRelatedInformation, DiagnosticSeverity, Location, NumberOrString, Range};
-use lsp_data::ls_util;
+use crate::ls_types::{DiagnosticRelatedInformation, DiagnosticSeverity, Location, NumberOrString, Range};
+use crate::lsp_data::ls_util;
 use serde_json;
-use span::compiler::DiagnosticSpan;
+use crate::span::compiler::DiagnosticSpan;
 use url::Url;
 
-pub use ls_types::Diagnostic;
+pub use crate::ls_types::Diagnostic;
 
 #[derive(Debug)]
 pub struct Suggestion {

--- a/src/actions/diagnostics.rs
+++ b/src/actions/diagnostics.rs
@@ -18,13 +18,13 @@ use std::collections::HashMap;
 use std::iter;
 use std::path::{Path, PathBuf};
 
-use crate::ls_types::{DiagnosticRelatedInformation, DiagnosticSeverity, Location, NumberOrString, Range};
+use languageserver_types::{DiagnosticRelatedInformation, DiagnosticSeverity, Location, NumberOrString, Range};
 use crate::lsp_data::ls_util;
 use serde_json;
-use crate::span::compiler::DiagnosticSpan;
+use rls_span::compiler::DiagnosticSpan;
 use url::Url;
 
-pub use crate::ls_types::Diagnostic;
+pub use languageserver_types::Diagnostic;
 
 #[derive(Debug)]
 pub struct Suggestion {

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -11,13 +11,13 @@
 //! Actions that the RLS can perform: responding to requests, watching files,
 //! etc.
 
-use crate::analysis::AnalysisHost;
-use crate::vfs::Vfs;
+use rls_analysis::AnalysisHost;
+use rls_vfs::Vfs;
 use crate::config::FmtConfig;
 use crate::config::Config;
 use serde_json;
 use url::Url;
-use span;
+use rls_span as span;
 use crate::Span;
 use walkdir::WalkDir;
 

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -11,22 +11,22 @@
 //! Actions that the RLS can perform: responding to requests, watching files,
 //! etc.
 
-use analysis::AnalysisHost;
-use vfs::Vfs;
-use config::FmtConfig;
-use config::Config;
+use crate::analysis::AnalysisHost;
+use crate::vfs::Vfs;
+use crate::config::FmtConfig;
+use crate::config::Config;
 use serde_json;
 use url::Url;
 use span;
-use Span;
+use crate::Span;
 use walkdir::WalkDir;
 
-use actions::post_build::{BuildResults, PostBuildHandler, AnalysisQueue};
-use actions::progress::{BuildProgressNotifier, BuildDiagnosticsNotifier};
-use build::*;
-use lsp_data;
-use lsp_data::*;
-use server::Output;
+use crate::actions::post_build::{BuildResults, PostBuildHandler, AnalysisQueue};
+use crate::actions::progress::{BuildProgressNotifier, BuildDiagnosticsNotifier};
+use crate::build::*;
+use crate::lsp_data;
+use crate::lsp_data::*;
+use crate::server::Output;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -11,7 +11,7 @@
 //! One-way notifications that the RLS receives from the client.
 
 use crate::actions::{InitActionContext, FileWatch, VersionOrdering};
-use crate::vfs::Change;
+use rls_vfs::Change;
 use crate::config::Config;
 use serde::Deserialize;
 use serde::de::Error;
@@ -22,7 +22,7 @@ use std::sync::atomic::Ordering;
 use crate::build::*;
 use crate::lsp_data::*;
 use crate::lsp_data::request::{RangeFormatting, RegisterCapability, UnregisterCapability};
-use crate::ls_types::notification::ShowMessage;
+use languageserver_types::notification::ShowMessage;
 use crate::server::Request;
 
 pub use crate::lsp_data::notification::{

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -10,22 +10,22 @@
 
 //! One-way notifications that the RLS receives from the client.
 
-use actions::{InitActionContext, FileWatch, VersionOrdering};
-use vfs::Change;
-use config::Config;
+use crate::actions::{InitActionContext, FileWatch, VersionOrdering};
+use crate::vfs::Change;
+use crate::config::Config;
 use serde::Deserialize;
 use serde::de::Error;
 use serde_json;
-use Span;
+use crate::Span;
 use std::sync::atomic::Ordering;
 
-use build::*;
-use lsp_data::*;
-use lsp_data::request::{RangeFormatting, RegisterCapability, UnregisterCapability};
-use ls_types::notification::ShowMessage;
-use server::Request;
+use crate::build::*;
+use crate::lsp_data::*;
+use crate::lsp_data::request::{RangeFormatting, RegisterCapability, UnregisterCapability};
+use crate::ls_types::notification::ShowMessage;
+use crate::server::Request;
 
-pub use lsp_data::notification::{
+pub use crate::lsp_data::notification::{
     Initialized,
     DidOpenTextDocument,
     DidChangeTextDocument,
@@ -35,7 +35,7 @@ pub use lsp_data::notification::{
     Cancel,
 };
 
-use server::{BlockingNotificationAction, Notification, Output};
+use crate::server::{BlockingNotificationAction, Notification, Output};
 
 use std::thread;
 

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -24,12 +24,12 @@ use std::thread::{self, Thread};
 use crate::actions::diagnostics::{parse_diagnostics, Diagnostic, ParsedDiagnostics, Suggestion};
 use crate::actions::progress::DiagnosticsNotifier;
 use crate::build::BuildResult;
-use crate::ls_types::DiagnosticSeverity;
+use languageserver_types::DiagnosticSeverity;
 use itertools::Itertools;
 use crate::lsp_data::PublishDiagnosticsParams;
 
-use crate::analysis::AnalysisHost;
-use crate::data::Analysis;
+use rls_analysis::AnalysisHost;
+use rls_data::Analysis;
 use url::Url;
 
 pub type BuildResults = HashMap<PathBuf, Vec<(Diagnostic, Vec<Suggestion>)>>;
@@ -111,7 +111,7 @@ impl PostBuildHandler {
     fn reload_analysis_from_disk(&self, cwd: &Path) {
         if self.use_black_list {
             self.analysis
-                .reload_with_blacklist(&self.project_path, cwd, &crate::blacklist::CRATE_BLACKLIST)
+                .reload_with_blacklist(&self.project_path, cwd, &rls_blacklist::CRATE_BLACKLIST)
                 .unwrap();
         } else {
             self.analysis.reload(&self.project_path, cwd).unwrap();
@@ -125,7 +125,7 @@ impl PostBuildHandler {
                     analysis,
                     &self.project_path,
                     cwd,
-                    &crate::blacklist::CRATE_BLACKLIST,
+                    &rls_blacklist::CRATE_BLACKLIST,
                 )
                 .unwrap();
         } else {

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -21,15 +21,15 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, Thread};
 
-use actions::diagnostics::{parse_diagnostics, Diagnostic, ParsedDiagnostics, Suggestion};
-use actions::progress::DiagnosticsNotifier;
-use build::BuildResult;
-use ls_types::DiagnosticSeverity;
+use crate::actions::diagnostics::{parse_diagnostics, Diagnostic, ParsedDiagnostics, Suggestion};
+use crate::actions::progress::DiagnosticsNotifier;
+use crate::build::BuildResult;
+use crate::ls_types::DiagnosticSeverity;
 use itertools::Itertools;
-use lsp_data::PublishDiagnosticsParams;
+use crate::lsp_data::PublishDiagnosticsParams;
 
-use analysis::AnalysisHost;
-use data::Analysis;
+use crate::analysis::AnalysisHost;
+use crate::data::Analysis;
 use url::Url;
 
 pub type BuildResults = HashMap<PathBuf, Vec<(Diagnostic, Vec<Suggestion>)>>;
@@ -111,7 +111,7 @@ impl PostBuildHandler {
     fn reload_analysis_from_disk(&self, cwd: &Path) {
         if self.use_black_list {
             self.analysis
-                .reload_with_blacklist(&self.project_path, cwd, &::blacklist::CRATE_BLACKLIST)
+                .reload_with_blacklist(&self.project_path, cwd, &crate::blacklist::CRATE_BLACKLIST)
                 .unwrap();
         } else {
             self.analysis.reload(&self.project_path, cwd).unwrap();
@@ -125,7 +125,7 @@ impl PostBuildHandler {
                     analysis,
                     &self.project_path,
                     cwd,
-                    &::blacklist::CRATE_BLACKLIST,
+                    &crate::blacklist::CRATE_BLACKLIST,
                 )
                 .unwrap();
         } else {

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -44,7 +44,7 @@ pub struct PostBuildHandler {
     pub related_information_support: bool,
     pub shown_cargo_error: Arc<AtomicBool>,
     pub active_build_count: Arc<AtomicUsize>,
-    pub notifier: Box<DiagnosticsNotifier>,
+    pub notifier: Box<dyn DiagnosticsNotifier>,
     pub blocked_threads: Vec<thread::Thread>,
 }
 

--- a/src/actions/progress.rs
+++ b/src/actions/progress.rs
@@ -10,9 +10,9 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use lsp_data::{ProgressParams, PublishDiagnosticsParams, Progress, ShowMessageParams, MessageType};
-use server::{Output, Notification};
-use ls_types::notification::{PublishDiagnostics, ShowMessage};
+use crate::lsp_data::{ProgressParams, PublishDiagnosticsParams, Progress, ShowMessageParams, MessageType};
+use crate::server::{Output, Notification};
+use crate::ls_types::notification::{PublishDiagnostics, ShowMessage};
 
 /// Trait for communication of build progress back to the client.
 pub trait ProgressNotifier: Send {

--- a/src/actions/progress.rs
+++ b/src/actions/progress.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::lsp_data::{ProgressParams, PublishDiagnosticsParams, Progress, ShowMessageParams, MessageType};
 use crate::server::{Output, Notification};
-use crate::ls_types::notification::{PublishDiagnostics, ShowMessage};
+use languageserver_types::notification::{PublishDiagnostics, ShowMessage};
 
 /// Trait for communication of build progress back to the client.
 pub trait ProgressNotifier: Send {
@@ -33,7 +33,7 @@ pub enum ProgressUpdate {
 // is not object-safe).
 pub trait DiagnosticsNotifier: Send {
     fn notify_begin_diagnostics(&self);
-    fn notify_publish_diagnostics(&self, PublishDiagnosticsParams);
+    fn notify_publish_diagnostics(&self, _: PublishDiagnosticsParams);
     fn notify_error_diagnostics(&self, msg: String);
     fn notify_end_diagnostics(&self);
 }

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -10,27 +10,27 @@
 
 //! Requests that the RLS can respond to.
 
-use actions::InitActionContext;
+use crate::actions::InitActionContext;
 use data;
 use url::Url;
-use vfs::FileContents;
+use crate::vfs::FileContents;
 use racer;
-use rustfmt::{format_input, FileLines, FileName, Input as FmtInput, Range as RustfmtRange};
+use crate::rustfmt::{format_input, FileLines, FileName, Input as FmtInput, Range as RustfmtRange};
 use serde_json;
 use span;
 
-use actions::work_pool;
-use actions::work_pool::WorkDescription;
-use actions::run::collect_run_actions;
-use lsp_data;
-use lsp_data::*;
-use server;
-use server::{Ack, Output, Request, RequestAction, ResponseError};
+use crate::actions::work_pool;
+use crate::actions::work_pool::WorkDescription;
+use crate::actions::run::collect_run_actions;
+use crate::lsp_data;
+use crate::lsp_data::*;
+use crate::server;
+use crate::server::{Ack, Output, Request, RequestAction, ResponseError};
 use jsonrpc_core::types::ErrorCode;
-use analysis::SymbolQuery;
+use crate::analysis::SymbolQuery;
 
-use lsp_data::request::ApplyWorkspaceEdit;
-pub use lsp_data::request::{
+use crate::lsp_data::request::ApplyWorkspaceEdit;
+pub use crate::lsp_data::request::{
     WorkspaceSymbol,
     DocumentSymbol as Symbols,
     HoverRequest as Hover,

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -11,13 +11,13 @@
 //! Requests that the RLS can respond to.
 
 use crate::actions::InitActionContext;
-use data;
+use rls_data as data;
 use url::Url;
-use crate::vfs::FileContents;
+use rls_vfs::FileContents;
 use racer;
-use crate::rustfmt::{format_input, FileLines, FileName, Input as FmtInput, Range as RustfmtRange};
+use rustfmt_nightly::{format_input, FileLines, FileName, Input as FmtInput, Range as RustfmtRange};
 use serde_json;
-use span;
+use rls_span as span;
 
 use crate::actions::work_pool;
 use crate::actions::work_pool::WorkDescription;
@@ -27,7 +27,7 @@ use crate::lsp_data::*;
 use crate::server;
 use crate::server::{Ack, Output, Request, RequestAction, ResponseError};
 use jsonrpc_core::types::ErrorCode;
-use crate::analysis::SymbolQuery;
+use rls_analysis::SymbolQuery;
 
 use crate::lsp_data::request::ApplyWorkspaceEdit;
 pub use crate::lsp_data::request::{

--- a/src/actions/run.rs
+++ b/src/actions/run.rs
@@ -1,8 +1,8 @@
-use actions::InitActionContext;
+use crate::actions::InitActionContext;
 use ordslice::Ext;
 use regex::Regex;
-use span::{Column, Position, Range, Row, ZeroIndexed};
-use vfs::FileContents;
+use crate::span::{Column, Position, Range, Row, ZeroIndexed};
+use crate::vfs::FileContents;
 
 use std::{collections::HashMap, iter, path::Path};
 

--- a/src/actions/run.rs
+++ b/src/actions/run.rs
@@ -1,8 +1,8 @@
 use crate::actions::InitActionContext;
 use ordslice::Ext;
 use regex::Regex;
-use crate::span::{Column, Position, Range, Row, ZeroIndexed};
-use crate::vfs::FileContents;
+use rls_span::{Column, Position, Range, Row, ZeroIndexed};
+use rls_vfs::FileContents;
 
 use std::{collections::HashMap, iter, path::Path};
 

--- a/src/actions/work_pool.rs
+++ b/src/actions/work_pool.rs
@@ -1,5 +1,5 @@
 use rayon;
-use server::DEFAULT_REQUEST_TIMEOUT;
+use crate::server::DEFAULT_REQUEST_TIMEOUT;
 use std::{fmt, panic};
 use std::time::{Duration, Instant};
 use std::sync::{mpsc, Mutex};

--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -17,11 +17,11 @@ use failure;
 use serde_json;
 
 use crate::actions::progress::ProgressUpdate;
-use crate::data::Analysis;
+use rls_data::Analysis;
 use crate::build::{BufWriter, BuildResult, CompilationContext, Internals, PackageArg};
 use crate::build::environment::{self, Environment, EnvironmentLock};
 use crate::config::Config;
-use crate::vfs::Vfs;
+use rls_vfs::Vfs;
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
@@ -430,14 +430,14 @@ impl Executor for RlsExecutor {
                 cmd.get_envs(),
             );
 
-            if crate::blacklist::CRATE_BLACKLIST.contains(&&*crate_name) {
+            if rls_blacklist::CRATE_BLACKLIST.contains(&&*crate_name) {
                 // By running the original command (rather than using our shim), we
                 // avoid producing save-analysis data.
                 trace!("crate is blacklisted");
                 return cargo_cmd.exec();
             }
             // Only include public symbols in externally compiled deps data
-            let mut save_config = crate::data::config::Config::default();
+            let mut save_config = rls_data::config::Config::default();
             save_config.pub_only = true;
             save_config.reachable_only = true;
             let save_config = serde_json::to_string(&save_config)?;

--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -16,12 +16,12 @@ use cargo::util::{homedir, important_paths, CargoResult, Config as CargoConfig, 
 use failure;
 use serde_json;
 
-use actions::progress::ProgressUpdate;
-use data::Analysis;
-use build::{BufWriter, BuildResult, CompilationContext, Internals, PackageArg};
-use build::environment::{self, Environment, EnvironmentLock};
-use config::Config;
-use vfs::Vfs;
+use crate::actions::progress::ProgressUpdate;
+use crate::data::Analysis;
+use crate::build::{BufWriter, BuildResult, CompilationContext, Internals, PackageArg};
+use crate::build::environment::{self, Environment, EnvironmentLock};
+use crate::config::Config;
+use crate::vfs::Vfs;
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
@@ -386,7 +386,7 @@ impl Executor for RlsExecutor {
             .or_else(|| env::current_exe().ok().and_then(|x| x.to_str().map(String::from)))
             .expect("Couldn't set executable for RLS rustc shim");
         cmd.program(rustc_shim);
-        cmd.env(::RUSTC_SHIM_ENV_VAR_NAME, "1");
+        cmd.env(crate::RUSTC_SHIM_ENV_VAR_NAME, "1");
 
         // Add args and envs to cmd.
         let mut args: Vec<_> = cargo_args
@@ -430,14 +430,14 @@ impl Executor for RlsExecutor {
                 cmd.get_envs(),
             );
 
-            if ::blacklist::CRATE_BLACKLIST.contains(&&*crate_name) {
+            if crate::blacklist::CRATE_BLACKLIST.contains(&&*crate_name) {
                 // By running the original command (rather than using our shim), we
                 // avoid producing save-analysis data.
                 trace!("crate is blacklisted");
                 return cargo_cmd.exec();
             }
             // Only include public symbols in externally compiled deps data
-            let mut save_config = ::data::config::Config::default();
+            let mut save_config = crate::data::config::Config::default();
             save_config.pub_only = true;
             save_config.reachable_only = true;
             let save_config = serde_json::to_string(&save_config)?;

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -185,7 +185,7 @@ struct PendingBuild {
     build_dir: PathBuf,
     priority: BuildPriority,
     built_files: HashMap<PathBuf, FileVersion>,
-    notifier: Box<ProgressNotifier>,
+    notifier: Box<dyn ProgressNotifier>,
     pbh: PostBuildHandler,
 }
 
@@ -259,7 +259,7 @@ impl BuildQueue {
         &self,
         new_build_dir: &Path,
         mut priority: BuildPriority,
-        notifier: Box<ProgressNotifier>,
+        notifier: Box<dyn ProgressNotifier>,
         pbh: PostBuildHandler
     ) {
         trace!("request_build {:?}", priority);

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -12,12 +12,12 @@
 
 pub use self::cargo::make_cargo_config;
 
-use actions::progress::{ProgressNotifier, ProgressUpdate};
-use actions::post_build::PostBuildHandler;
+use crate::actions::progress::{ProgressNotifier, ProgressUpdate};
+use crate::actions::post_build::PostBuildHandler;
 use cargo::util::important_paths;
-use config::Config;
-use data::Analysis;
-use vfs::Vfs;
+use crate::config::Config;
+use crate::data::Analysis;
+use crate::vfs::Vfs;
 
 use self::environment::EnvironmentLock;
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -16,8 +16,8 @@ use crate::actions::progress::{ProgressNotifier, ProgressUpdate};
 use crate::actions::post_build::PostBuildHandler;
 use cargo::util::important_paths;
 use crate::config::Config;
-use crate::data::Analysis;
-use crate::vfs::Vfs;
+use rls_data::Analysis;
+use rls_vfs::Vfs;
 
 use self::environment::EnvironmentLock;
 

--- a/src/build/plan.rs
+++ b/src/build/plan.rs
@@ -30,16 +30,16 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::Sender;
 
-use build::PackageArg;
+use crate::build::PackageArg;
 use cargo::core::{PackageId, Target, TargetKind};
 use cargo::core::compiler::{Context, Kind, Unit};
 use cargo::core::profiles::Profile;
 use cargo::util::{CargoResult, ProcessBuilder};
 use cargo_metadata;
-use lsp_data::parse_file_path;
+use crate::lsp_data::parse_file_path;
 use url::Url;
 
-use actions::progress::ProgressUpdate;
+use crate::actions::progress::ProgressUpdate;
 use super::{BuildResult, Internals};
 
 /// Main key type by which `Unit`s will be distinguished in the build plan.

--- a/src/build/plan.rs
+++ b/src/build/plan.rs
@@ -43,19 +43,19 @@ use crate::actions::progress::ProgressUpdate;
 use super::{BuildResult, Internals};
 
 /// Main key type by which `Unit`s will be distinguished in the build plan.
-pub type UnitKey = (PackageId, TargetKind);
+crate type UnitKey = (PackageId, TargetKind);
 
 /// Holds the information how exactly the build will be performed for a given
 /// workspace with given, specified features.
-pub struct Plan {
+crate struct Plan {
     /// Stores a full Cargo `Unit` data for a first processed unit with a given key.
-    pub units: HashMap<UnitKey, OwnedUnit>,
+    crate units: HashMap<UnitKey, OwnedUnit>,
     /// Main dependency graph between the simplified units.
-    pub dep_graph: HashMap<UnitKey, HashSet<UnitKey>>,
+    crate dep_graph: HashMap<UnitKey, HashSet<UnitKey>>,
     /// Reverse dependency graph that's used to construct a dirty compiler call queue.
-    pub rev_dep_graph: HashMap<UnitKey, HashSet<UnitKey>>,
+    crate rev_dep_graph: HashMap<UnitKey, HashSet<UnitKey>>,
     /// Cached compiler calls used when creating a compiler call queue.
-    pub compiler_jobs: HashMap<UnitKey, ProcessBuilder>,
+    crate compiler_jobs: HashMap<UnitKey, ProcessBuilder>,
     // An object for finding the package which a file belongs to and this inferring
     // a package argument.
     package_map: Option<PackageMap>,
@@ -64,7 +64,7 @@ pub struct Plan {
 }
 
 impl Plan {
-    pub fn new() -> Plan {
+    crate fn new() -> Plan {
         Plan {
             units: HashMap::new(),
             dep_graph: HashMap::new(),
@@ -75,7 +75,7 @@ impl Plan {
         }
     }
 
-    pub fn clear(&mut self) {
+    crate fn clear(&mut self) {
         self.units = HashMap::new();
         self.dep_graph = HashMap::new();
         self.rev_dep_graph = HashMap::new();
@@ -84,14 +84,14 @@ impl Plan {
 
     /// Returns whether a build plan has cached compiler invocations and dep
     /// graph so it's at all able to return a job queue via `prepare_work`.
-    pub fn is_ready(&self) -> bool {
+    crate fn is_ready(&self) -> bool {
         !self.compiler_jobs.is_empty()
     }
 
     /// Cache a given compiler invocation in `ProcessBuilder` for a given
     /// `PackageId` and `TargetKind` in `Target`, to be used when processing
     /// cached build plan.
-    pub fn cache_compiler_job(&mut self, id: &PackageId, target: &Target, cmd: &ProcessBuilder) {
+    crate fn cache_compiler_job(&mut self, id: &PackageId, target: &Target, cmd: &ProcessBuilder) {
         let pkg_key = (id.clone(), target.kind().clone());
         self.compiler_jobs.insert(pkg_key, cmd.clone());
     }
@@ -99,7 +99,7 @@ impl Plan {
     /// Emplace a given `Unit`, along with its `Unit` dependencies (recursively)
     /// into the dependency graph.
     #[allow(dead_code)]
-    pub fn emplace_dep(&mut self, unit: &Unit, cx: &Context) -> CargoResult<()> {
+    crate fn emplace_dep(&mut self, unit: &Unit, cx: &Context) -> CargoResult<()> {
         let null_filter = |_unit: &Unit| true;
         self.emplace_dep_with_filter(unit, cx, &null_filter)
     }
@@ -107,7 +107,7 @@ impl Plan {
     /// Emplace a given `Unit`, along with its `Unit` dependencies (recursively)
     /// into the dependency graph as long as the passed `Unit` isn't filtered
     /// out by the `filter` closure.
-    pub fn emplace_dep_with_filter<Filter>(
+    crate fn emplace_dep_with_filter<Filter>(
         &mut self,
         unit: &Unit,
         cx: &Context,
@@ -301,7 +301,7 @@ impl Plan {
         }
     }
 
-    pub fn prepare_work<T: AsRef<Path> + fmt::Debug>(
+    crate fn prepare_work<T: AsRef<Path> + fmt::Debug>(
         &mut self,
         manifest_path: &Path,
         modified: &[T],
@@ -373,7 +373,7 @@ impl Plan {
     }
 }
 
-pub enum WorkStatus {
+crate enum WorkStatus {
     NeedsCargo(PackageArg),
     Execute(JobQueue),
 }
@@ -470,10 +470,10 @@ impl PackageMap {
     }
 }
 
-pub struct JobQueue(Vec<ProcessBuilder>);
+crate struct JobQueue(Vec<ProcessBuilder>);
 
 impl JobQueue {
-    pub fn dequeue(&mut self) -> Option<ProcessBuilder> {
+    crate fn dequeue(&mut self) -> Option<ProcessBuilder> {
         self.0.pop()
     }
 
@@ -597,11 +597,11 @@ impl fmt::Debug for Plan {
 
 #[derive(Hash, PartialEq, Eq, Debug)]
 /// An owned version of `cargo::core::Unit`.
-pub struct OwnedUnit {
-    pub id: PackageId,
-    pub target: Target,
-    pub profile: Profile,
-    pub kind: Kind,
+crate struct OwnedUnit {
+    crate id: PackageId,
+    crate target: Target,
+    crate profile: Profile,
+    crate kind: Kind,
 }
 
 impl<'a> From<&'a Unit<'a>> for OwnedUnit {

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -44,7 +44,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 // Runs a single instance of rustc. Runs in-process.
-pub fn rustc(
+crate fn rustc(
     vfs: &Vfs,
     args: &[String],
     envs: &HashMap<String, Option<OsString>>,
@@ -215,10 +215,10 @@ impl<'a> CompilerCalls<'a> for RlsRustcCalls {
 
     fn late_callback(
         &mut self,
-        codegen_backend: &CodegenBackend,
+        codegen_backend: &dyn CodegenBackend,
         matches: &getopts::Matches,
         sess: &Session,
-        cstore: &CrateStore,
+        cstore: &dyn CrateStore,
         input: &Input,
         odir: &Option<PathBuf>,
         ofile: &Option<PathBuf>,

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -31,11 +31,11 @@ use self::rustc_codegen_utils::codegen_backend::CodegenBackend;
 use self::syntax::ast;
 use self::syntax::codemap::{FileLoader, RealFileLoader};
 
-use config::{ClippyPreference, Config};
-use build::{BufWriter, BuildResult};
-use build::environment::{Environment, EnvironmentLockFacade};
-use data::Analysis;
-use vfs::Vfs;
+use crate::config::{ClippyPreference, Config};
+use crate::build::{BufWriter, BuildResult};
+use crate::build::environment::{Environment, EnvironmentLockFacade};
+use crate::data::Analysis;
+use crate::vfs::Vfs;
 
 use std::collections::HashMap;
 use std::ffi::OsString;

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -8,33 +8,28 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate getopts;
-extern crate rustc;
-extern crate rustc_driver;
-extern crate rustc_errors as errors;
-extern crate rustc_resolve;
-extern crate rustc_save_analysis;
-extern crate rustc_codegen_utils;
 #[cfg(feature = "clippy")]
 extern crate clippy_lints;
-extern crate syntax;
 
-use self::rustc::middle::cstore::CrateStore;
-use self::rustc::session::Session;
-use self::rustc::session::config::{self, ErrorOutputType, Input};
-use self::rustc_driver::{run, run_compiler, Compilation, CompilerCalls, RustcDefaultCalls};
-use self::rustc_driver::driver::{CompileController};
-use self::rustc_save_analysis as save;
-use self::rustc_save_analysis::CallbackHandler;
-use self::rustc_codegen_utils::codegen_backend::CodegenBackend;
-use self::syntax::ast;
-use self::syntax::codemap::{FileLoader, RealFileLoader};
+use getopts;
+use rustc::middle::cstore::CrateStore;
+use rustc::session::Session;
+use rustc::session::config::{self, ErrorOutputType, Input};
+use rustc_driver::{run, run_compiler, Compilation, CompilerCalls, RustcDefaultCalls};
+use rustc_driver::driver::{CompileController};
+use rustc_errors;
+use rustc_resolve;
+use rustc_save_analysis as save;
+use rustc_save_analysis::CallbackHandler;
+use rustc_codegen_utils::codegen_backend::CodegenBackend;
+use syntax::ast;
+use syntax::codemap::{FileLoader, RealFileLoader};
+use rls_data::Analysis;
+use rls_vfs::Vfs;
 
 use crate::config::{ClippyPreference, Config};
 use crate::build::{BufWriter, BuildResult};
 use crate::build::environment::{Environment, EnvironmentLockFacade};
-use crate::data::Analysis;
-use crate::vfs::Vfs;
 
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -192,7 +187,7 @@ impl<'a> CompilerCalls<'a> for RlsRustcCalls {
         matches: &getopts::Matches,
         sopts: &config::Options,
         cfg: &ast::CrateConfig,
-        descriptions: &errors::registry::Registry,
+        descriptions: &rustc_errors::registry::Registry,
         output: ErrorOutputType,
     ) -> Compilation {
         self.default_calls
@@ -206,7 +201,7 @@ impl<'a> CompilerCalls<'a> for RlsRustcCalls {
         cfg: &ast::CrateConfig,
         odir: &Option<PathBuf>,
         ofile: &Option<PathBuf>,
-        descriptions: &errors::registry::Registry,
+        descriptions: &rustc_errors::registry::Registry,
     ) -> Option<(Input, Option<PathBuf>)> {
         self.default_calls
             .no_input(matches, sopts, cfg, odir, ofile, descriptions)

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -11,7 +11,6 @@
 extern crate getopts;
 extern crate rustc;
 extern crate rustc_driver;
-extern crate rustc_plugin;
 extern crate rustc_errors as errors;
 extern crate rustc_resolve;
 extern crate rustc_save_analysis;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -13,13 +13,13 @@
 //! the RLS as usual and prints the JSON result back on the command line.
 
 use crate::actions::requests;
-use crate::analysis::{AnalysisHost, Target};
+use rls_analysis::{AnalysisHost, Target};
 use crate::config::Config;
 use crate::server::{self, LsService, Notification, Request, RequestId};
 use std::sync::atomic::{AtomicU64, Ordering};
-use crate::vfs::Vfs;
+use rls_vfs::Vfs;
 
-use crate::ls_types::{
+use languageserver_types::{
     ClientCapabilities, CodeActionContext, CodeActionParams, CompletionItem,
     DocumentFormattingParams, DocumentRangeFormattingParams, DocumentSymbolParams,
     FormattingOptions, InitializeParams, Position, Range, RenameParams, TextDocumentIdentifier,

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -12,14 +12,14 @@
 //! versions of commands, turns them into messages the RLS will understand, runs
 //! the RLS as usual and prints the JSON result back on the command line.
 
-use actions::requests;
-use analysis::{AnalysisHost, Target};
-use config::Config;
-use server::{self, LsService, Notification, Request, RequestId};
+use crate::actions::requests;
+use crate::analysis::{AnalysisHost, Target};
+use crate::config::Config;
+use crate::server::{self, LsService, Notification, Request, RequestId};
 use std::sync::atomic::{AtomicU64, Ordering};
-use vfs::Vfs;
+use crate::vfs::Vfs;
 
-use ls_types::{
+use crate::ls_types::{
     ClientCapabilities, CodeActionContext, CodeActionParams, CompletionItem,
     DocumentFormattingParams, DocumentRangeFormattingParams, DocumentSymbolParams,
     FormattingOptions, InitializeParams, Position, Range, RenameParams, TextDocumentIdentifier,

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,8 +26,8 @@ use cargo::core::{Shell, Workspace};
 use serde;
 use serde::de::{Deserialize, Deserializer, Visitor};
 
-use rustfmt::Config as RustfmtConfig;
-use rustfmt::{self, load_config, CliOptions, EmitMode, Verbosity};
+use crate::rustfmt::Config as RustfmtConfig;
+use crate::rustfmt::{self, load_config, CliOptions, EmitMode, Verbosity};
 
 const DEFAULT_WAIT_TO_BUILD: u64 = 1500;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,8 +26,8 @@ use cargo::core::{Shell, Workspace};
 use serde;
 use serde::de::{Deserialize, Deserializer, Visitor};
 
-use crate::rustfmt::Config as RustfmtConfig;
-use crate::rustfmt::{self, load_config, CliOptions, EmitMode, Verbosity};
+use rustfmt_nightly::Config as RustfmtConfig;
+use rustfmt_nightly::{load_config, CliOptions, EmitMode, Verbosity};
 
 const DEFAULT_WAIT_TO_BUILD: u64 = 1500;
 
@@ -322,7 +322,7 @@ impl FmtConfig {
         struct NullOptions;
 
         impl CliOptions for NullOptions {
-            fn apply_to(self, _: &mut rustfmt::Config) {
+            fn apply_to(self, _: &mut RustfmtConfig) {
                 unreachable!();
             }
             fn config_path(&self) -> Option<&Path> {

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -14,16 +14,16 @@ use std::fmt;
 use std::path::PathBuf;
 use std::error::Error;
 
-use crate::analysis::DefKind;
+use rls_analysis::DefKind;
 use url::Url;
-use span;
+use rls_span as span;
 use racer;
-use crate::vfs::FileContents;
-use ls_types;
+use rls_vfs::FileContents;
+use languageserver_types as ls_types;
 
-pub use crate::ls_types::*;
-pub use crate::ls_types::request::Request as LSPRequest;
-pub use crate::ls_types::notification::Notification as LSPNotification;
+pub use languageserver_types::*;
+pub use languageserver_types::request::Request as LSPRequest;
+pub use languageserver_types::notification::Notification as LSPNotification;
 
 /// Errors that can occur when parsing a file URI.
 #[derive(Debug)]
@@ -86,7 +86,7 @@ pub mod ls_util {
     use crate::Span;
 
     use std::path::Path;
-    use crate::vfs::Vfs;
+    use rls_vfs::Vfs;
 
     /// Convert a language server protocol range into an RLS range.
     pub fn range_to_rls(r: Range) -> span::Range<span::ZeroIndexed> {

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -14,16 +14,16 @@ use std::fmt;
 use std::path::PathBuf;
 use std::error::Error;
 
-use analysis::DefKind;
+use crate::analysis::DefKind;
 use url::Url;
 use span;
 use racer;
-use vfs::FileContents;
+use crate::vfs::FileContents;
 use ls_types;
 
-pub use ls_types::*;
-pub use ls_types::request::Request as LSPRequest;
-pub use ls_types::notification::Notification as LSPNotification;
+pub use crate::ls_types::*;
+pub use crate::ls_types::request::Request as LSPRequest;
+pub use crate::ls_types::notification::Notification as LSPNotification;
 
 /// Errors that can occur when parsing a file URI.
 #[derive(Debug)]
@@ -83,10 +83,10 @@ pub fn make_workspace_edit(location: Location, new_text: String) -> WorkspaceEdi
 /// Utilities for working with the language server protocol.
 pub mod ls_util {
     use super::*;
-    use Span;
+    use crate::Span;
 
     use std::path::Path;
-    use vfs::Vfs;
+    use crate::vfs::Vfs;
 
     /// Convert a language server protocol range into an RLS range.
     pub fn range_to_rls(r: Range) -> span::Range<span::ZeroIndexed> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,42 +32,24 @@
 #[cfg_attr(all(windows, not(target_env = "msvc")), link_args = "-Wl,--stack,16777216")]
 extern {}
 
-extern crate cargo;
-extern crate cargo_metadata;
-extern crate env_logger;
+use env_logger;
 #[macro_use]
 extern crate failure;
-extern crate itertools;
-extern crate jsonrpc_core;
-extern crate languageserver_types as ls_types;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-extern crate num_cpus;
-extern crate racer;
-extern crate rayon;
-extern crate rls_analysis as analysis;
-extern crate rls_blacklist as blacklist;
-extern crate rls_data as data;
-extern crate rls_rustc as rustc_shim;
-extern crate rls_span as span;
-extern crate rls_vfs as vfs;
-extern crate rustfmt_nightly as rustfmt;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-
 #[macro_use]
 extern crate serde_json;
 
-extern crate url;
-extern crate walkdir;
-extern crate regex;
-extern crate ordslice;
-
 use std::env;
 use std::sync::Arc;
+
+use rls_analysis::{AnalysisHost, Target};
+use rls_rustc as rustc_shim;
+use rls_vfs::Vfs;
 
 pub mod actions;
 pub mod build;
@@ -81,7 +63,7 @@ mod test;
 
 const RUSTC_SHIM_ENV_VAR_NAME: &str = "RLS_RUSTC_SHIM";
 
-type Span = span::Span<span::ZeroIndexed>;
+type Span = rls_span::Span<rls_span::ZeroIndexed>;
 
 /// The main entry point to the RLS. Parses CLI arguments and then runs the
 /// server.
@@ -126,8 +108,8 @@ fn main_inner() -> i32 {
         }
     }
 
-    let analysis = Arc::new(analysis::AnalysisHost::new(analysis::Target::Debug));
-    let vfs = Arc::new(vfs::Vfs::new());
+    let analysis = Arc::new(AnalysisHost::new(Target::Debug));
+    let vfs = Arc::new(Vfs::new());
 
     server::run_server(analysis, vfs)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@
 #![feature(drain_filter)]
 #![feature(rust_2018_preview)]
 
+#![deny(rust_2018_idioms)]
 #![allow(unknown_lints)]
 #![warn(clippy)]
 #![allow(cyclomatic_complexity, needless_pass_by_value, too_many_arguments)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@
 #![feature(drain_filter)]
 #![feature(rust_2018_preview)]
 
-#![deny(rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![allow(unknown_lints)]
 #![warn(clippy)]
 #![allow(cyclomatic_complexity, needless_pass_by_value, too_many_arguments)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@
 #![feature(rustc_private)]
 #![feature(integer_atomics)]
 #![feature(drain_filter)]
+#![feature(rust_2018_preview)]
 
 #![allow(unknown_lints)]
 #![warn(clippy)]

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -9,15 +9,15 @@
 // except according to those terms.
 
 use super::requests::*;
-use actions::work_pool;
-use actions::work_pool::WorkDescription;
-use actions::InitActionContext;
+use crate::actions::work_pool;
+use crate::actions::work_pool::WorkDescription;
+use crate::actions::InitActionContext;
 use jsonrpc_core::types::ErrorCode;
-use lsp_data::LSPRequest;
-use server;
-use server::io::Output;
-use server::message::ResponseError;
-use server::{Request, Response};
+use crate::lsp_data::LSPRequest;
+use crate::server;
+use crate::server::io::Output;
+use crate::server::message::ResponseError;
+use crate::server::{Request, Response};
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -35,7 +35,7 @@ pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(3_600_000);
 macro_rules! define_dispatch_request_enum {
     ($($request_type:ident),*$(,)*) => {
         #[allow(large_enum_variant)] // seems ok for a short lived macro-enum
-        pub enum DispatchRequest {
+        crate enum DispatchRequest {
             $(
                 $request_type(Request<$request_type>, InitActionContext),
             )*

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -110,7 +110,7 @@ define_dispatch_request_enum!(
 /// handle the requests sequentially, without blocking stdin.
 /// Requests dispatched this way are automatically timed out & avoid
 /// processing if have already timed out before starting.
-pub struct Dispatcher {
+crate struct Dispatcher {
     sender: mpsc::Sender<DispatchRequest>,
 
     request_handled_receiver: mpsc::Receiver<()>,
@@ -120,7 +120,7 @@ pub struct Dispatcher {
 
 impl Dispatcher {
     /// Creates a new `Dispatcher` starting a new thread and channel
-    pub fn new<O: Output>(out: O) -> Self {
+    crate fn new<O: Output>(out: O) -> Self {
         let (sender, receiver) = mpsc::channel::<DispatchRequest>();
         let (request_handled_sender, request_handled_receiver) = mpsc::channel::<()>();
 
@@ -142,7 +142,7 @@ impl Dispatcher {
     }
 
     /// Blocks until all dispatched requests have been handled
-    pub fn await_all_dispatched(&mut self) {
+    crate fn await_all_dispatched(&mut self) {
         while self.in_flight_requests != 0 {
             self.request_handled_receiver.recv().unwrap();
             self.in_flight_requests -= 1;
@@ -150,7 +150,7 @@ impl Dispatcher {
     }
 
     /// Sends a request to the dispatch-worker thread, does not block
-    pub fn dispatch<R: Into<DispatchRequest>>(&mut self, request: R) {
+    crate fn dispatch<R: Into<DispatchRequest>>(&mut self, request: R) {
         if let Err(err) = self.sender.send(request.into()) {
             debug!("Failed to dispatch request: {:?}", err);
         } else {

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -12,7 +12,7 @@ use serde;
 use serde_json;
 
 use super::{Notification, Request, RequestId};
-use lsp_data::{LSPNotification, LSPRequest};
+use crate::lsp_data::{LSPNotification, LSPRequest};
 
 use std::fmt;
 use std::io::{self, BufRead, Write};

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -194,7 +194,7 @@ pub(super) struct StdioOutput {
 
 impl StdioOutput {
     /// Construct a new `stdout` output.
-    pub fn new() -> StdioOutput {
+    crate fn new() -> StdioOutput {
         StdioOutput {
             next_id: Arc::new(AtomicU64::new(1)),
         }

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -10,16 +10,16 @@
 
 //! Traits and structs for message handling
 
-use actions::InitActionContext;
+use crate::actions::InitActionContext;
 use jsonrpc_core::{self as jsonrpc, Id};
 use serde;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use serde::Deserialize;
 use serde_json;
 
-use actions::ActionContext;
-use lsp_data::{LSPNotification, LSPRequest};
-use server::io::Output;
+use crate::actions::ActionContext;
+use crate::lsp_data::{LSPNotification, LSPRequest};
+use crate::server::io::Output;
 
 use std::fmt;
 use std::marker::PhantomData;

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -68,7 +68,7 @@ impl From<()> for ResponseError {
 /// Blocks stdin whilst being handled.
 pub trait BlockingNotificationAction: LSPNotification {
     /// Handle this notification.
-    fn handle<O: Output>(Self::Params, &mut InitActionContext, O) -> Result<(), ()>;
+    fn handle<O: Output>(_: Self::Params, _: &mut InitActionContext, _: O) -> Result<(), ()>;
 }
 
 /// A request that blocks stdin whilst being handled

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -428,7 +428,7 @@ mod test {
     #[test]
     fn raw_message_with_string_id_parses_into_request() {
         #[derive(Debug)]
-        pub enum DummyRequest {}
+        enum DummyRequest {}
         impl LSPRequest for DummyRequest {
             type Params = ();
             type Result = ();
@@ -450,7 +450,7 @@ mod test {
     #[test]
     fn serialize_message_no_params() {
         #[derive(Debug)]
-        pub enum DummyNotification {}
+        enum DummyNotification {}
 
         impl LSPNotification for DummyNotification {
             type Params = ();
@@ -472,9 +472,9 @@ mod test {
     #[test]
     fn serialize_message_empty_params() {
         #[derive(Debug)]
-        pub enum DummyNotification {}
+        enum DummyNotification {}
         #[derive(Serialize)]
-        pub struct EmptyParams {}
+        struct EmptyParams {}
 
         impl LSPNotification for DummyNotification {
             type Params = EmptyParams;

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -365,8 +365,8 @@ impl Serialize for RawMessage {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ls_types::InitializedParams;
-    use server::notifications;
+    use languageserver_types::InitializedParams;
+    use crate::server::notifications;
 
     #[test]
     fn test_parse_as_notification() {

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -250,13 +250,13 @@ where
 
 #[derive(Debug, PartialEq)]
 pub(super) struct RawMessage {
-    pub method: String,
-    pub id: Id,
-    pub params: serde_json::Value,
+    crate method: String,
+    crate id: Id,
+    crate params: serde_json::Value,
 }
 
 impl RawMessage {
-    pub fn parse_as_request<'de, R>(&'de self) -> Result<Request<R>, jsonrpc::Error>
+    crate fn parse_as_request<'de, R>(&'de self) -> Result<Request<R>, jsonrpc::Error>
     where
         R: LSPRequest,
         <R as LSPRequest>::Params: serde::Deserialize<'de>,
@@ -283,7 +283,7 @@ impl RawMessage {
         }
     }
 
-    pub fn parse_as_notification<'de, T>(&'de self) -> Result<Notification<T>, jsonrpc::Error>
+    crate fn parse_as_notification<'de, T>(&'de self) -> Result<Notification<T>, jsonrpc::Error>
     where
         T: LSPNotification,
         <T as LSPNotification>::Params: serde::Deserialize<'de>,
@@ -299,7 +299,7 @@ impl RawMessage {
         })
     }
 
-    pub fn try_parse(msg: &str) -> Result<Option<RawMessage>, jsonrpc::Error> {
+    crate fn try_parse(msg: &str) -> Result<Option<RawMessage>, jsonrpc::Error> {
         // Parse the message.
         let ls_command: serde_json::Value =
             serde_json::from_str(msg).map_err(|_| jsonrpc::Error::parse_error())?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -127,7 +127,7 @@ impl BlockingRequestAction for InitializeRequest {
 
 /// A service implementing a language server.
 pub struct LsService<O: Output> {
-    msg_reader: Box<MessageReader + Send + Sync>,
+    msg_reader: Box<dyn MessageReader + Send + Sync>,
     output: O,
     ctx: ActionContext,
     dispatcher: Dispatcher,
@@ -139,7 +139,7 @@ impl<O: Output> LsService<O> {
         analysis: Arc<AnalysisHost>,
         vfs: Arc<Vfs>,
         config: Arc<Mutex<Config>>,
-        reader: Box<MessageReader + Send + Sync>,
+        reader: Box<dyn MessageReader + Send + Sync>,
         output: O,
     ) -> LsService<O> {
         let dispatcher = Dispatcher::new(output.clone());

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -421,12 +421,12 @@ mod test {
             root_path: None,
             root_uri: None,
             initialization_options: None,
-            capabilities: ::ls_types::ClientCapabilities {
+            capabilities: languageserver_types::ClientCapabilities {
                 workspace: None,
                 text_document: None,
                 experimental: None,
             },
-            trace: Some(::ls_types::TraceOption::Off),
+            trace: Some(languageserver_types::TraceOption::Off),
         }
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,34 +12,34 @@
 //! interactions (for example, to add support for handling new types of
 //! requests).
 
-use actions::{notifications, requests, ActionContext};
-use analysis::AnalysisHost;
-use config::Config;
+use crate::actions::{notifications, requests, ActionContext};
+use crate::analysis::AnalysisHost;
+use crate::config::Config;
 use jsonrpc_core::{self as jsonrpc, Id, types::error::ErrorCode};
-pub use ls_types::notification::Exit as ExitNotification;
-pub use ls_types::request::Initialize as InitializeRequest;
-pub use ls_types::request::Shutdown as ShutdownRequest;
-use ls_types::{
+pub use crate::ls_types::notification::Exit as ExitNotification;
+pub use crate::ls_types::request::Initialize as InitializeRequest;
+pub use crate::ls_types::request::Shutdown as ShutdownRequest;
+use crate::ls_types::{
     CompletionOptions, ExecuteCommandOptions, ImplementationProviderCapability, InitializeParams, InitializeResult,
     ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, CodeLensOptions,
 };
-use lsp_data;
-use lsp_data::{InitializationOptions, LSPNotification, LSPRequest};
+use crate::lsp_data;
+use crate::lsp_data::{InitializationOptions, LSPNotification, LSPRequest};
 use serde_json;
-use server::dispatch::Dispatcher;
-pub use server::dispatch::{RequestAction, DEFAULT_REQUEST_TIMEOUT};
-pub use server::io::{MessageReader, Output};
-use server::io::{StdioMsgReader, StdioOutput};
-use server::message::RawMessage;
-pub use server::message::{
+use crate::server::dispatch::Dispatcher;
+pub use crate::server::dispatch::{RequestAction, DEFAULT_REQUEST_TIMEOUT};
+pub use crate::server::io::{MessageReader, Output};
+use crate::server::io::{StdioMsgReader, StdioOutput};
+use crate::server::message::RawMessage;
+pub use crate::server::message::{
     Ack, BlockingNotificationAction, BlockingRequestAction, NoResponse, Notification, Request,
     Response, ResponseError, RequestId
 };
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
-use version;
-use vfs::Vfs;
+use crate::version;
+use crate::vfs::Vfs;
 
 mod dispatch;
 mod io;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,13 +13,13 @@
 //! requests).
 
 use crate::actions::{notifications, requests, ActionContext};
-use crate::analysis::AnalysisHost;
+use rls_analysis::AnalysisHost;
 use crate::config::Config;
 use jsonrpc_core::{self as jsonrpc, Id, types::error::ErrorCode};
-pub use crate::ls_types::notification::Exit as ExitNotification;
-pub use crate::ls_types::request::Initialize as InitializeRequest;
-pub use crate::ls_types::request::Shutdown as ShutdownRequest;
-use crate::ls_types::{
+pub use languageserver_types::notification::Exit as ExitNotification;
+pub use languageserver_types::request::Initialize as InitializeRequest;
+pub use languageserver_types::request::Shutdown as ShutdownRequest;
+use languageserver_types::{
     CompletionOptions, ExecuteCommandOptions, ImplementationProviderCapability, InitializeParams, InitializeResult,
     ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, CodeLensOptions,
 };
@@ -39,7 +39,7 @@ use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use crate::version;
-use crate::vfs::Vfs;
+use rls_vfs::Vfs;
 
 mod dispatch;
 mod io;

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -16,13 +16,13 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-use analysis;
-use config::{Config, Inferrable};
+use rls_analysis::{AnalysisHost, Target};
+use crate::config::{Config, Inferrable};
 use env_logger;
-use languageserver_types;
+use languageserver_types as ls_types;
 use serde_json;
-use server as ls_server;
-use vfs;
+use crate::server as ls_server;
+use rls_vfs::Vfs;
 
 pub struct Environment {
     pub config: Option<Config>,
@@ -46,7 +46,7 @@ impl Environment {
         // Acquire the current directory, but this is changing when tests are
         // running so we need to be sure to access it in a synchronized fashion.
         let cur_dir = {
-            use build::environment::{EnvironmentLock, Environment};
+            use crate::build::environment::{EnvironmentLock, Environment};
             let env = EnvironmentLock::get();
             let (guard, _other) = env.lock();
             Environment::push_with_lock(&HashMap::new(), None, guard)
@@ -93,8 +93,8 @@ impl Environment {
         &mut self,
         messages: Vec<String>,
     ) -> (ls_server::LsService<RecordOutput>, LsResultList) {
-        let analysis = Arc::new(analysis::AnalysisHost::new(analysis::Target::Debug));
-        let vfs = Arc::new(vfs::Vfs::new());
+        let analysis = Arc::new(AnalysisHost::new(Target::Debug));
+        let vfs = Arc::new(Vfs::new());
         let config = Arc::new(Mutex::new(self.config.take().unwrap()));
         let reader = Box::new(MockMsgReader::new(messages));
         let output = RecordOutput::new();

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -24,14 +24,14 @@ use serde_json;
 use crate::server as ls_server;
 use rls_vfs::Vfs;
 
-pub struct Environment {
-    pub config: Option<Config>,
-    pub cache: Cache,
-    pub target_path: PathBuf,
+crate struct Environment {
+    crate config: Option<Config>,
+    crate cache: Cache,
+    crate target_path: PathBuf,
 }
 
 impl Environment {
-    pub fn new(project_dir: &str) -> Self {
+    crate fn new(project_dir: &str) -> Self {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         lazy_static! {
@@ -80,7 +80,7 @@ impl Environment {
 }
 
 impl Environment {
-    pub fn with_config<F>(&mut self, f: F)
+    crate fn with_config<F>(&mut self, f: F)
     where
         F: FnOnce(&mut Config),
     {
@@ -89,7 +89,7 @@ impl Environment {
     }
 
     // Initialize and run the internals of an LS protocol RLS server.
-    pub fn mock_server(
+    crate fn mock_server(
         &mut self,
         messages: Vec<String>,
     ) -> (ls_server::LsService<RecordOutput>, LsResultList) {
@@ -148,13 +148,13 @@ impl ls_server::MessageReader for MockMsgReader {
 type LsResultList = Arc<Mutex<Vec<String>>>;
 
 #[derive(Clone)]
-pub struct RecordOutput {
-    pub output: LsResultList,
+crate struct RecordOutput {
+    crate output: LsResultList,
     output_id: Arc<Mutex<u32>>,
 }
 
 impl RecordOutput {
-    pub fn new() -> RecordOutput {
+    crate fn new() -> RecordOutput {
         RecordOutput {
             output: Arc::new(Mutex::new(vec![])),
             // use some distinguishable value
@@ -177,20 +177,20 @@ impl ls_server::Output for RecordOutput {
 }
 
 #[derive(Clone, Debug)]
-pub struct ExpectedMessage {
+crate struct ExpectedMessage {
     id: Option<u64>,
     contains: Vec<String>,
 }
 
 impl ExpectedMessage {
-    pub fn new(id: Option<u64>) -> ExpectedMessage {
+    crate fn new(id: Option<u64>) -> ExpectedMessage {
         ExpectedMessage {
             id,
             contains: vec![],
         }
     }
 
-    pub fn expect_contains(&mut self, s: &str) -> &mut ExpectedMessage {
+    crate fn expect_contains(&mut self, s: &str) -> &mut ExpectedMessage {
         self.contains.push(s.to_owned());
         self
     }
@@ -214,7 +214,7 @@ macro_rules! wait_for_n_results {
     }};
 }
 
-pub fn expect_messages(results: LsResultList, expected: &[&ExpectedMessage]) {
+crate fn expect_messages(results: LsResultList, expected: &[&ExpectedMessage]) {
     wait_for_n_results!(expected.len(), results);
 
     let mut results = results.lock().unwrap();
@@ -257,14 +257,14 @@ pub fn expect_messages(results: LsResultList, expected: &[&ExpectedMessage]) {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct Src<'a, 'b> {
-    pub file_name: &'a Path,
+crate struct Src<'a, 'b> {
+    crate file_name: &'a Path,
     // 1 indexed
-    pub line: usize,
-    pub name: &'b str,
+    crate line: usize,
+    crate name: &'b str,
 }
 
-pub fn src<'a, 'b>(file_name: &'a Path, line: usize, name: &'b str) -> Src<'a, 'b> {
+crate fn src<'a, 'b>(file_name: &'a Path, line: usize, name: &'b str) -> Src<'a, 'b> {
     Src {
         file_name,
         line,
@@ -272,7 +272,7 @@ pub fn src<'a, 'b>(file_name: &'a Path, line: usize, name: &'b str) -> Src<'a, '
     }
 }
 
-pub struct Cache {
+crate struct Cache {
     base_path: PathBuf,
     files: HashMap<PathBuf, Vec<String>>,
 }
@@ -285,7 +285,7 @@ impl Cache {
         }
     }
 
-    pub fn mk_ls_position(&mut self, src: Src) -> ls_types::Position {
+    crate fn mk_ls_position(&mut self, src: Src) -> ls_types::Position {
         let line = self.get_line(src);
         let col = line.find(src.name)
             .expect(&format!("Line does not contain name {}", src.name));
@@ -295,14 +295,14 @@ impl Cache {
     /// Create a range convering the initial position on the line
     ///
     /// The line number uses a 0-based index.
-    pub fn mk_ls_range_from_line(&mut self, line: u64) -> ls_types::Range {
+    crate fn mk_ls_range_from_line(&mut self, line: u64) -> ls_types::Range {
         ls_types::Range::new(
             ls_types::Position::new(line, 0),
             ls_types::Position::new(line, 0),
         )
     }
 
-    pub fn abs_path(&self, file_name: &Path) -> PathBuf {
+    crate fn abs_path(&self, file_name: &Path) -> PathBuf {
         let result = self.base_path
             .join(file_name)
             .canonicalize()

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex};
 use analysis;
 use config::{Config, Inferrable};
 use env_logger;
-use ls_types;
+use languageserver_types;
 use serde_json;
 use server as ls_server;
 use vfs;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -38,14 +38,14 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use url::Url;
 
-pub fn initialize(
+fn initialize(
     id: usize,
     root_path: Option<String>,
 ) -> Request<ls_server::InitializeRequest> {
     initialize_with_opts(id, root_path, None)
 }
 
-pub fn initialize_with_opts(
+fn initialize_with_opts(
     id: usize,
     root_path: Option<String>,
     initialization_options: Option<InitializationOptions>,
@@ -71,7 +71,7 @@ pub fn initialize_with_opts(
     }
 }
 
-pub fn blocking_request<T: ls_server::BlockingRequestAction>(
+fn blocking_request<T: ls_server::BlockingRequestAction>(
     id: usize,
     params: T::Params,
 ) -> Request<T> {
@@ -83,7 +83,7 @@ pub fn blocking_request<T: ls_server::BlockingRequestAction>(
     }
 }
 
-pub fn request<T: ls_server::RequestAction>(id: usize, params: T::Params) -> Request<T> {
+fn request<T: ls_server::RequestAction>(id: usize, params: T::Params) -> Request<T> {
     Request {
         id: RequestId::Num(id as u64),
         params,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -11,24 +11,24 @@
 // Utilities and infrastructure for testing. Tests in this module test the
 // testing infrastructure *not* the RLS.
 
-extern crate json;
+use json;
 
 #[macro_use]
 mod harness;
 // FIXME(#925) intermittent failure
 //mod lens;
 
-use analysis;
-use actions::{requests, notifications};
-use config::{Config, Inferrable};
-use server::{self as ls_server, Request, ShutdownRequest, Notification, RequestId};
+use rls_analysis::{AnalysisHost, Target};
+use crate::actions::{requests, notifications};
+use crate::config::{Config, Inferrable};
+use crate::server::{self as ls_server, Request, ShutdownRequest, Notification, RequestId};
 use jsonrpc_core;
-use vfs;
+use rls_vfs::Vfs;
 
 use self::harness::{expect_messages, src, Environment, ExpectedMessage, RecordOutput};
 
-use ls_types::*;
-use lsp_data::InitializationOptions;
+use languageserver_types::*;
+use crate::lsp_data::InitializationOptions;
 
 use env_logger;
 use serde_json;
@@ -1107,8 +1107,8 @@ fn test_parse_error_on_malformed_input() {
         }
     }
 
-    let analysis = Arc::new(analysis::AnalysisHost::new(analysis::Target::Debug));
-    let vfs = Arc::new(vfs::Vfs::new());
+    let analysis = Arc::new(AnalysisHost::new(Target::Debug));
+    let vfs = Arc::new(Vfs::new());
     let reader = Box::new(NoneMsgReader);
     let output = RecordOutput::new();
     let results = output.output.clone();

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -21,7 +21,7 @@ use std::thread;
 use std::time::Duration;
 use std::panic;
 
-use support::paths::TestPathExt;
+use self::paths::TestPathExt;
 
 pub mod paths;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -9,14 +9,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate cargo;
 #[macro_use]
 extern crate serde_json;
 
 use std::time::Duration;
 
 mod support;
-use support::{ExpectedMessage, RlsHandle, basic_bin_manifest, project, timeout};
+use self::support::{ExpectedMessage, RlsHandle, basic_bin_manifest, project, timeout};
 
 const TIME_LIMIT_SECS: u64 = 300;
 


### PR DESCRIPTION
While `dyn` fixing annotations was straightforward, doing that for urneachable_pub was awkward... Not sure I agree with most of the changes - IMO `pub(crate)` adds more noise and regular `pub` should be treated as such, especially for bin targets, but that may be just me. Tried to go for the most restrictive visibility for the warned against items (not sure if that's good).

r? @nrc