### PR TITLE
Remove "edition" Cargo feature (it's stable now)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "rls"
 version = "0.130.5"


### PR DESCRIPTION
Gets rid of the 
```
warning: the cargo feature `edition` is now stable and is no longer necessary to be listed in the manifest
```
warning message.