### PR TITLE
Don't build bors .tmp branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: rust
 dist: trusty
 sudo: false
+branches:
+  except:
+  - staging.tmp
+  - trying.tmp
 cache: cargo
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,8 @@
+branches:
+  except:
+  - staging.tmp
+  - trying.tmp
+
 environment:
   global:
     PROJECT_NAME: rls


### PR DESCRIPTION
We should exclude the staging.tmp branch from CI according to
https://bors.tech/documentation/getting-started/