### PR TITLE
Add rust-toolstate shields to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build Status](https://travis-ci.org/rust-lang-nursery/rls.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/rls) [![Build status](https://ci.appveyor.com/api/projects/status/cxfejvsqnnc1oygs?svg=true)](https://ci.appveyor.com/project/jonathandturner/rls-x6grn)
+[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Windows)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24[2].windows&colorB=lightgrey)](https://github.com/rust-lang-nursery/rust-toolstate)
+[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Linux)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24[2].linux&colorB=lightgrey)](https://github.com/rust-lang-nursery/rust-toolstate)
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/rust-lang-nursery/rls.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/rls) [![Build status](https://ci.appveyor.com/api/projects/status/cxfejvsqnnc1oygs?svg=true)](https://ci.appveyor.com/project/jonathandturner/rls-x6grn)
-[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Windows)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24[2].windows&colorB=lightgrey)](https://rust-lang-nursery.github.io/rust-toolstate/)
-[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Linux)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24[2].linux&colorB=lightgrey)](https://rust-lang-nursery.github.io/rust-toolstate/)
+[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Windows)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24%5B%3F(%40.tool%3D%3D%22rls%22)%5D.windows&colorB=lightgrey)](https://rust-lang-nursery.github.io/rust-toolstate/)
+[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Linux)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24%5B%3F(%40.tool%3D%3D%22rls%22)%5D.linux&colorB=lightgrey)](https://rust-lang-nursery.github.io/rust-toolstate/)
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/rust-lang-nursery/rls.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/rls) [![Build status](https://ci.appveyor.com/api/projects/status/cxfejvsqnnc1oygs?svg=true)](https://ci.appveyor.com/project/jonathandturner/rls-x6grn)
-[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Windows)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24[2].windows&colorB=lightgrey)](https://github.com/rust-lang-nursery/rust-toolstate)
-[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Linux)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24[2].linux&colorB=lightgrey)](https://github.com/rust-lang-nursery/rust-toolstate)
+[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Windows)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24[2].windows&colorB=lightgrey)](https://rust-lang-nursery.github.io/rust-toolstate/)
+[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Linux)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24[2].linux&colorB=lightgrey)](https://rust-lang-nursery.github.io/rust-toolstate/)
 
 
 


### PR DESCRIPTION
This uses awesome dynamic shields from https://shields.io and queries https://raw.githubusercontent.com/rust-lang-nursery/rust-toolstate/master/_data/latest.json tracked by our awesome [rust-toolstate](https://rust-lang-nursery.github.io/rust-toolstate/) bot.

[Rendered](https://github.com/Xanewok/rls/tree/nightly-shields)

The queries are currently `$[2].windows` and `$[2].linux` (jsonpath) respectively, because the data is an array of objects and RLS tool currently happens to be the 3rd one on the list.

@kennytm hopefully this info in README.md shouldn't be useful for too long (because we might want to block nightlies again on RLS fail etc.) but do you think it might be a good idea to change the data format to an object with tool keys `{ "rls": {...}, "clippy": {...}, ... }` to facilitate the quering (e.g. `$.rls.linux`) or do you think it's not worth the hassle?

Doesn't seem we can dynamically set the color via the dynamic JSON badge, so I hardcoded the color to grey.

@nrc @jonathandturner @alexheretic
do you think this might be useful?