### PR TITLE
Issue #939 - DocumentSymbol sending arg0

### DIFF
--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -122,6 +122,10 @@ impl RequestAction for Symbols {
         Ok(
             symbols
                 .into_iter()
+                .filter(|s| {
+                    let range = ls_util::rls_to_range(s.span.range);
+                    range.start != range.end
+                })
                 .map(|s| {
                     SymbolInformation {
                         name: s.name,


### PR DESCRIPTION
 - Filter out symbols with their ranges having the equal start and end positions