### PR TITLE
libsyntax2 based files symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,11 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "drop_bomb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "dtoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +792,15 @@ version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libeditor"
+version = "0.1.0"
+source = "git+https://github.com/matklad/libsyntax2?rev=50a7daa042c5f652cd724de55a056f9785a22a85#50a7daa042c5f652cd724de55a056f9785a22a85"
+dependencies = [
+ "libsyntax2 0.1.0 (git+https://github.com/matklad/libsyntax2?rev=50a7daa042c5f652cd724de55a056f9785a22a85)",
+ "text_unit 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libgit2-sys"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +826,18 @@ dependencies = [
  "openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libsyntax2"
+version = "0.1.0"
+source = "git+https://github.com/matklad/libsyntax2?rev=50a7daa042c5f652cd724de55a056f9785a22a85#50a7daa042c5f652cd724de55a056f9785a22a85"
+dependencies = [
+ "drop_bomb 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "text_unit 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1176,6 +1202,7 @@ dependencies = [
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "languageserver-types 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libeditor 0.1.0 (git+https://github.com/matklad/libsyntax2?rev=50a7daa042c5f652cd724de55a056f9785a22a85)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordslice 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1721,6 +1748,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "text_unit"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "textwrap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +1952,7 @@ dependencies = [
 "checksum derive-new 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "899ec79626c14e00ccc9729b4d750bbe67fe76a8f436824c16e0233bbd9d7daa"
 "checksum derive_more 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46c7f14685a20f5dd08e7f754f2ea8cc064d8f4214ae21116c106a2768ba7b9b"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
+"checksum drop_bomb 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "69b26e475fd29098530e709294e94e661974c851aed42512793f120fed4e199f"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum ena 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "88dc8393b3c7352f94092497f6b52019643e493b6b890eb417cdb7c46117e621"
@@ -1960,8 +1993,10 @@ dependencies = [
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum lazycell 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d33a48d0365c96081958cc663eef834975cb1e8d8bea3378513fc72bdbf11e50"
 "checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
+"checksum libeditor 0.1.0 (git+https://github.com/matklad/libsyntax2?rev=50a7daa042c5f652cd724de55a056f9785a22a85)" = "<none>"
 "checksum libgit2-sys 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6ab62b46003ba97701554631fa570d9f7e7947e2480ae3d941e555a54a2c0f05"
 "checksum libssh2-sys 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c628b499e8d1a4f4bd09a95d6cb1f8aeb231b46a9d40959bbd0408f14dd63adf"
+"checksum libsyntax2 0.1.0 (git+https://github.com/matklad/libsyntax2?rev=50a7daa042c5f652cd724de55a056f9785a22a85)" = "<none>"
 "checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
@@ -2059,6 +2094,7 @@ dependencies = [
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termcolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "722426c4a0539da2c4ffd9b419d90ad540b4cff4a053be9069c908d4d07e2836"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum text_unit 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "efccd26c15ac99ac1a1fc2211ff3a2fc4c767bc522bd31a861bef7636cc17152"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ walkdir = "2.1"
 regex = "1"
 ordslice = "0.3"
 crossbeam-channel = "0.2.3"
+libeditor = { git = "https://github.com/matklad/libsyntax2", rev = "50a7daa042c5f652cd724de55a056f9785a22a85" }
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`


### PR DESCRIPTION
I've been hacking on libsyntax2 recently, and now it can parse some significant subset of Rust. Just to try it in action, I've tried to implement document symbols request using it, and looks like it works:

<img width="784" alt="image" src="https://user-images.githubusercontent.com/1711539/43689038-8bfe6b76-98fc-11e8-8386-d9e0527493bd.png">

this is a fun example, because analysis based approach does not work here for two reasons:

* there's no `mod tmp` declaration for the file, so we don't have analysis info for it
* it contains a critical parsing error, which completely flummoxes the rust-lang/rust parser. 


I don't expect this to be merged, I'd just want to show the current progress on the libsyntax2 front :-) 

That said, I think such fallback are very important for IDE use-cases, and so it might be interesting to implement something similar once libsytnax2 is relatively more ready :) 