### PR TITLE
Enable nightly flag for cargo

### DIFF
--- a/src/project_model.rs
+++ b/src/project_model.rs
@@ -44,6 +44,8 @@ impl ProjectModel {
     pub fn load(ws_manifest: &Path, vfs: &Vfs) -> Result<ProjectModel, failure::Error> {
         assert!(ws_manifest.ends_with("Cargo.toml"));
         let mut config = Config::default()?;
+        // Enable nightly flag for cargo(see #1043)
+        cargo::core::enable_nightly_features();
         // frozen = false, locked = false
         config.configure(0, Some(true), &None, false, false, &None, &[])?;
         let ws = Workspace::new(&ws_manifest, &config)?;


### PR DESCRIPTION
For #1043 
But I want to note here that racer has not yet implemented 2018 style path features completely(e.g. see https://github.com/racer-rust/racer/issues/916).
So to make all things work we have to do additional works on racer side.