### PR TITLE
Fix clippy code compile + add to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,32 +7,18 @@ branches:
   - trying.tmp
 cache: cargo
 os:
-  - linux
-  - osx
+- linux
+- osx
 rust:
-  - nightly
-matrix:
-  include:
-  - rust: nightly
-    env: USE_FEATURES=true
-    os: linux
-  allow_failures:
-  # avoid delaying prs with travis osx issues
-  - os: osx
-  # clippy compilation issues are somewhat expected
-  - env: USE_FEATURES=true
-  fast_finish: true
+- nightly
 install:
     # Required for Racer autoconfiguration
     rustup component add rust-src
 script: |
   #!/bin/bash
-  if [ -v USE_FEATURES ]; then
-    # compile #[cfg(not(test))] code
-    cargo build -v --all-features
-    cargo test -v --all-features
-  else
-    # compile #[cfg(not(test))] code
-    cargo build -v
-    cargo test -v
-  fi
+  set -e
+
+  cargo build -v
+  cargo test -v
+
+  set +e

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,5 @@ crossbeam-channel = "0.2.1"
 json = "0.11"
 
 [features]
-default = ["clippy_lints"]
+default = ["clippy"]
 clippy = ["clippy_lints"]

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -7,10 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-#[cfg(feature = "clippy")]
-extern crate clippy_lints;
-
 use getopts;
 use rustc::middle::cstore::CrateStore;
 use rustc::session::Session;
@@ -141,8 +137,10 @@ impl RlsRustcCalls {
 }
 
 #[cfg(feature = "clippy")]
-fn clippy_after_parse_callback(state: &mut self::rustc_driver::driver::CompileState) {
-    let mut registry = rustc_plugin::registry::Registry::new(
+fn clippy_after_parse_callback(state: &mut ::rustc_driver::driver::CompileState) {
+    use rustc_plugin::registry::Registry;
+
+    let mut registry = Registry::new(
         state.session,
         state
             .krate
@@ -156,7 +154,7 @@ fn clippy_after_parse_callback(state: &mut self::rustc_driver::driver::CompileSt
     registry.args_hidden = Some(Vec::new());
     clippy_lints::register_plugins(&mut registry);
 
-    let rustc_plugin::registry::Registry {
+    let Registry {
         early_lint_passes,
         late_lint_passes,
         lint_groups,


### PR DESCRIPTION
This pr:
- Fixes clippy feature code compiliation
- Enables clippy feature by default
- Make osx builds must-pass
- Removes travis allow-fail builds

The current default feature 
```toml
[features]
default = ["clippy_lints"]
clippy = ["clippy_lints"]
```

Is misleading, as it simply enables the dependency by default, but doesn't _use_ it as the feature `clippy` is not enabled.

This means clippy code is not being tested in CI, except the allow-fail build. Everyone is clearly ignoring this build so we may as well bin allow-fail builds in general. With this change clippy feature will be tested by default, the `--no-default-features` branch is not tested but that seems reasonable to me.