### PR TITLE
Future-proof for #![feature(uniform_paths)].

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -12,7 +12,7 @@
 
 pub use self::cargo::make_cargo_config;
 
-use cargo::util::important_paths;
+use ::cargo::util::important_paths;
 use crate::actions::post_build::PostBuildHandler;
 use crate::actions::progress::{ProgressNotifier, ProgressUpdate};
 use crate::config::Config;


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/54011#issuecomment-419828892 for the ambiguity error being fixed.