### PR TITLE
Require "Unix" newline style everywhere in reformat tests

### DIFF
--- a/test_data/reformat/rustfmt.toml
+++ b/test_data/reformat/rustfmt.toml
@@ -1,0 +1,1 @@
+newline_style = "Unix"

--- a/test_data/reformat_with_range/rustfmt.toml
+++ b/test_data/reformat_with_range/rustfmt.toml
@@ -1,0 +1,2 @@
+newline_style = "Unix"
+


### PR DESCRIPTION
The latest rustfmt includes rust-lang-nursery/rustfmt#2823 which changed the default line ending from `"Unix"` to `"Native"`. This breaks our test cases on Windows which still expected `\n` line endings. Rather than duplicating the test results for both Windows (`\r\n`) and elsewhere (`\n`), I configure rustfmt to always emit Unix (`\n`) line ending. This also insulates us from any future new decision from rust-lang-nursery/rustfmt#2846.