### PR TITLE
Allow harnessing from other than `$PWD/test_data`.

### DIFF
--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -50,9 +50,11 @@ impl Environment {
             use crate::build::environment::{EnvironmentLock, Environment};
             let env = EnvironmentLock::get();
             let (guard, _other) = env.lock();
-            Environment::push_with_lock(&HashMap::new(), None, guard)
-                .get_old_cwd()
-                .to_path_buf()
+            let env = Environment::push_with_lock(&HashMap::new(), None, guard);
+            match env::var_os("RLS_TEST_WORKSPACE_DIR") {
+                Some(cur_dir) => cur_dir.into(),
+                None => env.get_old_cwd().to_path_buf(),
+            }
         };
         let project_path = cur_dir.join("test_data").join(project_dir);
 


### PR DESCRIPTION
When the RLS source is mounted on a read-only drive, the test_data tests will all fail because `cargo` cannot write `Cargo.lock`. We allow caller to copy the `test_data` directory to a read-write location, and use `$RLS_TEST_WORKSPACE_DIR` to refer to the directory containing `test_data` to allow the tests to pass.

```
$RLS_TEST_WORKSPACE_DIR/     (default to $PWD)
    test_data/
        Cargo.toml
        Cargo.lock           (generated)
        bin_lib/
            ...
        ...
    target/                  (generated, if $CARGO_TARGET_DIR is undefined)
        tests/
            0/
                ...
            ...
```