### PR TITLE
use US spelling

### DIFF
--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -137,7 +137,7 @@ impl PostBuildHandler {
         }
     }
 
-    fn finalise(mut self) {
+    fn finalize(mut self) {
         // the end message must be dispatched before waking up
         // the blocked threads, or we might see "done":true message
         // first in the next action invocation.
@@ -212,7 +212,7 @@ impl AnalysisQueue {
                 queue.drain_filter(|j| match *j {
                     QueuedJob::Job(ref j) if j.hash == Some(hash) => true,
                     _ => false,
-                }).for_each(|j| j.unwrap_job().handler.finalise())
+                }).for_each(|j| j.unwrap_job().handler.finalize())
             }
             trace!("Post-prune queue len: {}", queue.len());
 
@@ -306,6 +306,6 @@ impl Job {
                 .reload_analysis_from_memory(&self.cwd, self.analysis);
         }
 
-        self.handler.finalise();
+        self.handler.finalize();
     }
 }


### PR DESCRIPTION
It took me quite some time to figure out why `Ctrl+T > finalize` was not finding this :) 