### PR TITLE
Fix/address all warnings

### DIFF
--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -943,6 +943,7 @@ pub fn tooltip(
 }
 
 #[cfg(test)]
+#[allow(expect_fun_call)]
 pub mod test {
     use super::*;
 
@@ -1537,7 +1538,7 @@ pub mod test {
                 T: Copy,
         ",
         );
-        let result = format_method(config, input.into());
+        let result = format_method(config, input);
         assert_eq!(
             expected, result,
             "method with type parameters; corrected spacing"
@@ -1594,7 +1595,7 @@ pub mod test {
             )
         ",
         );
-        let result = format_method(config, input.into());
+        let result = format_method(config, input);
         assert_eq!(expected, result, "function with multiline args");
     }
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -124,8 +124,8 @@ pub enum BuildPriority {
 }
 
 impl BuildPriority {
-    fn is_cargo(&self) -> bool {
-        match *self {
+    fn is_cargo(self) -> bool {
+        match self {
             BuildPriority::Cargo => true,
             _ => false,
         }
@@ -174,7 +174,7 @@ enum Build {
     // A build is in progress.
     InProgress,
     // A build is queued.
-    Pending(PendingBuild),
+    Pending(Box<PendingBuild>),
     // No build.
     None,
 }
@@ -208,7 +208,7 @@ impl Build {
 
     fn try_into_pending(self) -> Result<PendingBuild, ()> {
         match self {
-            Build::Pending(b) => Ok(b),
+            Build::Pending(b) => Ok(*b),
             _ => Err(()),
         }
     }
@@ -324,11 +324,11 @@ impl BuildQueue {
     fn push_build(queued: &mut (Build, Build), build: PendingBuild) {
         if build.priority == BuildPriority::Normal {
             Self::squash_build(&mut queued.0);
-            queued.0 = Build::Pending(build);
+            queued.0 = Build::Pending(build.into());
         } else {
             Self::squash_build(&mut queued.0);
             Self::squash_build(&mut queued.1);
-            queued.1 = Build::Pending(build);
+            queued.1 = Build::Pending(build.into());
         }
     }
 

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -223,6 +223,8 @@ impl<'a> CompilerCalls<'a> for RlsRustcCalls {
             .late_callback(codegen_backend, matches, sess, cstore, input, odir, ofile)
     }
 
+
+    #[allow(boxed_local)] // https://github.com/rust-lang-nursery/rust-clippy/issues/1123
     fn build_controller(
         self: Box<Self>,
         sess: &Session,

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -26,15 +26,12 @@ pub struct JobToken {
     _chan: Sender<Never>,
 }
 
+#[derive(Default)]
 pub struct Jobs {
     jobs: Vec<ConcurrentJob>,
 }
 
 impl Jobs {
-    pub fn new() -> Jobs {
-        Jobs { jobs: Vec::new() }
-    }
-
     pub fn add(&mut self, job: ConcurrentJob) {
         self.gc();
         self.jobs.push(job);

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,15 +15,10 @@
 //! functionality such as 'goto definition', symbol search, reformatting, and
 //! code completion, and enables renaming and refactorings.
 
-#![feature(rustc_private)]
-#![feature(integer_atomics)]
-#![feature(drain_filter)]
-#![feature(rust_2018_preview)]
-
-#![warn(rust_2018_idioms)]
+#![feature(rust_2018_preview, rustc_private, integer_atomics, drain_filter)]
 #![allow(unknown_lints)]
-#![warn(clippy)]
-#![allow(cyclomatic_complexity, needless_pass_by_value, too_many_arguments, unused_extern_crates)]
+#![warn(clippy, rust_2018_idioms)]
+#![allow(cyclomatic_complexity, needless_pass_by_value, too_many_arguments)]
 
 // See rustc/rustc.rs in rust repo for explanation of stack adjustments.
 #![feature(link_args)]

--- a/src/project_model.rs
+++ b/src/project_model.rs
@@ -129,7 +129,7 @@ impl racer::ProjectModelProvider for RacerProjectModel {
             Ok(val) => Some(val),
             Err(err) => {
                 warn!("Error in cargo: {}", err);
-                return None;
+                None
             }
         }
     }

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(expect_fun_call)]
+
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
@@ -153,7 +155,7 @@ type LsResultList = Arc<Mutex<Vec<String>>>;
 #[derive(Clone)]
 crate struct RecordOutput {
     crate output: LsResultList,
-    output_id: Arc<Mutex<u32>>,
+    output_id: Arc<Mutex<u64>>,
 }
 
 impl RecordOutput {
@@ -175,7 +177,7 @@ impl ls_server::Output for RecordOutput {
     fn provide_id(&self) -> ls_server::RequestId {
         let mut id = self.output_id.lock().unwrap();
         *id += 1;
-        ls_server::RequestId::Num(*id as u64)
+        ls_server::RequestId::Num(*id)
     }
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -131,7 +131,7 @@ impl ExpectedMessage {
         for c in &self.contains {
             s
                 .find(c)
-                .ok_or(MsgMatchError::StringNotFound(c.to_owned(), s.to_owned()))
+                .ok_or_else(|| MsgMatchError::StringNotFound(c.to_owned(), s.to_owned()))
                 .map(|_| ())?;
         }
         Ok(())

--- a/tests/support/paths.rs
+++ b/tests/support/paths.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_lints)]
+
 use std::env;
 use std::cell::Cell;
 use std::fs;
@@ -64,6 +66,7 @@ pub trait TestPathExt {
     fn mkdir_p(&self);
 }
 
+#[allow(redundant_closure)] // &Path is not AsRef<Path>
 impl TestPathExt for Path {
     /* Technically there is a potential race condition, but we don't
      * care all that much for our tests


### PR DESCRIPTION
Continuing the sisyphean act of making rls warning free.

* Compress feature & allow declarations in main.rs
* Allow expect_fun_call in test scope
* Allow false positive boxed_local trait impl in rustc.rs
* Remove allow unused_extern_crates in main.rs