### PR TITLE
Indicate a cfg(test) build in window/progress messages

### DIFF
--- a/src/build/plan.rs
+++ b/src/build/plan.rs
@@ -578,7 +578,14 @@ impl JobQueue {
             {
                 let crate_name = proc_argument_value(&job, "--crate-name").and_then(|x| x.to_str());
                 let update = match crate_name {
-                    Some(name) => ProgressUpdate::Message(name.to_owned()),
+                    Some(name) => {
+                        let cfg_test = job.get_args().iter().any(|arg| arg == "--test");
+                        ProgressUpdate::Message(if cfg_test {
+                            format!("{} cfg(test)", name)
+                        } else {
+                            name.to_owned()
+                        })
+                    }
                     None => {
                         // divide by zero is avoided by earlier assert!
                         let percentage = compiler_messages.len() as f64 / self.0.len() as f64;


### PR DESCRIPTION
Currently you get your crates cropping up a couple of times in the build progress messages. The 2nd time is building the crate with `cfg(test)`. This change helps make that clear.

Using [glyph-brush](https://github.com/alexheretic/glyph-brush) as an example:
## Before
```
window/progress {id: "progress_1", title: "Building"}
window/progress {id: "progress_1", message: "glyph_brush_layout", title: "Building"}
window/progress {id: "progress_1", message: "glyph_brush_layout", title: "Building"}
window/progress {id: "progress_1", message: "glyph_brush", title: "Building"}
window/progress {id: "progress_1", message: "glyph_brush", title: "Building"}
window/progress {id: "progress_1", message: "gfx_glyph", title: "Building"}
window/progress {id: "progress_1", message: "gfx_glyph", title: "Building"}
window/progress {id: "progress_1", message: "opengl", title: "Building"}
window/progress {id: "progress_1", message: "bench", title: "Building"}
window/progress {id: "progress_1", message: "depth", title: "Building"}
window/progress {id: "progress_1", message: "paragraph", title: "Building"}
window/progress {id: "progress_1", message: "performance", title: "Building"}
window/progress {id: "progress_1", message: "varied", title: "Building"}
window/progress {id: "progress_1", message: "gfx_noop", title: "Building"}
window/progress {done: true, id: "progress_1", title: "Building"}
```

## After
```

window/progress {id: "progress_1", title: "Building"}
window/progress {id: "progress_1", message: "glyph_brush_layout", title: "Building"}
window/progress {id: "progress_1", message: "glyph_brush_layout cfg(test)", title: "Building"}
window/progress {id: "progress_1", message: "glyph_brush", title: "Building"}
window/progress {id: "progress_1", message: "glyph_brush cfg(test)", title: "Building"}
window/progress {id: "progress_1", message: "gfx_glyph", title: "Building"}
window/progress {id: "progress_1", message: "gfx_glyph cfg(test)", title: "Building"}
window/progress {id: "progress_1", message: "opengl", title: "Building"}
window/progress {id: "progress_1", message: "bench cfg(test)", title: "Building"}
window/progress {id: "progress_1", message: "depth", title: "Building"}
window/progress {id: "progress_1", message: "paragraph", title: "Building"}
window/progress {id: "progress_1", message: "performance", title: "Building"}
window/progress {id: "progress_1", message: "varied", title: "Building"}
window/progress {id: "progress_1", message: "gfx_noop cfg(test)", title: "Building"}
window/progress {done: true, id: "progress_1", title: "Building"}
```

## Format
I went with **"$crate cfg(test)"**, but maybe **"$crate(test)"** is enough/better. Is one more like current rustc/cargo output than the other? I don't mind too much as long as I can tell it's a cfg(test) build clearly. _Also easy to change later_.