### PR TITLE
Fix warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@
 #![warn(rust_2018_idioms)]
 #![allow(unknown_lints)]
 #![warn(clippy)]
-#![allow(cyclomatic_complexity, needless_pass_by_value, too_many_arguments)]
+#![allow(cyclomatic_complexity, needless_pass_by_value, too_many_arguments, unused_extern_crates)]
 
 // See rustc/rustc.rs in rust repo for explanation of stack adjustments.
 #![feature(link_args)]

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -196,11 +196,6 @@ impl ExpectedMessage {
     }
 }
 
-crate fn clear_messages(server: &mut ls_server::LsService<RecordOutput>, results: LsResultList) {
-    server.wait_for_concurrent_jobs();
-    results.lock().unwrap().clear();
-}
-
 crate fn expect_messages(server: &mut ls_server::LsService<RecordOutput>, results: LsResultList, expected: &[&ExpectedMessage]) {
     server.wait_for_concurrent_jobs();
 


### PR DESCRIPTION
Building rls inside of rust-lang rust fails due to these