### PR TITLE
Rework cmd tests

### DIFF
--- a/tests/support/paths.rs
+++ b/tests/support/paths.rs
@@ -65,7 +65,7 @@ pub trait TestPathExt {
     fn mkdir_p(&self);
 }
 
-#[allow(redundant_closure)] // &Path is not AsRef<Path>
+#[allow(clippy::redundant_closure)] // &Path is not AsRef<Path>
 impl TestPathExt for Path {
     /* Technically there is a potential race condition, but we don't
      * care all that much for our tests


### PR DESCRIPTION
* Rewrite all _tests/tests.rs_ "cmd" tests
* <s>cargo update</s>
* cmd test wait-for-rls-stdout timeout reduced 300 -> 30

The cmd tests aren't good enough because they don't fail very usefully. They either work or block for 300 seconds then say nothing. For example the build is currently failing in master, but can anyone see why?

The new code has
* Explicit timeouts for any blocking calls, meaning it's easy to see where we wait for stdout.
* More accurate dynamic json assertions. 
   ```rust
   assert_eq!(json["method"], "window/progress");
   assert_eq!(json["params"]["title"], "Indexing");
   ```
* Removed all but one test checking _window/progress_ messages.
* Removed outer timeout/closure which obfuscates test panics & adds complexity.

The `RlsHandle` now uses a thread to eagerly read stdout, and eprints that stdout when an assertion fails. This stdout allows us to debug the tests when they fail. To see the improvement here is the failure output of the tests with this change:

```
running 4 tests
test cmd_test_infer_bin ... FAILED
test cmd_test_complete_self_crate_name ... ok
test cmd_test_simple_workspace ... ok
test cmd_changing_workspace_lib_retains_bin_diagnostics ... ok

failures:

---- cmd_test_infer_bin stdout ----
thread 'cmd_test_infer_bin' panicked at 'assertion failed: `(left == right)`
  left: `String("window/showMessage")`,
 right: `"textDocument/publishDiagnostics"`', tests/tests.rs:58:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
---rls-stdout---
Content-Length: 607

{"jsonrpc":"2.0","id":0,"result":{"capabilities":{"textDocumentSync":2,"hoverProvider":true,"completionProvider":{"resolveProvider":true,"triggerCharacters":[".",":"]},"definitionProvider":true,"implementationProvider":true,"referencesProvider":true,"documentHighlightProvider":true,"documentSymbolProvider":true,"workspaceSymbolProvider":true,"codeActionProvider":true,"codeLensProvider":{"resolveProvider":false},"documentFormattingProvider":true,"documentRangeFormattingProvider":false,"renameProvider":true,"executeCommandProvider":{"commands":["rls.applySuggestion-29146","rls.deglobImports-29146"]}}}}Content-Length: 92

{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_1","title":"Building"}}Content-Length: 104

{"jsonrpc":"2.0","method":"window/progress","params":{"done":true,"id":"progress_1","title":"Building"}}Content-Length: 92

{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_0","title":"Indexing"}}Content-Length: 157

{"jsonrpc":"2.0","method":"window/showMessage","params":{"message":"Cargo failed: failed to parse manifest at `/home/alex/project/rls/Cargo.toml`","type":1}}Content-Length: 104

{"jsonrpc":"2.0","method":"window/progress","params":{"done":true,"id":"progress_0","title":"Indexing"}}
---------------


failures:
    cmd_test_infer_bin

test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

Once you have this output it's fairly easy to see **Cargo failed: failed to parse manifest at `/home/alex/project/rls/Cargo.toml`**. The recent update (#1058) to the main Cargo.toml <s>is</s> was interfering with the cmd tests.

And all this with ~100 lines net removed :)