### PR TITLE
Compile with newest rustc master

### DIFF
--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -29,7 +29,6 @@ use crate::build::{BufWriter, BuildResult};
 use crate::config::{ClippyPreference, Config};
 
 use std::collections::HashMap;
-use std::default::Default;
 use std::ffi::OsString;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -161,9 +160,8 @@ fn clippy_after_parse_callback(state: &mut ::rustc_driver::driver::CompileState<
     );
     registry.args_hidden = Some(Vec::new());
 
-    // TODO handle clippy toml config
-    let empty_clippy_conf = clippy_lints::Conf::default();
-    clippy_lints::register_plugins(&mut registry, &empty_clippy_conf);
+    let conf = clippy_lints::read_conf(&registry);
+    clippy_lints::register_plugins(&mut registry, &conf);
 
     let Registry {
         early_lint_passes,

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -70,8 +70,9 @@ crate fn rustc(
         let mut clippy_args = vec!["--cfg".to_owned(), r#"feature="cargo-clippy""#.to_owned()];
 
         if clippy_pref == ClippyPreference::OptIn {
-            // `OptIn`: allow clippy require `#![warn(clippy)]` override in each workspace crate
-            clippy_args.push("-Aclippy".to_owned());
+            // `OptIn`: Require explicit `#![warn(clippy::all)]` annotation in each workspace crate
+            clippy_args.push("-A".to_owned());
+            clippy_args.push("clippy::all".to_owned());
         }
 
         args.iter()


### PR DESCRIPTION
Despite recent Clippy bump in Rust, the current master doesn't compile because `clippy_lints::Conf` is private. Changed this to `clippy_lints::read_conf` like in clippy's analogous [driver.rs](https://github.com/rust-lang-nursery/rust-clippy/blob/c81d70e6bdf264c62136b571760f152be9638ec0/src/driver.rs#L102).

I believe this should detect clippy.toml on the filesystem level and the TODO comment can be removed @oli-obk @alexheretic 

Will try to pull this in https://github.com/rust-lang/rust/pull/53870 to see if RLS is fixed for the next nightlies.

cc @nrc 