### PR TITLE
[WIP] Refactoring test harness

### DIFF
--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -237,7 +237,11 @@ fn soft_expect_message(
     server.wait_for_concurrent_jobs();
     let mut results = results.lock().unwrap();
 
-    let found = results.get(0).unwrap();
+    let found = match results.get(0) {
+        Some(s) => s,
+        None => return Err("No message found!".into())
+    };
+
     let values: serde_json::Value = serde_json::from_str(&found).unwrap();
     if values
         .get("jsonrpc")

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -204,7 +204,7 @@ impl ExpectedMessage {
 /// This function checks for messages with a series of constraints (expecrations)
 /// to appear in the buffer, removing valid messages and returning when encountering
 /// some that didn't meet the expectation
-crate fn expect_fuzzy(
+crate fn expect_series(
     server: &mut ls_server::LsService<RecordOutput>,
     results: LsResultList,
     contains: Vec<&str>,
@@ -213,7 +213,7 @@ crate fn expect_fuzzy(
     for c in contains {
         expected.expect_contains(c);
     }
-    while soft_expect_message(server, results.clone(), &expected).is_ok() {}
+    while try_expect_message(server, results.clone(), &expected).is_ok() {}
 }
 
 /// Expect a single message
@@ -225,7 +225,7 @@ crate fn expect_message(
     results: LsResultList,
     expected: &ExpectedMessage,
 ) {
-    if let Err(e) = soft_expect_message(server, results, expected) {
+    if let Err(e) = try_expect_message(server, results, expected) {
         panic!("Assert failed: {}", e);
     }
 }
@@ -234,7 +234,7 @@ crate fn expect_message(
 ///
 /// A valid message is removed from the buffer while invalid messages
 /// are left in place
-fn soft_expect_message(
+fn try_expect_message(
     server: &mut ls_server::LsService<RecordOutput>,
     results: LsResultList,
     expected: &ExpectedMessage,

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -280,47 +280,47 @@ fn soft_expect_message(
     Ok(())
 }
 
-crate fn expect_messages(server: &mut ls_server::LsService<RecordOutput>, results: LsResultList, expected: &[&ExpectedMessage]) {
-    server.wait_for_concurrent_jobs();
+// crate fn expect_messages(server: &mut ls_server::LsService<RecordOutput>, results: LsResultList, expected: &[&ExpectedMessage]) {
+//     server.wait_for_concurrent_jobs();
 
-    let mut results = results.lock().unwrap();
+//     let mut results = results.lock().unwrap();
 
-    println!(
-        "expect_messages:\n  results: {:#?},\n  expected: {:#?}",
-        *results,
-        expected
-    );
-    assert_eq!(results.len(), expected.len());
-    for (found, expected) in results.iter().zip(expected.iter()) {
-        let values: serde_json::Value = serde_json::from_str(found).unwrap();
-        assert!(
-            values
-                .get("jsonrpc")
-                .expect("Missing jsonrpc field")
-                .as_str()
-                .unwrap() == "2.0",
-            "Bad jsonrpc field"
-        );
-        if let Some(id) = expected.id {
-            assert_eq!(
-                values
-                    .get("id")
-                    .expect("Missing id field")
-                    .as_u64()
-                    .unwrap(),
-                id,
-                "Unexpected id"
-            );
-        }
-        for c in &expected.contains {
-            found
-                .find(c)
-                .expect(&format!("Could not find `{}` in `{}`", c, found));
-        }
-    }
+//     println!(
+//         "expect_messages:\n  results: {:#?},\n  expected: {:#?}",
+//         *results,
+//         expected
+//     );
+//     assert_eq!(results.len(), expected.len());
+//     for (found, expected) in results.iter().zip(expected.iter()) {
+//         let values: serde_json::Value = serde_json::from_str(found).unwrap();
+//         assert!(
+//             values
+//                 .get("jsonrpc")
+//                 .expect("Missing jsonrpc field")
+//                 .as_str()
+//                 .unwrap() == "2.0",
+//             "Bad jsonrpc field"
+//         );
+//         if let Some(id) = expected.id {
+//             assert_eq!(
+//                 values
+//                     .get("id")
+//                     .expect("Missing id field")
+//                     .as_u64()
+//                     .unwrap(),
+//                 id,
+//                 "Unexpected id"
+//             );
+//         }
+//         for c in &expected.contains {
+//             found
+//                 .find(c)
+//                 .expect(&format!("Could not find `{}` in `{}`", c, found));
+//         }
+//     }
 
-    *results = vec![];
-}
+//     *results = vec![];
+// }
 
 crate fn compare_json(actual: &serde_json::Value, expected: &str) {
     let expected: serde_json::Value = serde_json::from_str(expected).unwrap();

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -201,10 +201,9 @@ impl ExpectedMessage {
     }
 }
 
-/// This function works similarly to `expect_messages` except that it only matches
-/// on a single string that needs to be present in a series of messages. It also
-/// doesn't panic when encountering an unknown message, instead yielding to the
-/// next expect-block
+/// This function checks for messages with a series of constraints (expecrations)
+/// to appear in the buffer, removing valid messages and returning when encountering
+/// some that didn't meet the expectation
 crate fn expect_fuzzy(
     server: &mut ls_server::LsService<RecordOutput>,
     results: LsResultList,
@@ -217,7 +216,10 @@ crate fn expect_fuzzy(
     while soft_expect_message(server, results.clone(), &expected).is_ok() {}
 }
 
-/// Expect a single message – panic if not present and removes message from buffer if it is
+/// Expect a single message
+///
+/// It panics if the message wasn't valid and removes it from the buffer
+/// if it was
 crate fn expect_message(
     server: &mut ls_server::LsService<RecordOutput>,
     results: LsResultList,
@@ -228,7 +230,10 @@ crate fn expect_message(
     }
 }
 
-/// Check if a message is contained in the first buffer position without crashing
+/// Check a single message without panicking
+///
+/// A valid message is removed from the buffer while invalid messages
+/// are left in place
 fn soft_expect_message(
     server: &mut ls_server::LsService<RecordOutput>,
     results: LsResultList,
@@ -271,7 +276,6 @@ fn soft_expect_message(
         }
     }
 
-    // The message is only removed if it's OK
     results.remove(0);
     Ok(())
 }

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -280,48 +280,6 @@ fn soft_expect_message(
     Ok(())
 }
 
-// crate fn expect_messages(server: &mut ls_server::LsService<RecordOutput>, results: LsResultList, expected: &[&ExpectedMessage]) {
-//     server.wait_for_concurrent_jobs();
-
-//     let mut results = results.lock().unwrap();
-
-//     println!(
-//         "expect_messages:\n  results: {:#?},\n  expected: {:#?}",
-//         *results,
-//         expected
-//     );
-//     assert_eq!(results.len(), expected.len());
-//     for (found, expected) in results.iter().zip(expected.iter()) {
-//         let values: serde_json::Value = serde_json::from_str(found).unwrap();
-//         assert!(
-//             values
-//                 .get("jsonrpc")
-//                 .expect("Missing jsonrpc field")
-//                 .as_str()
-//                 .unwrap() == "2.0",
-//             "Bad jsonrpc field"
-//         );
-//         if let Some(id) = expected.id {
-//             assert_eq!(
-//                 values
-//                     .get("id")
-//                     .expect("Missing id field")
-//                     .as_u64()
-//                     .unwrap(),
-//                 id,
-//                 "Unexpected id"
-//             );
-//         }
-//         for c in &expected.contains {
-//             found
-//                 .find(c)
-//                 .expect(&format!("Could not find `{}` in `{}`", c, found));
-//         }
-//     }
-
-//     *results = vec![];
-// }
-
 crate fn compare_json(actual: &serde_json::Value, expected: &str) {
     let expected: serde_json::Value = serde_json::from_str(expected).unwrap();
     if actual != &expected {

--- a/src/test/lens.rs
+++ b/src/test/lens.rs
@@ -10,7 +10,7 @@ use crate::{
     lsp_data::InitializationOptions,
     test::{
         request, initialize_with_opts,
-        harness::{expect_messages, compare_json, Environment, ExpectedMessage},
+        harness::{expect_message, expect_fuzzy, compare_json, Environment, ExpectedMessage},
     },
 };
 
@@ -48,20 +48,14 @@ fn test_lens_run() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0))
-                .expect_contains(r#""codeLensProvider":{"resolveProvider":false}"#),
-            ExpectedMessage::new(None).expect_contains("progress"),
-            ExpectedMessage::new(None).expect_contains("progress"),
-            ExpectedMessage::new(None).expect_contains("progress"),
-            ExpectedMessage::new(None).expect_contains("progress"),
-            ExpectedMessage::new(None).expect_contains("progress"),
-            ExpectedMessage::new(None).expect_contains("progress"),
-        ],
+        &ExpectedMessage::new(Some(0))
+            .expect_contains(r#""codeLensProvider":{"resolveProvider":false}"#),
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),

--- a/src/test/lens.rs
+++ b/src/test/lens.rs
@@ -10,7 +10,7 @@ use crate::{
     lsp_data::InitializationOptions,
     test::{
         request, initialize_with_opts,
-        harness::{expect_message, expect_fuzzy, compare_json, Environment, ExpectedMessage},
+        harness::{expect_message, expect_series, compare_json, Environment, ExpectedMessage},
     },
 };
 
@@ -55,7 +55,7 @@ fn test_lens_run() {
             .expect_contains(r#""codeLensProvider":{"resolveProvider":false}"#),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -19,7 +19,7 @@ use crate::server::{self as ls_server, Request, ShutdownRequest, Notification, R
 use jsonrpc_core;
 use rls_vfs::Vfs;
 
-use self::harness::{compare_json, expect_messages, src, Environment, ExpectedMessage, RecordOutput};
+use self::harness::{compare_json, expect_message, expect_fuzzy, expect_messages, src, Environment, ExpectedMessage, RecordOutput};
 
 use languageserver_types::*;
 use crate::lsp_data::InitializationOptions;
@@ -110,25 +110,20 @@ fn test_shutdown() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(&mut server, results.clone(), &[&ExpectedMessage::new(Some(1))]);
+    expect_message(&mut server, results.clone(), &ExpectedMessage::new(Some(1)));
 }
 
 #[test]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -19,7 +19,7 @@ use crate::server::{self as ls_server, Request, ShutdownRequest, Notification, R
 use jsonrpc_core;
 use rls_vfs::Vfs;
 
-use self::harness::{compare_json, expect_message, expect_fuzzy, src, Environment, ExpectedMessage, RecordOutput};
+use self::harness::{compare_json, expect_message, expect_series, src, Environment, ExpectedMessage, RecordOutput};
 
 use languageserver_types::*;
 use crate::lsp_data::InitializationOptions;
@@ -117,7 +117,7 @@ fn test_shutdown() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);;
+    expect_series(&mut server, results.clone(), vec!["progress"]);;
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -161,7 +161,7 @@ fn test_goto_def() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);;
+    expect_series(&mut server, results.clone(), vec!["progress"]);;
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -209,7 +209,7 @@ fn test_hover() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);;
+    expect_series(&mut server, results.clone(), vec!["progress"]);;
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -289,7 +289,7 @@ fn test_hover_after_src_line_change() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     // first hover over unmodified
     assert_eq!(
@@ -309,7 +309,7 @@ fn test_hover_after_src_line_change() {
         ls_server::ServerStateChange::Continue
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     // hover after line change should work at the new line
     assert_eq!(
@@ -353,7 +353,7 @@ fn test_workspace_symbol() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -407,7 +407,7 @@ fn test_workspace_symbol_duplicates() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -473,7 +473,7 @@ fn test_find_all_refs() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -530,7 +530,7 @@ fn test_find_all_refs_no_cfg_test() {
             ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -569,7 +569,7 @@ fn test_borrow_error() {
             ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     expect_message(
         &mut server,
@@ -578,7 +578,7 @@ fn test_borrow_error() {
             .expect_contains(r#""message":"cannot borrow `x` as mutable more than once at a time"#),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 }
 
 #[test]
@@ -615,7 +615,7 @@ fn test_highlight() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -668,7 +668,7 @@ fn test_rename() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -723,7 +723,7 @@ fn test_reformat() {
             ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -784,7 +784,7 @@ fn test_reformat_with_range() {
             ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -821,7 +821,7 @@ fn test_multiple_binaries() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server,results.clone(),vec!["progress"]);
+    expect_series(&mut server,results.clone(),vec!["progress"]);
 
     // These messages should be about bin_name1 and bin_name2, but the order is
     // not deterministic FIXME(#606)
@@ -835,7 +835,7 @@ fn test_multiple_binaries() {
         results.clone(),
         ExpectedMessage::new(None).expect_contains("unused variable: `bin_name"),
     );
-    expect_fuzzy(&mut server,results.clone(),vec!["progress"]);
+    expect_series(&mut server,results.clone(),vec!["progress"]);
 }
 
 // FIXME Requires rust-src component, which would break Rust CI
@@ -904,7 +904,7 @@ fn test_bin_lib_project() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     expect_message(
         &mut server,
@@ -994,7 +994,7 @@ fn test_infer_lib() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     expect_message(
         &mut server,
@@ -1031,7 +1031,7 @@ fn test_infer_bin() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     expect_message(
         &mut server,
@@ -1068,7 +1068,7 @@ fn test_infer_custom_bin() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     expect_message(
         &mut server,
@@ -1200,7 +1200,7 @@ fn test_find_impls() {
             ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1253,7 +1253,7 @@ fn test_features() {
             ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     expect_message(
         &mut server,
@@ -1292,7 +1292,7 @@ fn test_all_features() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 }
 
 #[test]
@@ -1320,7 +1320,7 @@ fn test_no_default_features() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     expect_message(
         &mut server,
@@ -1447,7 +1447,7 @@ fn test_deglob() {
         ExpectedMessage::new(Some(0)).expect_contains("rls.deglobImports-"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1600,7 +1600,7 @@ fn test_all_targets() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 
     expect_message(
         &mut server,
@@ -1669,7 +1669,7 @@ fn ignore_uninitialized_notification() {
         ExpectedMessage::new(Some(1)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 }
 
 /// Handle receiving requests before the `initialize` request by returning an error response
@@ -1726,7 +1726,7 @@ fn fail_uninitialized_request() {
         ExpectedMessage::new(Some(1)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_series(&mut server, results.clone(), vec!["progress"]);
 }
 
 // FIXME disabled since it is failing in the Rust repo.

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -19,7 +19,7 @@ use crate::server::{self as ls_server, Request, ShutdownRequest, Notification, R
 use jsonrpc_core;
 use rls_vfs::Vfs;
 
-use self::harness::{compare_json, expect_message, expect_fuzzy, expect_messages, src, Environment, ExpectedMessage, RecordOutput};
+use self::harness::{compare_json, expect_message, expect_fuzzy, src, Environment, ExpectedMessage, RecordOutput};
 
 use languageserver_types::*;
 use crate::lsp_data::InitializationOptions;
@@ -117,7 +117,7 @@ fn test_shutdown() {
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 
-    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);;
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -154,31 +154,24 @@ fn test_goto_def() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);;
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
     // TODO structural checking of result, rather than looking for a string - src(&source_file_path, 12, "world")
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(11)).expect_contains(r#""start":{"line":20,"character":8}"#),
-        ],
+        ExpectedMessage::new(Some(11)).expect_contains(r#""start":{"line":20,"character":8}"#),
     );
 }
 
@@ -210,31 +203,23 @@ fn test_hover() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);;
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(11))
-                .expect_contains(r#"[{"language":"rust","value":"&str"},{"language":"rust","value":"let world = \"world\";"}]"#),
-        ],
+        ExpectedMessage::new(Some(11))
+                .expect_contains(r#"[{"language":"rust","value":"&str"},{"language":"rust","value":"let world = \"world\";"}]"#)
     );
 }
 
@@ -298,32 +283,24 @@ fn test_hover_after_src_line_change() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     // first hover over unmodified
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(11))
+        ExpectedMessage::new(Some(11))
                 .expect_contains(r#"[{"language":"rust","value":"&str"}]"#),
-        ],
     );
 
     // handle didChange notification and wait for rebuild
@@ -332,31 +309,18 @@ fn test_hover_after_src_line_change() {
         ls_server::ServerStateChange::Continue
     );
 
-    expect_messages(
-        &mut server,
-        results.clone(),
-        &[
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
-    );
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     // hover after line change should work at the new line
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(None)
-                .expect_contains(r#"[{"language":"rust","value":"&str"}]"#),
-        ],
+        ExpectedMessage::new(None)
+                .expect_contains(r#"[{"language":"rust","value":"&str"}]"#)
     );
 }
 
@@ -383,39 +347,35 @@ fn test_workspace_symbol() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("workspace_symbol"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
 
-    expect_messages(
-        &mut server,results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains(r#""id":42"#)
-                                                                     // in main.rs
-                                                                     .expect_contains(r#"main.rs"#)
-                                                                     .expect_contains(r#""name":"nemo""#)
-                                                                     .expect_contains(r#""kind":12"#)
-                                                                     .expect_contains(r#""range":{"start":{"line":11,"character":11},"end":{"line":11,"character":15}}"#)
-                                                                     .expect_contains(r#""containerName":"x""#)
+    expect_message(
+        &mut server,results.clone(),
+            ExpectedMessage::new(Some(42)).expect_contains(r#""id":42"#)
+            // in main.rs
+            .expect_contains(r#"main.rs"#)
+            .expect_contains(r#""name":"nemo""#)
+            .expect_contains(r#""kind":12"#)
+            .expect_contains(r#""range":{"start":{"line":11,"character":11},"end":{"line":11,"character":15}}"#)
+            .expect_contains(r#""containerName":"x""#)
 
-                                                                     // in foo.rs
-                                                                     .expect_contains(r#"foo.rs"#)
-                                                                     .expect_contains(r#""name":"nemo""#)
-                                                                     .expect_contains(r#""kind":2"#)
-                                                                     .expect_contains(r#""range":{"start":{"line":0,"character":4},"end":{"line":0,"character":8}}"#)
-                                                                     .expect_contains(r#""containerName":"foo""#)]);
+            // in foo.rs
+            .expect_contains(r#"foo.rs"#)
+            .expect_contains(r#""name":"nemo""#)
+            .expect_contains(r#""kind":2"#)
+            .expect_contains(r#""range":{"start":{"line":0,"character":4},"end":{"line":0,"character":8}}"#)
+            .expect_contains(r#""containerName":"foo""#));
 }
 
 #[test]
@@ -441,18 +401,13 @@ fn test_workspace_symbol_duplicates() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("workspace_symbol"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -512,38 +467,29 @@ fn test_find_all_refs() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(42))
-                .expect_contains(
-                    r#"{"start":{"line":9,"character":7},"end":{"line":9,"character":10}}"#,
-                )
-                .expect_contains(
-                    r#"{"start":{"line":15,"character":14},"end":{"line":15,"character":17}}"#,
-                )
-                .expect_contains(
-                    r#"{"start":{"line":23,"character":15},"end":{"line":23,"character":18}}"#,
-                ),
-        ],
+        ExpectedMessage::new(Some(42))
+            .expect_contains(
+                r#"{"start":{"line":9,"character":7},"end":{"line":9,"character":10}}"#,
+            ).expect_contains(
+                r#"{"start":{"line":15,"character":14},"end":{"line":15,"character":17}}"#,
+            ).expect_contains(
+                r#"{"start":{"line":23,"character":15},"end":{"line":23,"character":18}}"#,
+            ),
     );
 }
 
@@ -578,35 +524,27 @@ fn test_find_all_refs_no_cfg_test() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
             ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("find_all_refs_no_cfg_test"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(42))
-                .expect_contains(
-                    r#"{"start":{"line":9,"character":7},"end":{"line":9,"character":10}}"#,
-                )
-                .expect_contains(
-                    r#"{"start":{"line":22,"character":15},"end":{"line":22,"character":18}}"#,
-                ),
-        ],
+        ExpectedMessage::new(Some(42))
+            .expect_contains(
+                r#"{"start":{"line":9,"character":7},"end":{"line":9,"character":10}}"#,
+            ).expect_contains(
+                r#"{"start":{"line":22,"character":15},"end":{"line":22,"character":18}}"#,
+            ),
     );
 }
 
@@ -625,22 +563,22 @@ fn test_borrow_error() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("borrow_error"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("borrow_error"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains(
-                r#""message":"cannot borrow `x` as mutable more than once at a time"#,
-            ),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+            ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None)
+            .expect_contains(r#""message":"cannot borrow `x` as mutable more than once at a time"#),
+    );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 }
 
 #[test]
@@ -671,36 +609,27 @@ fn test_highlight() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(42))
-                .expect_contains(
-                    r#"{"start":{"line":20,"character":8},"end":{"line":20,"character":13}}"#,
-                )
-                .expect_contains(
-                    r#"{"start":{"line":21,"character":27},"end":{"line":21,"character":32}}"#,
-                ),
-        ],
+        ExpectedMessage::new(Some(42))
+            .expect_contains(
+                r#"{"start":{"line":20,"character":8},"end":{"line":20,"character":13}}"#,
+            ).expect_contains(
+                r#"{"start":{"line":21,"character":27},"end":{"line":21,"character":32}}"#,
+            ),
     );
 }
 
@@ -733,37 +662,27 @@ fn test_rename() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(42))
-                .expect_contains(
-                    r#"{"start":{"line":20,"character":8},"end":{"line":20,"character":13}}"#,
-                )
-                .expect_contains(
-                    r#"{"start":{"line":21,"character":27},"end":{"line":21,"character":32}}"#,
-                )
-                .expect_contains(r#"{"changes""#),
-        ],
+        ExpectedMessage::new(Some(42))
+            .expect_contains(
+                r#"{"start":{"line":20,"character":8},"end":{"line":20,"character":13}}"#,
+            ).expect_contains(
+                r#"{"start":{"line":21,"character":27},"end":{"line":21,"character":32}}"#,
+            ).expect_contains(r#"{"changes""#),
     );
 }
 
@@ -798,27 +717,24 @@ fn test_reformat() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
             ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("reformat"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("reformat"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
-        &mut server,results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains(r#"{"start":{"line":0,"character":0},"end":{"line":12,"character":0}}"#)
-                                            .expect_contains(r#"newText":"// Copyright 2017 The Rust Project Developers. See the COPYRIGHT\n// file at the top-level directory of this distribution and at\n// http://rust-lang.org/COPYRIGHT.\n//\n// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms.\n\npub mod foo;\npub fn main() {\n    let world = \"world\";\n    println!(\"Hello, {}!\", world);\n}"#)]);
+    expect_message(
+        &mut server,results.clone(), 
+        ExpectedMessage::new(Some(42))
+            .expect_contains(r#"{"start":{"line":0,"character":0},"end":{"line":12,"character":0}}"#)
+            .expect_contains(r#"newText":"// Copyright 2017 The Rust Project Developers. See the COPYRIGHT\n// file at the top-level directory of this distribution and at\n// http://rust-lang.org/COPYRIGHT.\n//\n// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms.\n\npub mod foo;\npub fn main() {\n    let world = \"world\";\n    println!(\"Hello, {}!\", world);\n}"#)
+        );
 }
 
 #[test]
@@ -862,26 +778,22 @@ fn test_reformat_with_range() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("reformat_with_range"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("reformat_with_range"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+            ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(&mut server, results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains(r#"{"start":{"line":0,"character":0},"end":{"line":15,"character":5}}"#)
-                                            .expect_contains(r#"newText":"// Copyright 2017 The Rust Project Developers. See the COPYRIGHT\n// file at the top-level directory of this distribution and at\n// http://rust-lang.org/COPYRIGHT.\n//\n// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms.\n\npub fn main() {\n    let world1 = \"world\";\n    println!(\"Hello, {}!\", world1);\n    let world2 = \"world\";\n    println!(\"Hello, {}!\", world2);\n    let world3 = \"world\";\n    println!(\"Hello, {}!\", world3);\n}\n"#)]);
+    expect_message(&mut server, results.clone(),
+        ExpectedMessage::new(Some(42)).expect_contains(r#"{"start":{"line":0,"character":0},"end":{"line":15,"character":5}}"#)
+            .expect_contains(r#"newText":"// Copyright 2017 The Rust Project Developers. See the COPYRIGHT\n// file at the top-level directory of this distribution and at\n// http://rust-lang.org/COPYRIGHT.\n//\n// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms.\n\npub fn main() {\n    let world1 = \"world\";\n    println!(\"Hello, {}!\", world1);\n    let world2 = \"world\";\n    println!(\"Hello, {}!\", world2);\n    let world3 = \"world\";\n    println!(\"Hello, {}!\", world3);\n}\n"#)
+    );
 }
 
 #[test]
@@ -902,26 +814,28 @@ fn test_multiple_binaries() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-                                                                                           // order of these is random
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("bin"), // "bin1"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("bin"), // "bin1"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("bin"), // "bin2"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("bin"), // "bin2"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            // These messages should be about bin_name1 and bin_name2, but the order is
-            // not deterministic FIXME(#606)
-            ExpectedMessage::new(None).expect_contains("unused variable: `bin_name"),
-            ExpectedMessage::new(None).expect_contains("unused variable: `bin_name"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
+
+    expect_fuzzy(&mut server,results.clone(),vec!["progress"]);
+
+    // These messages should be about bin_name1 and bin_name2, but the order is
+    // not deterministic FIXME(#606)
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None).expect_contains("unused variable: `bin_name"),
+    );
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None).expect_contains("unused variable: `bin_name"),
+    );
+    expect_fuzzy(&mut server,results.clone(),vec!["progress"]);
 }
 
 // FIXME Requires rust-src component, which would break Rust CI
@@ -951,17 +865,17 @@ fn test_multiple_binaries() {
 //     // Initialize and build.
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
-//     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+//     expect_message(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
 //                                        ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
 //                                        ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#)]);
 
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
-//     expect_messages(results.clone(), &[ExpectedMessage::new(Some(11)).expect_contains(r#"[{"label":"world","kind":6,"detail":"let world = \"world\";"}]"#)]);
+//     expect_message(results.clone(), &[ExpectedMessage::new(Some(11)).expect_contains(r#"[{"label":"world","kind":6,"detail":"let world = \"world\";"}]"#)]);
 
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
-//     expect_messages(results.clone(), &[ExpectedMessage::new(Some(22)).expect_contains(r#"{"label":"x","kind":5,"detail":"u64"#)]);
+//     expect_message(results.clone(), &[ExpectedMessage::new(Some(22)).expect_contains(r#"{"label":"x","kind":5,"detail":"u64"#)]);
 // }
 
 #[test]
@@ -984,23 +898,28 @@ fn test_bin_lib_project() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("bin_lib"),
-            ExpectedMessage::new(None).expect_contains("progress"),
-            ExpectedMessage::new(None).expect_contains("progress"),
-            ExpectedMessage::new(None).expect_contains("progress"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None)
-                .expect_contains(r#"bin_lib/tests/tests.rs"#)
-                .expect_contains(r#"unused variable: `unused_var`"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+    );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None)
+            .expect_contains(r#"bin_lib/tests/tests.rs"#)
+            .expect_contains(r#"unused variable: `unused_var`"#),
+    );
+
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None)
+            .expect_contains("progress")
+            .expect_contains(r#""done":true"#),
     );
 }
 
@@ -1023,7 +942,7 @@ fn test_bin_lib_project() {
 //     // Initialize and build.
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
-//     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+//     expect_message(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
 //                                        ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
 //                                        ExpectedMessage::new(None).expect_contains("cannot find struct, variant or union type `LibCfgTestStruct` in module `bin_lib`"),
 //                                        ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#)]);
@@ -1044,7 +963,7 @@ fn test_bin_lib_project() {
 //     // Initialize and build.
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
-//     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+//     expect_message(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
 //                                        ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
 //                                        // TODO: Ideally we should check for message contents for different crates/targets,
 //                                        // however order of received messages is non-deterministic and this
@@ -1069,19 +988,25 @@ fn test_infer_lib() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("infer_lib"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("infer_lib"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("struct is never constructed: `UnusedLib`"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+    );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None).expect_contains("struct is never constructed: `UnusedLib`"),
+    );
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None)
+            .expect_contains("progress")
+            .expect_contains(r#""done":true"#),
     );
 }
 
@@ -1100,19 +1025,25 @@ fn test_infer_bin() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("infer_bin"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("infer_bin"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("struct is never constructed: `UnusedBin`"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+    );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None).expect_contains("struct is never constructed: `UnusedBin`"),
+    );
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None)
+            .expect_contains("progress")
+            .expect_contains(r#""done":true"#),
     );
 }
 
@@ -1131,19 +1062,26 @@ fn test_infer_custom_bin() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("custom_bin"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("custom_bin"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("struct is never constructed: `UnusedCustomBin`"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+    );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None)
+            .expect_contains("struct is never constructed: `UnusedCustomBin`"),
+    );
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None)
+            .expect_contains("progress")
+            .expect_contains(r#""done":true"#),
     );
 }
 
@@ -1167,11 +1105,9 @@ fn test_omit_init_build() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(&mut server,
+    expect_message(&mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
 }
 
@@ -1259,42 +1195,36 @@ fn test_find_impls() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(&mut server,
+    expect_message(&mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("find_impls"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("find_impls"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+            ExpectedMessage::new(Some(0)).expect_contains("capabilities")
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
     // TODO structural checking of result, rather than looking for a string - src(&source_file_path, 12, "world")
-    expect_messages(&mut server, results.clone(), &[
+    expect_message(&mut server, results.clone(),
         ExpectedMessage::new(Some(1))
             .expect_contains(r#""range":{"start":{"line":18,"character":15},"end":{"line":18,"character":18}}"#)
             .expect_contains(r#""range":{"start":{"line":19,"character":12},"end":{"line":19,"character":15}}"#)
-    ]);
+    );
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(&mut server, results.clone(), &[
+    expect_message(&mut server, results.clone(),
         ExpectedMessage::new(Some(2))
             .expect_contains(r#""range":{"start":{"line":18,"character":15},"end":{"line":18,"character":18}}"#)
             .expect_contains(r#""range":{"start":{"line":22,"character":15},"end":{"line":22,"character":18}}"#)
-    ]);
+    );
     // FIXME Does not work on Travis
     // assert_eq!(ls_server::LsService::handle_message(&mut server),
     //            ls_server::ServerStateChange::Continue);
-    // expect_messages(results.clone(), &[
+    // expect_message(results.clone(), &[
     //     // TODO assert that only one position is returned
     //     ExpectedMessage::new(Some(3))
     //         .expect_contains(r#""range":{"start":{"line":19,"character":12},"end":{"line":19,"character":15}}"#)
@@ -1317,21 +1247,27 @@ fn test_features() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
             ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("features"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("features"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains(
-                r#""message":"cannot find struct, variant or union type `Bar` in this scope"#,
-            ),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+    );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None).expect_contains(
+            r#""message":"cannot find struct, variant or union type `Bar` in this scope"#,
+        ),
+    );
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None)
+            .expect_contains("progress")
+            .expect_contains(r#""done":true"#),
     );
 }
 
@@ -1340,9 +1276,8 @@ fn test_all_features() {
     let mut env = Environment::new("features");
 
     let root_path = env.cache.abs_path(Path::new("."));
-    let messages = vec![
-        initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
-    ];
+    let messages =
+        vec![initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string()];
 
     env.with_config(|c| c.all_features = true);
     let (mut server, results) = env.mock_server(messages);
@@ -1351,19 +1286,13 @@ fn test_all_features() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("features"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("features"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 }
 
 #[test]
@@ -1385,21 +1314,27 @@ fn test_no_default_features() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("features"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("features"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains(
-                r#""message":"cannot find struct, variant or union type `Baz` in this scope"#,
-            ),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+    );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None).expect_contains(
+            r#""message":"cannot find struct, variant or union type `Baz` in this scope"#,
+        ),
+    );
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None)
+            .expect_contains("progress")
+            .expect_contains(r#""done":true"#),
     );
 }
 
@@ -1417,7 +1352,7 @@ fn test_no_default_features() {
 //     // Initialize and build.
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
-//     expect_messages(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+//     expect_message(results.clone(), &[ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
 //                                        ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
 //                                        ExpectedMessage::new(None)
 //                                            .expect_contains(root_url.path())
@@ -1506,19 +1441,13 @@ fn test_deglob() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("rls.deglobImports-"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("deglob"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("deglob"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("rls.deglobImports-"),
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1593,20 +1522,18 @@ fn test_deglob() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(1100))
-                .expect_contains(r#""title":"Deglob imports""#)
-                .expect_contains(r#""command":"rls.deglobImports-"#)
-                .expect_contains(r#"{"location":{"range":{"end":{"character":15,"line":15},"start":{"character":14,"line":15}},"uri":"#)
-                .expect_contains(r#"deglob/src/main.rs"}"#)
-                .expect_contains(r#""new_text":"size_of""#)
-                .expect_contains(r#"{"location":{"range":{"end":{"character":32,"line":15},"start":{"character":31,"line":15}},"uri":"#)
-                .expect_contains(r#"deglob/src/main.rs"}"#)
-                .expect_contains(r#""new_text":"max""#)
-        ],
+        ExpectedMessage::new(Some(1100))
+            .expect_contains(r#""title":"Deglob imports""#)
+            .expect_contains(r#""command":"rls.deglobImports-"#)
+            .expect_contains(r#"{"location":{"range":{"end":{"character":15,"line":15},"start":{"character":14,"line":15}},"uri":"#)
+            .expect_contains(r#"deglob/src/main.rs"}"#)
+            .expect_contains(r#""new_text":"size_of""#)
+            .expect_contains(r#"{"location":{"range":{"end":{"character":32,"line":15},"start":{"character":31,"line":15}},"uri":"#)
+            .expect_contains(r#"deglob/src/main.rs"}"#)
+            .expect_contains(r#""new_text":"max""#)
     );
 
     assert_eq!(
@@ -1640,12 +1567,10 @@ fn test_deglob() {
         assert_eq!(change["newText"], "max");
     }
 
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
             ExpectedMessage::new(Some(1200)).expect_contains(r#"null"#),
-        ],
     );
 }
 
@@ -1669,23 +1594,27 @@ fn test_all_targets() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("message"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("message"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("message"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("message"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None)
-                .expect_contains(r#"bin_lib/tests/tests.rs"#)
-                .expect_contains(r#"unused variable: `unused_var`"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities")
+    );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
+
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None)
+            .expect_contains(r#"bin_lib/tests/tests.rs"#)
+            .expect_contains(r#"unused variable: `unused_var`"#),
+    );
+    expect_message(
+        &mut server,
+        results.clone(),
+        ExpectedMessage::new(None)
+            .expect_contains("progress")
+            .expect_contains(r#""done":true"#),
     );
 }
 
@@ -1728,27 +1657,19 @@ fn ignore_uninitialized_notification() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
-        &mut server,results.clone(), &[]);
-
+    
     // Initialize and build
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(1)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(1)).expect_contains("capabilities"),
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 }
 
 /// Handle receiving requests before the `initialize` request by returning an error response
@@ -1799,19 +1720,13 @@ fn fail_uninitialized_request() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
-    expect_messages(
+    expect_message(
         &mut server,
         results.clone(),
-        &[
-            ExpectedMessage::new(Some(1)).expect_contains("capabilities"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Building""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains("completion"),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#"title":"Indexing""#),
-            ExpectedMessage::new(None).expect_contains("progress").expect_contains(r#""done":true"#),
-        ],
+        ExpectedMessage::new(Some(1)).expect_contains("capabilities"),
     );
+
+    expect_fuzzy(&mut server, results.clone(), vec!["progress"]);
 }
 
 // FIXME disabled since it is failing in the Rust repo.
@@ -1831,7 +1746,7 @@ fn fail_uninitialized_request() {
 //         ls_server::LsService::handle_message(&mut server),
 //         ls_server::ServerStateChange::Continue
 //     );
-//     expect_messages(
+//     expect_message(
 //         results.clone(),
 //         &[
 //             ExpectedMessage::new(Some(0)).expect_contains("capabilities"),


### PR DESCRIPTION
This PR adds three functions to the test harness, essentially replacing `expect_messages`. Most notably operations are now done on a message-by-message basis, clearing valid messages from the buffer.

* `soft_expect_message` checks if a message matches the expectation and returns an `Err` if not
* `expect_message` is a `panic!` wrapper around `soft_expect_message`, which is not public
* `expect_fuzzy` (name to be :bike::house:) soft_checks for messages until they no longer match the expectation.

Things that are left to do
- [x] Port all the tests over to the new functions
- [x] Remove the old `expect_messages` from the test harness