### PR TITLE
enable crate_visibility_modifier since it is used but no longer part of 2018 edition.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@
 //! code completion, and enables renaming and refactorings.
 
 #![feature(rustc_private, integer_atomics, drain_filter)]
+#![feature(crate_visibility_modifier)] // needed for edition 2018
 #![allow(unknown_lints)]
 #![warn(clippy, rust_2018_idioms)]
 #![allow(


### PR DESCRIPTION
Needed to fix https://github.com/rust-lang/rust/pull/54057