### PR TITLE
Make the workspace hack local to RLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 
 target
+test_data/Cargo.lock

--- a/src/test/lens.rs
+++ b/src/test/lens.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 
 #[test]
-#[ignore] // FIXME(#925) intermittent failure
 fn test_lens_run() {
     let mut env = Environment::new("lens_run");
 

--- a/test_data/Cargo.toml
+++ b/test_data/Cargo.toml
@@ -1,0 +1,5 @@
+# Make sure that test are not accidentally become members of
+# the main workspace in the rust-lang/rust repository
+[workspace]
+members = ["./*/"]
+exclude = ["./compiler_message", "./target"]


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/42146

closes https://github.com/rust-lang-nursery/rls/issues/925

After this, we could and should eliminate https://github.com/rust-lang/rust/blob/4260c8b1e4b273facf1072b9457dfaedd7f03f3e/src/Cargo.toml#L26-L40