### PR TITLE
Move vfs-racer impls to RLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,6 @@ name = "rls-vfs"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "racer 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rls-blacklist = "0.1.2"
 rls-data = { version = "0.16", features = ["serialize-serde"] }
 rls-rustc = "0.4.0"
 rls-span = { version = "0.4", features = ["serialize-serde"] }
-rls-vfs = { version = "0.4.6", features = ["racer-impls"] }
+rls-vfs = { version = "0.4.6" }
 rustfmt-nightly = { git = "https://github.com/rust-lang-nursery/rustfmt", rev = "7e3dc8fae7ed84cc1879ef4e0bc6f00dfe059e1b" }
 serde = "1.0"
 serde_json = "1.0"

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -13,7 +13,7 @@
 use crate::actions::InitActionContext;
 use rls_data as data;
 use url::Url;
-use rls_vfs::FileContents;
+use rls_vfs::{self, Vfs, FileContents};
 use racer;
 use rustfmt_nightly::{Session, FileLines, FileName, Input as FmtInput, Range as RustfmtRange};
 use serde_json;
@@ -52,6 +52,8 @@ pub use crate::lsp_data::request::{
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::io;
 
 
 /// Represent the result of a deglob action for a single wildcard import.
@@ -237,7 +239,7 @@ impl RequestAction for Definition {
         let racer_receiver = {
             if ctx.config.lock().unwrap().goto_def_racer_fallback {
                 Some(work_pool::receive_from_thread(move || {
-                    let cache = racer::FileCache::new(vfs);
+                    let cache = racer_cache(vfs);
                     let session = racer::Session::new(&cache);
                     let location = pos_to_racer_location(params.position);
 
@@ -321,7 +323,7 @@ impl RequestAction for Completion {
         let vfs = ctx.vfs;
         let file_path = parse_file_path!(&params.text_document.uri, "complete")?;
 
-        let cache = racer::FileCache::new(vfs);
+        let cache = racer_cache(vfs);
         let session = racer::Session::new(&cache);
 
         let location = pos_to_racer_location(params.position);
@@ -903,6 +905,23 @@ impl RequestAction for CodeLensRequest {
         Ok(ret)
     }
 }
+
+fn racer_cache(vfs: Arc<Vfs>) -> racer::FileCache {
+    struct RacerVfs(Arc<Vfs>);
+    impl racer::FileLoader for RacerVfs {
+        fn load_file(&self, path: &Path) -> io::Result<String> {
+            match self.0.load_file(path) {
+                Ok(FileContents::Text(t)) => Ok(t),
+                Ok(FileContents::Binary(_)) => Err(
+                    io::Error::new(io::ErrorKind::Other, rls_vfs::Error::BadFileKind),
+                ),
+                Err(err) => Err(io::Error::new(io::ErrorKind::Other, err)),
+            }
+        }
+    }
+    racer::FileCache::new(RacerVfs(vfs))
+}
+
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
That way, we don't need to maintain racer version in VFS.

Right now, for example, I can't say `racer = { path = "../racer" }` in `rls/Cargo.toml`, b/c that won't be the same racer that rls_vfs usues. But given that the amount of code in question is tiny, it seems operationally more effective to just write a newtype wrapper inside rls.