### PR TITLE
Support simple external builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,6 +1108,7 @@ dependencies = [
  "rls-rustc 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-vfs 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt-nightly 0.99.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,12 @@ racer = { version = "2.1.5", default-features = false }
 rayon = "1"
 rls-analysis = "0.16"
 rls-blacklist = "0.1.2"
-rls-data = { version = "0.18", features = ["serialize-serde"] }
+rls-data = { version = "0.18", features = ["serialize-serde", "serialize-rustc"] }
 rls-rustc = "0.5.0"
 rls-span = { version = "0.4", features = ["serialize-serde"] }
 rls-vfs = "0.4.6"
 rustfmt-nightly = "0.99.4"
+rustc-serialize = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/src/build/external.rs
+++ b/src/build/external.rs
@@ -1,0 +1,101 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Performs a build using a provided black-box build command, which ought to
+//! return a list of save-analysis JSON files to be reloaded by the RLS.
+//! Please note that since the command is ran externally (at a file/OS level)
+//! this doesn't work with files that are not saved.
+
+use std::io::Read;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use super::BuildResult;
+
+use rls_data::Analysis;
+use log::{log, trace};
+
+/// Performs a build using an external command and interprets the results.
+/// The command should output on stdout a list of save-analysis .json files
+/// to be reloaded by the RLS.
+/// Note: This is *very* experimental and preliminary - this can viewed as
+/// an experimentation until a more complete solution emerges.
+pub(super) fn build_with_external_cmd<S: AsRef<str>>(path: S, build_dir: PathBuf) -> BuildResult {
+    let path = path.as_ref();
+    let (cmd, args) = {
+        let mut words = path.split_whitespace();
+        let cmd = match words.next() {
+            Some(cmd) => cmd,
+            None => {
+                return BuildResult::Err("Specified build_command is empty".into(), None);
+            }
+        };
+        (cmd, words)
+    };
+    let spawned = Command::new(&cmd)
+        .args(args)
+        .current_dir(&build_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn();
+
+    let child = match spawned {
+        Ok(child) => child,
+        Err(io) => {
+            let err_msg = format!("Couldn't execute: {} ({:?})", path, io.kind());
+            trace!("{}", err_msg);
+            return BuildResult::Err(err_msg, Some(path.to_owned()));
+        },
+    };
+
+    // TODO: Timeout?
+    let reader = std::io::BufReader::new(child.stdout.unwrap());
+    use std::io::BufRead;
+
+    let files = reader.lines().filter_map(|res| res.ok())
+        .map(PathBuf::from)
+        // Relative paths are relative to build command, not RLS itself (cwd may be different)
+        .map(|path| if !path.is_absolute() { build_dir.join(path) } else { path });
+
+    let analyses = match read_analysis_files(files) {
+        Ok(analyses) => analyses,
+        Err(cause) => {
+            let err_msg = format!("Couldn't read analysis data: {}", cause);
+            return BuildResult::Err(err_msg, Some(path.to_owned()));
+        }
+    };
+
+    BuildResult::Success(build_dir.clone(), vec![], analyses, false)
+}
+
+/// Reads and deserializes given save-analysis JSON files into corresponding
+/// `rls_data::Analysis` for each file. If an error is encountered, a `String`
+/// with the error message is returned.
+fn read_analysis_files<I>(files: I) -> Result<Vec<Analysis>, String>
+where
+    I: Iterator,
+    I::Item: AsRef<Path>
+{
+    let mut analyses = Vec::new();
+
+    for path in files {
+        trace!("external::read_analysis_files: Attempt to read `{}`", path.as_ref().display());
+
+        let mut file = File::open(path).map_err(|e| e.to_string())?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).map_err(|e| e.to_string())?;
+
+        let data = rustc_serialize::json::decode(&contents).map_err(|e| e.to_string())?;
+        analyses.push(data);
+    }
+
+    Ok(analyses)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -160,6 +160,13 @@ pub struct Config {
     /// Use provided rustfmt binary instead of the statically linked one.
     /// (requires unstable features)
     pub rustfmt_path: Option<String>,
+    /// EXPERIMENTAL (needs unstable features)
+    /// If set, executes a given program responsible for rebuilding save-analysis
+    /// to be loaded by the RLS. The program given should output a list of
+    /// resulting .json files on stdout.
+    /// Currently also requires `build_on_save` to be set to true, since external
+    /// commands have no insight into in-memory text buffers (unsaved files).
+    pub build_command: Option<String>,
 }
 
 impl Default for Config {
@@ -189,6 +196,7 @@ impl Default for Config {
             full_docs: Inferrable::Inferred(false),
             show_hover_context: true,
             rustfmt_path: None,
+            build_command: None,
         };
         result.normalise();
         result
@@ -226,6 +234,10 @@ impl Config {
             self.build_lib = Inferrable::Inferred(false);
             self.cfg_test = false;
             self.rustfmt_path = None;
+            self.build_command = None;
+        } else if !self.build_on_save {
+            self.build_command = None;
+            eprintln!("`build_command` also requires enabled `build_on_save` option");
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,8 +164,8 @@ pub struct Config {
     /// If set, executes a given program responsible for rebuilding save-analysis
     /// to be loaded by the RLS. The program given should output a list of
     /// resulting .json files on stdout.
-    /// Currently also requires `build_on_save` to be set to true, since external
-    /// commands have no insight into in-memory text buffers (unsaved files).
+    ///
+    /// Implies `build_on_save`: true.
     pub build_command: Option<String>,
 }
 
@@ -235,9 +235,8 @@ impl Config {
             self.cfg_test = false;
             self.rustfmt_path = None;
             self.build_command = None;
-        } else if !self.build_on_save {
-            self.build_command = None;
-            eprintln!("`build_command` also requires enabled `build_on_save` option");
+        } else if self.build_command.is_some() {
+            self.build_on_save = true;
         }
     }
 


### PR DESCRIPTION
@nrc this is the implementation of external build we talked about.
What's left is resolving the timeout issue (otherwise RLS will be stuck waiting 'building' if the build command loops) and resolving the pathbuf (de)serialize in rls-data (rustc serializes it with rustc-serialize, added a Deserialize impl for Serde backend deserializing with rustc-serialize format).

Since I worked on integrating this with Buck, here's a simple script that I used:
```bash
#!/bin/bash

# $1 - input file
# Output - directories of rebuilt json files
BUCK=~/repos/buck/bin/buck

RULE=$("$BUCK" query "owner($1)")
DEPS=$("$BUCK" query "kind('^rust_.*$', deps($RULE))")
for dep in $DEPS; do
	# Outputs save-analysis file for each dependency lib/bin
	$BUCK build "$dep#save-analysis" --show-output | awk '{print $2}'
done

```

which for `"rust.build_command": "/home/xanewok/.../script.sh server/src/main.rs`, for example, outputs:
```
buck-out/gen/server/server#default,save-analysis/save-analysis/server-e9d875ca101d0939.json
buck-out/gen/project1/project1#default,save-analysis/save-analysis/libproject1-f0ccf02843c7368b.json
buck-out/gen/project2/project2#default,save-analysis/save-analysis/libproject2-a1b98c5ddb92a465.json
```

As of now, build command does not support diagnostics, but I imagine we could tweak it further and support diagnostics/save-analysis via different message JSON payloads.

@nrc do you think this is good for now as-is?