### PR TITLE
Revert "Remove "edition" Cargo feature (it's stable now)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition"]
+
 [package]
 name = "rls"
 version = "0.130.5"


### PR DESCRIPTION
This reverts commit a34334dcdd291f4fc42cd910a098a95f1f53a4a2.

The problem is that rustc uses an older cargo version to bootstrap.
This cargo version does not have the edition feature stabilized yet.

Clippy also had this problem.

cc @Xanewok 