### PR TITLE
Fix some edition issues

### DIFF
--- a/src/actions/progress.rs
+++ b/src/actions/progress.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use crate::lsp_data::{ProgressParams, PublishDiagnosticsParams, Progress, ShowMessageParams, MessageType};
 use crate::server::{Output, Notification};
 use languageserver_types::notification::{PublishDiagnostics, ShowMessage};
+use lazy_static::lazy_static;
 
 /// Trait for communication of build progress back to the client.
 pub trait ProgressNotifier: Send {

--- a/src/actions/run.rs
+++ b/src/actions/run.rs
@@ -3,6 +3,7 @@ use ordslice::Ext;
 use regex::Regex;
 use rls_span::{Column, Position, Range, Row, ZeroIndexed};
 use rls_vfs::FileContents;
+use lazy_static::lazy_static;
 
 use std::{collections::HashMap, iter, path::Path};
 

--- a/src/actions/work_pool.rs
+++ b/src/actions/work_pool.rs
@@ -3,6 +3,7 @@ use crate::server::DEFAULT_REQUEST_TIMEOUT;
 use std::{fmt, panic};
 use std::time::{Duration, Instant};
 use std::sync::{mpsc, Mutex};
+use lazy_static::lazy_static;
 
 /// Description of work on the request work pool. Equality implies two pieces of work are the same
 /// kind of thing. The `str` should be human readable for logging, ie the language server protocol
@@ -11,7 +12,7 @@ use std::sync::{mpsc, Mutex};
 pub struct WorkDescription(pub &'static str);
 
 impl fmt::Display for WorkDescription {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/src/build/environment.rs
+++ b/src/build/environment.rs
@@ -13,6 +13,7 @@ use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard};
+use lazy_static::lazy_static;
 
 // Ensures we don't race on the env vars. This is only also important in tests,
 // where we have multiple copies of the RLS running in the same process.

--- a/src/build/plan.rs
+++ b/src/build/plan.rs
@@ -99,8 +99,8 @@ impl Plan {
     /// Emplace a given `Unit`, along with its `Unit` dependencies (recursively)
     /// into the dependency graph.
     #[allow(dead_code)]
-    crate fn emplace_dep(&mut self, unit: &Unit, cx: &Context) -> CargoResult<()> {
-        let null_filter = |_unit: &Unit| true;
+    crate fn emplace_dep(&mut self, unit: &Unit<'_>, cx: &Context<'_, '_>) -> CargoResult<()> {
+        let null_filter = |_unit: &Unit<'_>| true;
         self.emplace_dep_with_filter(unit, cx, &null_filter)
     }
 
@@ -109,12 +109,12 @@ impl Plan {
     /// out by the `filter` closure.
     crate fn emplace_dep_with_filter<Filter>(
         &mut self,
-        unit: &Unit,
-        cx: &Context,
+        unit: &Unit<'_>,
+        cx: &Context<'_, '_>,
         filter: &Filter,
     ) -> CargoResult<()>
     where
-        Filter: Fn(&Unit) -> bool,
+        Filter: Fn(&Unit<'_>) -> bool,
     {
         if !filter(unit) {
             return Ok(());
@@ -569,7 +569,7 @@ impl JobQueue {
     }
 }
 
-fn key_from_unit(unit: &Unit) -> UnitKey {
+fn key_from_unit(unit: &Unit<'_>) -> UnitKey {
     (unit.pkg.package_id().clone(), unit.target.kind().clone())
 }
 
@@ -586,7 +586,7 @@ macro_rules! print_dep_graph {
 }
 
 impl fmt::Debug for Plan {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&format!("Units: {:?}\n", self.units))?;
         print_dep_graph!("Dependency graph", self.dep_graph, f);
         print_dep_graph!("Reverse dependency graph", self.rev_dep_graph, f);

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -137,7 +137,7 @@ impl RlsRustcCalls {
 }
 
 #[cfg(feature = "clippy")]
-fn clippy_after_parse_callback(state: &mut ::rustc_driver::driver::CompileState) {
+fn clippy_after_parse_callback(state: &mut ::rustc_driver::driver::CompileState<'_, '_>) {
     use rustc_plugin::registry::Registry;
 
     let mut registry = Registry::new(

--- a/src/config.rs
+++ b/src/config.rs
@@ -297,7 +297,7 @@ where
         T: Deserialize<'de> + FromStr<Err = ()>,
     {
         type Value = T;
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str("`on`, `opt-in` or `off`")
         }
         fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<T, E> {

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -47,7 +47,7 @@ impl fmt::Display for UrlFileParseError
 where
     UrlFileParseError: Error,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,10 +34,6 @@ extern {}
 
 use env_logger;
 #[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serde_derive;

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -95,7 +95,7 @@ pub enum RequestId {
 }
 
 impl fmt::Display for RequestId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RequestId::Str(ref s) => write!(f, "\"{}\"", s),
             RequestId::Num(n) => write!(f, "{}", n),
@@ -225,7 +225,7 @@ where
     A: LSPRequest,
     <A as LSPRequest>::Params: serde::Serialize,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let raw: RawMessage = self.into();
         match serde_json::to_string(&raw) {
             Ok(val) => val.fmt(f),
@@ -239,7 +239,7 @@ where
     A: LSPNotification,
     <A as LSPNotification>::Params: serde::Serialize,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let raw: RawMessage = self.into();
         match serde_json::to_string(&raw) {
             Ok(val) => val.fmt(f),

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -23,6 +23,7 @@ use languageserver_types as ls_types;
 use serde_json;
 use crate::server as ls_server;
 use rls_vfs::Vfs;
+use lazy_static::lazy_static;
 
 crate struct Environment {
     crate config: Option<Config>,
@@ -278,7 +279,7 @@ impl Cache {
         }
     }
 
-    crate fn mk_ls_position(&mut self, src: Src) -> ls_types::Position {
+    crate fn mk_ls_position(&mut self, src: Src<'_, '_>) -> ls_types::Position {
         let line = self.get_line(src);
         let col = line.find(src.name)
             .expect(&format!("Line does not contain name {}", src.name));
@@ -309,7 +310,7 @@ impl Cache {
         }
     }
 
-    fn get_line(&mut self, src: Src) -> String {
+    fn get_line(&mut self, src: Src<'_, '_>) -> String {
         let base_path = &self.base_path;
         let lines = self.files
             .entry(src.file_name.to_owned())


### PR DESCRIPTION
- Ran cargo fix to add '_ lifetimes
- removed #[macro_use] statements for failure & lazy_static

I stopped at
```rust
#[macro_use]
extern crate log;
```
It seems a bit painful to have to import the log macros at each use. So I'll leave the more problematic ones for now, maybe there is, or will be, a better option?