### PR TITLE
Avoid void-params deserialize errors

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -465,4 +465,18 @@ mod test {
 
         assert_eq!(get_root_path(&params), root_path);
     }
+
+    /// Some clients send empty object params for void params requests (see #1038)
+    #[test]
+    fn parse_shutdown_object_params() {
+        let raw = RawMessage::try_parse(
+            r#"{"jsonrpc": "2.0", "id": 2, "method": "shutdown", "params": {}}"#,
+        ).ok()
+        .and_then(|x| x)
+        .expect("raw parse failed");
+
+        let _request: Request<ShutdownRequest> = raw
+            .parse_as_request()
+            .expect("Boring validation is happening");
+    }
 }


### PR DESCRIPTION
This change moves to permissive deserialisation of request void-params. Currently if a client sends a requests with non-null params, ie a `{}`, we error. But in the case the params end up as `()` we're better served just continuing.

Technically this was actually more of a pain than it seemed. With our use of generics it's not easy to tell if params _are_ `()`. Without specialisation I can't add an additional implementation for void param requests.

Instead I used `size_of<R::Params> == 0` to deduce that the params are void-type and put in a workaround.

Fixes #1038 

