### PR TITLE
Import `json_internal`

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -15,7 +15,7 @@ use rls_analysis::AnalysisHost;
 use rls_vfs::{Vfs, FileContents};
 use crate::config::FmtConfig;
 use crate::config::Config;
-use serde_json::{self, json};
+use serde_json::{self, json, json_internal};
 use url::Url;
 use rls_span as span;
 use crate::Span;


### PR DESCRIPTION
Fixing error from https://github.com/rust-lang/rust/pull/53610#issuecomment-415710193, specifically https://ci.appveyor.com/project/rust-lang/rust/build/1.0.8732/job/1vio56we88sawdcb#L11560.
```
error: cannot find macro `json_internal!` in this scope
   --> tools\rls\src\actions\mod.rs:506:9
    |
506 | /         json!({
507 | |             "watchers": watchers
508 | |         })
    | |__________^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

Confirmed the error and the fix while using https://github.com/rust-lang/rust/commit/61b00727076ce251b54bdefa18779a13819d2209.