### PR TITLE
deps: update clippy_lints git dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "clippy_lints"
 version = "0.0.212"
-source = "git+https://github.com/rust-lang-nursery/rust-clippy?rev=07c2e614362ad8645eafe771e672a65f92e3b9a2#07c2e614362ad8645eafe771e672a65f92e3b9a2"
+source = "git+https://github.com/rust-lang-nursery/rust-clippy?rev=f05a1038b59cd4217e58b3aef7a0751a0efd01e4#f05a1038b59cd4217e58b3aef7a0751a0efd01e4"
 dependencies = [
  "cargo_metadata 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1093,7 +1093,7 @@ version = "0.130.5"
 dependencies = [
  "cargo 0.30.0 (git+https://github.com/rust-lang/cargo?rev=6a7672ef5344c1bb570610f2574250fbee932355)",
  "cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.212 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=07c2e614362ad8645eafe771e672a65f92e3b9a2)",
+ "clippy_lints 0.0.212 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=f05a1038b59cd4217e58b3aef7a0751a0efd01e4)",
  "crossbeam-channel 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1737,7 +1737,7 @@ dependencies = [
 "checksum cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "2119ea4867bd2b8ed3aecab467709720b2d55b1bcfe09f772fd68066eaf15275"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
-"checksum clippy_lints 0.0.212 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=07c2e614362ad8645eafe771e672a65f92e3b9a2)" = "<none>"
+"checksum clippy_lints 0.0.212 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=f05a1038b59cd4217e58b3aef7a0751a0efd01e4)" = "<none>"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "704fbf3bb5149daab0afb255dbea24a1f08d2f4099cedb9baab6d470d4c5eefb"
 "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 [dependencies]
 cargo = { git = "https://github.com/rust-lang/cargo", rev = "6a7672ef5344c1bb570610f2574250fbee932355" }
 cargo_metadata = "0.6"
-clippy_lints = { git = "https://github.com/rust-lang-nursery/rust-clippy", rev = "07c2e614362ad8645eafe771e672a65f92e3b9a2", optional = true }
+clippy_lints = { git = "https://github.com/rust-lang-nursery/rust-clippy", rev = "f05a1038b59cd4217e58b3aef7a0751a0efd01e4", optional = true }
 env_logger = "0.5"
 failure = "0.1.1"
 itertools = "0.7.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@
 //! functionality such as 'goto definition', symbol search, reformatting, and
 //! code completion, and enables renaming and refactorings.
 
-#![feature(rust_2018_preview, rustc_private, integer_atomics, drain_filter)]
+#![feature(rustc_private, integer_atomics, drain_filter)]
 #![allow(unknown_lints)]
 #![warn(clippy, rust_2018_idioms)]
 #![allow(cyclomatic_complexity, needless_pass_by_value, too_many_arguments)]


### PR DESCRIPTION
update clippy_lints git dependency to f05a1038b59cd4217e58b3aef7a0751a0efd01e4

hopefully this fixes rls build with latest rustc master, and, once rls is submodule is updated in the rustc repo, the broken rustc rls toolstate.