### PR TITLE
Include message in dispatch error log line

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -329,7 +329,7 @@ impl<O: Output> LsService<O> {
         }
 
         if let Err(e) = self.dispatch_message(&raw_message) {
-            error!("dispatch error, {:?}", e);
+            error!("dispatch error: {:?}, message: `{}`", e, msg_string);
             self.output.failure(raw_message.id, e);
             return ServerStateChange::Break { exit_code: 101 };
         }


### PR DESCRIPTION
Avoids needing to trace log to pull out an offending json request. Will help with issues like #1038