### PR TITLE
Import macros using `use` statements instead `#[macro_use]`.

### DIFF
--- a/src/actions/diagnostics.rs
+++ b/src/actions/diagnostics.rs
@@ -23,6 +23,8 @@ use crate::lsp_data::ls_util;
 use serde_json;
 use rls_span::compiler::DiagnosticSpan;
 use url::Url;
+use serde_derive::Deserialize;
+use log::{debug, log};
 
 pub use languageserver_types::Diagnostic;
 

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -15,11 +15,12 @@ use rls_analysis::AnalysisHost;
 use rls_vfs::Vfs;
 use crate::config::FmtConfig;
 use crate::config::Config;
-use serde_json;
+use serde_json::{self, json, json_internal};
 use url::Url;
 use rls_span as span;
 use crate::Span;
 use walkdir::WalkDir;
+use log::{debug, log, trace};
 
 use crate::actions::post_build::{BuildResults, PostBuildHandler, AnalysisQueue};
 use crate::actions::progress::{BuildProgressNotifier, BuildDiagnosticsNotifier};
@@ -42,6 +43,7 @@ use std::thread;
 macro_rules! ignore_non_file_uri {
     ($expr: expr, $uri: expr, $log_name: expr) => {
         $expr.map_err(|_| {
+            use log::{log, trace};
             trace!("{}: Non-`file` URI scheme, ignoring: {:?}", $log_name, $uri);
             ()
         })

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -18,6 +18,7 @@ use serde::de::Error;
 use serde_json;
 use crate::Span;
 use std::sync::atomic::Ordering;
+use log::{debug, log, trace, warn};
 
 use crate::build::*;
 use crate::lsp_data::*;

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -28,6 +28,7 @@ use crate::lsp_data::PublishDiagnosticsParams;
 use crate::concurrency::JobToken;
 use languageserver_types::DiagnosticSeverity;
 use itertools::Itertools;
+use log::{log, trace};
 
 use rls_analysis::AnalysisHost;
 use rls_data::Analysis;

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -19,6 +19,8 @@ use rustfmt_nightly::{Session, FileLines, FileName, Input as FmtInput, Range as 
 use serde_json;
 use rls_span as span;
 use itertools::Itertools;
+use serde_derive::{Serialize, Deserialize};
+use log::{debug, log, trace};
 
 use crate::actions::work_pool;
 use crate::actions::work_pool::WorkDescription;

--- a/src/actions/run.rs
+++ b/src/actions/run.rs
@@ -4,6 +4,8 @@ use regex::Regex;
 use rls_span::{Column, Position, Range, Row, ZeroIndexed};
 use rls_vfs::FileContents;
 use lazy_static::lazy_static;
+use log::{log, error};
+use serde_derive::Serialize;
 
 use std::{collections::HashMap, iter, path::Path};
 

--- a/src/actions/work_pool.rs
+++ b/src/actions/work_pool.rs
@@ -4,6 +4,7 @@ use std::{fmt, panic};
 use std::time::{Duration, Instant};
 use std::sync::{mpsc, Mutex};
 use lazy_static::lazy_static;
+use log::{info, log, warn};
 
 /// Description of work on the request work pool. Equality implies two pieces of work are the same
 /// kind of thing. The `str` should be human readable for logging, ie the language server protocol

--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -22,6 +22,7 @@ use crate::build::{BufWriter, BuildResult, CompilationContext, Internals, Packag
 use crate::build::environment::{self, Environment, EnvironmentLock};
 use crate::config::Config;
 use rls_vfs::Vfs;
+use log::{debug, error, log, trace, warn};
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -18,6 +18,7 @@ use cargo::util::important_paths;
 use crate::config::Config;
 use rls_data::Analysis;
 use rls_vfs::Vfs;
+use log::{log, trace};
 
 use self::environment::EnvironmentLock;
 

--- a/src/build/plan.rs
+++ b/src/build/plan.rs
@@ -38,6 +38,7 @@ use cargo::util::{CargoResult, ProcessBuilder};
 use cargo_metadata;
 use crate::lsp_data::parse_file_path;
 use url::Url;
+use log::{log, trace};
 
 use crate::actions::progress::ProgressUpdate;
 use super::{BuildResult, Internals};

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -22,6 +22,7 @@ use syntax::ast;
 use syntax::codemap::{FileLoader, RealFileLoader};
 use rls_data::Analysis;
 use rls_vfs::Vfs;
+use log::{log, trace};
 
 use crate::config::{ClippyPreference, Config};
 use crate::build::{BufWriter, BuildResult};

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1,6 +1,7 @@
 use std::{thread};
 
 use crossbeam_channel::{bounded, Receiver, Sender};
+use crossbeam_channel::{select, __crossbeam_channel_parse, __crossbeam_channel_codegen};
 
 /// `ConcurrentJob` is a handle for some long-running computation
 /// off the main thread. It can be used, indirectly, to wait for

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,9 @@ use cargo::core::{Shell, Workspace};
 
 use serde;
 use serde::de::{Deserialize, Deserializer, Visitor};
+use serde_derive::{Serialize, Deserialize};
+
+use log::{log, trace};
 
 use rustfmt_nightly::Config as RustfmtConfig;
 use rustfmt_nightly::{load_config, CliOptions, EmitMode, Verbosity};

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -20,6 +20,7 @@ use rls_span as span;
 use racer;
 use rls_vfs::FileContents;
 use languageserver_types as ls_types;
+use serde_derive::{Serialize, Deserialize};
 
 pub use languageserver_types::*;
 pub use languageserver_types::request::Request as LSPRequest;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,14 +33,6 @@
 extern {}
 
 use env_logger;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate serde_json;
-#[macro_use]
-extern crate crossbeam_channel;
 
 use std::env;
 use std::sync::Arc;

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -19,6 +19,7 @@ use crate::server::io::Output;
 use crate::server::message::ResponseError;
 use crate::server::{Request, Response};
 use crate::concurrency::{ConcurrentJob, JobToken};
+use log::{debug, log};
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -10,6 +10,7 @@
 
 use serde;
 use serde_json;
+use log::{debug, trace, log};
 
 use super::{Notification, Request, RequestId};
 use crate::lsp_data::{LSPNotification, LSPRequest};

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -16,6 +16,8 @@ use serde;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use serde::Deserialize;
 use serde_json;
+use serde_derive::Serialize;
+use log::{debug, log};
 
 use crate::actions::ActionContext;
 use crate::lsp_data::{LSPNotification, LSPRequest};
@@ -367,6 +369,7 @@ mod test {
     use super::*;
     use languageserver_types::InitializedParams;
     use crate::server::notifications;
+    use serde_json::{json, json_internal};
 
     #[test]
     fn test_parse_as_notification() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -40,6 +40,7 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use crate::version;
 use rls_vfs::Vfs;
+use log::{debug, error, log, trace, warn};
 
 mod dispatch;
 mod io;


### PR DESCRIPTION
Fixed all `rust_2018_idioms` lints. 

(Because we compile the tools with `-D warnings` in the rustc repository, all lints have to be fixed 🤷)
