### PR TITLE
Improve cmd test timeout reliability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,10 @@ install: |
     # Required for Racer autoconfiguration
     rustup component add rust-src
     rustup component add rust-analysis
-script: |
-  #!/bin/bash
-  set -e
-  cargo build -v
-  cargo test -v
-  set +e
+script:
+- cargo build -v
+- cargo test -v
 env:
   global:
-    - RUSTFLAGS=--cfg=enable_tooltip_tests
+  - RUSTFLAGS=--cfg=enable_tooltip_tests
+  - RUST_BACKTRACE=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -134,7 +134,7 @@ dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "clippy_lints"
 version = "0.0.212"
-source = "git+https://github.com/rust-lang-nursery/rust-clippy?rev=e69fe2fb19b7b2f3b07fe1178c536810dabf896f#e69fe2fb19b7b2f3b07fe1178c536810dabf896f"
+source = "git+https://github.com/rust-lang-nursery/rust-clippy?rev=93de5fc6c87ea775730cddcea672a870130cf9fe#93de5fc6c87ea775730cddcea672a870130cf9fe"
 dependencies = [
  "cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -230,7 +230,7 @@ dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -648,7 +648,7 @@ dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -666,11 +666,11 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -809,13 +809,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num-derive"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "racer"
-version = "2.1.6"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1095,7 +1095,7 @@ version = "0.130.5"
 dependencies = [
  "cargo 0.32.0 (git+https://github.com/rust-lang/cargo?rev=ad6e5c0037d88602a1c95051e42b392ed5ffcbe8)",
  "cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.212 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=e69fe2fb19b7b2f3b07fe1178c536810dabf896f)",
+ "clippy_lints 0.0.212 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=93de5fc6c87ea775730cddcea672a870130cf9fe)",
  "crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1106,7 +1106,7 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordslice 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "racer 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "racer 2.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1118,11 +1118,11 @@ dependencies = [
  "rls-vfs 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_tools_util 0.1.0 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=e69fe2fb19b7b2f3b07fe1178c536810dabf896f)",
+ "rustc_tools_util 0.1.0 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=93de5fc6c87ea775730cddcea672a870130cf9fe)",
  "rustfmt-nightly 0.99.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1328,7 +1328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rustc_tools_util"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang-nursery/rust-clippy?rev=e69fe2fb19b7b2f3b07fe1178c536810dabf896f#e69fe2fb19b7b2f3b07fe1178c536810dabf896f"
+source = "git+https://github.com/rust-lang-nursery/rust-clippy?rev=93de5fc6c87ea775730cddcea672a870130cf9fe#93de5fc6c87ea775730cddcea672a870130cf9fe"
 
 [[package]]
 name = "rustc_version"
@@ -1347,7 +1347,7 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1370,7 +1370,7 @@ dependencies = [
  "rustc-ap-syntax_pos 263.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1434,7 +1434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1761,7 +1761,7 @@ dependencies = [
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
-"checksum clippy_lints 0.0.212 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=e69fe2fb19b7b2f3b07fe1178c536810dabf896f)" = "<none>"
+"checksum clippy_lints 0.0.212 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=93de5fc6c87ea775730cddcea672a870130cf9fe)" = "<none>"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
 "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
@@ -1832,7 +1832,7 @@ dependencies = [
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
-"checksum num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d2c31b75c36a993d30c7a13d70513cb93f02acafdd5b7ba250f9b0e18615de7"
+"checksum num-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8af1847c907c2f04d7bfd572fb25bbb4385c637fe5be163cf2f8c5d778fe1e7d"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum opener 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "176cd8eadff5ef9fa5c6d19452535662c02c6bf29b3d594a3fc01f749bb24c94"
@@ -1853,7 +1853,7 @@ dependencies = [
 "checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
-"checksum racer 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "99e820b7f7701c834c3f6f8226f388c19c0ea948a3ef79ddc96aa7398b5ba87a"
+"checksum racer 2.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0beefbfaed799c3554021a48856113ad53862311395f6d75376192884ba5fbe6"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
@@ -1885,7 +1885,7 @@ dependencies = [
 "checksum rustc-rayon-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40f06724db71e18d68b3b946fdf890ca8c921d9edccc1404fdfdb537b0d12649"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb"
-"checksum rustc_tools_util 0.1.0 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=e69fe2fb19b7b2f3b07fe1178c536810dabf896f)" = "<none>"
+"checksum rustc_tools_util 0.1.0 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=93de5fc6c87ea775730cddcea672a870130cf9fe)" = "<none>"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustfix 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "756567f00f7d89c9f89a5c401b8b1caaa122e27240b9eaadd0bb52ee0b680b1b"
 "checksum rustfmt-nightly 0.99.5 (registry+https://github.com/rust-lang/crates.io-index)" = "28a88113365d242de0f50f2467e6012c69333c685b10636ff8327386b0a6a3cd"
@@ -1899,7 +1899,7 @@ dependencies = [
 "checksum serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "84257ccd054dc351472528c8587b4de2dbf0dc0fe2e634030c1a90bfdacebaa9"
 "checksum serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "31569d901045afbff7a9479f793177fe9259819aff10ab4f89ef69bbc5f567fe"
 "checksum serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "190e9765dcedb56be63b6e0993a006c7e3b071a016a304736e4a315dc01fb142"
-"checksum serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "bb47a3d5c84320222f66d7db21157c4a7407755de41798f9b4c1c40593397b1a"
+"checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
 "checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
 "checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
@@ -1907,7 +1907,7 @@ dependencies = [
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
-"checksum syn 0.15.7 (registry+https://github.com/rust-lang/crates.io-index)" = "455a6ec9b368f8c479b0ae5494d13b22dc00990d2f00d68c9dc6a2dc4f17f210"
+"checksum syn 0.15.8 (registry+https://github.com/rust-lang/crates.io-index)" = "356d1c5043597c40489e9af2d2498c7fefc33e99b7d75b43be336c8a59b3e45e"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum tar 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "83b0d14b53dbfd62681933fadd651e815f99e6084b649e049ab99296e05ab3de"
 "checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 [dependencies]
 cargo = { git = "https://github.com/rust-lang/cargo", rev = "ad6e5c0037d88602a1c95051e42b392ed5ffcbe8" }
 cargo_metadata = "0.6"
-clippy_lints = { git = "https://github.com/rust-lang-nursery/rust-clippy", rev = "e69fe2fb19b7b2f3b07fe1178c536810dabf896f", optional = true }
+clippy_lints = { git = "https://github.com/rust-lang-nursery/rust-clippy", rev = "93de5fc6c87ea775730cddcea672a870130cf9fe", optional = true }
 env_logger = "0.5"
 failure = "0.1.1"
 itertools = "0.7.3"
@@ -31,7 +31,7 @@ rls-data = { version = "0.18.1", features = ["serialize-serde", "serialize-rustc
 rls-rustc = "0.5.0"
 rls-span = { version = "0.4", features = ["serialize-serde"] }
 rls-vfs = "0.4.6"
-rustc_tools_util = { git = "https://github.com/rust-lang-nursery/rust-clippy", rev = "e69fe2fb19b7b2f3b07fe1178c536810dabf896f" }
+rustc_tools_util = { git = "https://github.com/rust-lang-nursery/rust-clippy", rev = "93de5fc6c87ea775730cddcea672a870130cf9fe" }
 rustfmt-nightly = "0.99.5"
 rustc-serialize = "0.3"
 serde = "1.0"
@@ -49,7 +49,7 @@ crossbeam-channel = "0.2.3"
 rustc-workspace-hack = "1.0.0"
 
 [build-dependencies]
-rustc_tools_util = { git = "https://github.com/rust-lang-nursery/rust-clippy", rev = "e69fe2fb19b7b2f3b07fe1178c536810dabf896f" }
+rustc_tools_util = { git = "https://github.com/rust-lang-nursery/rust-clippy", rev = "93de5fc6c87ea775730cddcea672a870130cf9fe" }
 
 [features]
 default = ["clippy"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
   global:
     PROJECT_NAME: rls
     RUSTFLAGS: --cfg=enable_tooltip_tests
+    RUST_BACKTRACE: 1
   matrix:
     - TARGET: i686-pc-windows-msvc
       CHANNEL: nightly

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -229,11 +229,10 @@ impl RlsHandle {
     ///
     /// Also uses `timeout * 10` from the `call_start` as an absolute limit.
     fn within_timeout(&self, call_start: Instant, timeout: Duration) -> bool {
-        let call_or_stdout_elapsed = call_start
-            .elapsed()
-            .min(self.stdout.lock().unwrap().1.elapsed());
+        let call_elapsed = call_start.elapsed();
+        let stdout_elapsed = self.stdout.lock().unwrap().1.elapsed();
 
-        call_or_stdout_elapsed < timeout && call_start.elapsed() < timeout * 10
+        call_elapsed.min(stdout_elapsed) < timeout && call_elapsed < timeout * 10
     }
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -25,7 +25,6 @@ use self::paths::TestPathExt;
 
 pub mod paths;
 
-
 /// Parse valid LSP stdout into a list of json messages
 pub fn parse_messages(stdout: &str) -> Vec<String> {
     let mut messages = vec![];
@@ -40,7 +39,8 @@ pub fn parse_messages(stdout: &str) -> Vec<String> {
             .and_then(|s| match s.trim().parse() {
                 Ok(s) => Some(s),
                 Err(err) => panic!("Unexpected Content-Length {:?}: {}", s.trim(), err),
-            }).unwrap_or(0);
+            })
+            .unwrap_or(0);
     }
 
     messages
@@ -49,15 +49,15 @@ pub fn parse_messages(stdout: &str) -> Vec<String> {
 pub struct RlsHandle {
     child: Child,
     stdin: ChildStdin,
-    stdout: Arc<Mutex<String>>,
-    // stdout: BufReader<ChildStdout>,
+    /// stdout from rls along with the last write instant
+    stdout: Arc<Mutex<(String, Instant)>>,
 }
 
 impl RlsHandle {
     pub fn new(mut child: Child) -> RlsHandle {
         let stdin = mem::replace(&mut child.stdin, None).unwrap();
         let child_stdout = mem::replace(&mut child.stdout, None).unwrap();
-        let stdout: Arc<Mutex<String>> = Arc::default();
+        let stdout = Arc::new(Mutex::new((String::new(), Instant::now())));
         let processed_stdout = Arc::clone(&stdout);
 
         thread::spawn(move || {
@@ -73,7 +73,9 @@ impl RlsHandle {
 
                 buf = match String::from_utf8(buf) {
                     Ok(s) => {
-                        processed_stdout.lock().unwrap().push_str(&s);
+                        let mut guard = processed_stdout.lock().unwrap();
+                        guard.0.push_str(&s);
+                        guard.1 = Instant::now();
                         vec![0; 1024]
                     }
                     Err(e) => {
@@ -141,7 +143,8 @@ impl RlsHandle {
 
     /// Blocks until at least `count` messages have appearing in stdout.
     ///
-    /// Panics if the timeout is reached.
+    /// Panics if the timeout has been exceeded from call time **and** exceeded
+    /// from the last rls-stdout write instant.
     pub fn wait_until<P>(&self, stdout_predicate: P, timeout: Duration) -> RlsStdout
     where
         P: Fn(&RlsStdout) -> bool,
@@ -150,17 +153,19 @@ impl RlsHandle {
         let mut stdout_len = 0;
         loop {
             let stdout = self.stdout();
-            if stdout.0.len() != stdout_len {
+            if stdout.out.len() != stdout_len {
                 if stdout_predicate(&stdout) {
                     break stdout;
                 }
-                stdout_len = stdout.0.len();
+                stdout_len = stdout.out.len();
             }
 
             assert!(
-                start.elapsed() < timeout,
-                "Timed out waiting {:?} for predicate",
-                timeout
+                start.elapsed().min(stdout.last_write.elapsed()) < timeout
+                    && start.elapsed() < timeout * 10,
+                "Timed out waiting {:?} for predicate, last rls-stdout write {:.1?} ago",
+                timeout,
+                stdout.last_write.elapsed(),
             );
 
             thread::sleep(Duration::from_millis(10));
@@ -179,7 +184,8 @@ impl RlsHandle {
                     .filter(|json| {
                         json["params"]["title"] == "Indexing"
                             && json["params"]["done"].as_bool().unwrap_or(false)
-                    }).count()
+                    })
+                    .count()
                     >= n
             },
             timeout,
@@ -187,7 +193,11 @@ impl RlsHandle {
     }
 
     pub fn stdout(&self) -> RlsStdout {
-        RlsStdout(self.stdout.lock().unwrap().clone())
+        let stdout = self.stdout.lock().unwrap();
+        RlsStdout {
+            out: stdout.0.clone(),
+            last_write: stdout.1,
+        }
     }
 
     /// Sends shutdown messages, assets successful exit of process and returns stdout
@@ -196,14 +206,15 @@ impl RlsHandle {
         self.notify("exit", None).unwrap();
 
         let start = Instant::now();
-
-        while start.elapsed() < timeout {
+        while start.elapsed().min(self.stdout.lock().unwrap().1.elapsed()) < timeout
+            && start.elapsed() < timeout * 10
+        {
             if let Some(ecode) = self
                 .child
                 .try_wait()
                 .expect("failed to wait on child rls process")
             {
-                assert!(ecode.success());
+                assert!(ecode.success(), "rls exit code {}", ecode);
                 return self.stdout();
             }
         }
@@ -214,7 +225,10 @@ impl RlsHandle {
 impl Drop for RlsHandle {
     fn drop(&mut self) {
         if thread::panicking() {
-            eprintln!("---rls-stdout---\n{}\n---------------", self.stdout().0);
+            eprintln!(
+                "---rls-stdout---\n{}\n---------------",
+                self.stdout.lock().unwrap().0
+            );
         }
 
         let _ = self.child.kill();
@@ -222,14 +236,17 @@ impl Drop for RlsHandle {
 }
 
 #[derive(Debug, Clone)]
-pub struct RlsStdout(String);
+pub struct RlsStdout {
+    out: String,
+    last_write: Instant,
+}
 
 impl RlsStdout {
     /// Parse into a list of string messages.
     ///
     /// The last one should be the shutdown response.
     pub fn to_string_messages(&self) -> Vec<String> {
-        parse_messages(&self.0)
+        parse_messages(&self.out)
     }
     /// Parse into json values.
     ///

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -33,7 +33,8 @@ fn cmd_test_infer_bin() {
                     println!("Hello world!");
                 }
             "#,
-        ).build();
+        )
+        .build();
 
     let root_path = p.root();
     let mut rls = p.spawn_rls();
@@ -45,7 +46,8 @@ fn cmd_test_infer_bin() {
             "rootPath": root_path,
             "capabilities": {}
         })),
-    ).unwrap();
+    )
+    .unwrap();
 
     let json: Vec<_> = rls
         .wait_until_done_indexing(RLS_TIMEOUT)
@@ -76,7 +78,8 @@ fn cmd_test_simple_workspace() {
                 "member_bin",
                 ]
             "#,
-        ).file(
+        )
+        .file(
             "Cargo.lock",
             r#"
                 [root]
@@ -90,7 +93,8 @@ fn cmd_test_simple_workspace() {
                 "member_lib 0.1.0",
                 ]
             "#,
-        ).file(
+        )
+        .file(
             "member_bin/Cargo.toml",
             r#"
                 [package]
@@ -101,7 +105,8 @@ fn cmd_test_simple_workspace() {
                 [dependencies]
                 member_lib = { path = "../member_lib" }
             "#,
-        ).file(
+        )
+        .file(
             "member_bin/src/main.rs",
             r#"
                 extern crate member_lib;
@@ -110,7 +115,8 @@ fn cmd_test_simple_workspace() {
                     let a = member_lib::MemberLibStruct;
                 }
             "#,
-        ).file(
+        )
+        .file(
             "member_lib/Cargo.toml",
             r#"
                 [package]
@@ -120,7 +126,8 @@ fn cmd_test_simple_workspace() {
 
                 [dependencies]
             "#,
-        ).file(
+        )
+        .file(
             "member_lib/src/lib.rs",
             r#"
                 pub struct MemberLibStruct;
@@ -134,7 +141,8 @@ fn cmd_test_simple_workspace() {
                     }
                 }
             "#,
-        ).build();
+        )
+        .build();
 
     let root_path = p.root();
     let mut rls = p.spawn_rls();
@@ -146,7 +154,8 @@ fn cmd_test_simple_workspace() {
             "rootPath": root_path,
             "capabilities": {}
         })),
-    ).unwrap();
+    )
+    .unwrap();
 
     let json: Vec<_> = rls
         .wait_until_done_indexing(RLS_TIMEOUT)
@@ -187,9 +196,13 @@ fn cmd_test_simple_workspace() {
     assert_eq!(json[10]["params"]["done"], true);
     assert_eq!(json[10]["params"]["title"], "Indexing");
 
-    let json: Vec<_> = rls.shutdown(RLS_TIMEOUT).to_json_messages().collect();
+    let json = rls
+        .shutdown(RLS_TIMEOUT)
+        .to_json_messages()
+        .nth(11)
+        .expect("No shutdown response received");
 
-    assert_eq!(json[11]["id"], 99999);
+    assert_eq!(json["id"], 99999);
 }
 
 #[test]
@@ -204,7 +217,8 @@ fn cmd_changing_workspace_lib_retains_bin_diagnostics() {
                 "binary",
                 ]
             "#,
-        ).file(
+        )
+        .file(
             "library/Cargo.toml",
             r#"
                 [package]
@@ -212,7 +226,8 @@ fn cmd_changing_workspace_lib_retains_bin_diagnostics() {
                 version = "0.1.0"
                 authors = ["Example <rls@example.com>"]
             "#,
-        ).file(
+        )
+        .file(
             "library/src/lib.rs",
             r#"
                 pub fn fetch_u32() -> u32 {
@@ -227,7 +242,8 @@ fn cmd_changing_workspace_lib_retains_bin_diagnostics() {
                     }
                 }
             "#,
-        ).file(
+        )
+        .file(
             "binary/Cargo.toml",
             r#"
                 [package]
@@ -238,7 +254,8 @@ fn cmd_changing_workspace_lib_retains_bin_diagnostics() {
                 [dependencies]
                 library = { path = "../library" }
             "#,
-        ).file(
+        )
+        .file(
             "binary/src/main.rs",
             r#"
                 extern crate library;
@@ -247,7 +264,8 @@ fn cmd_changing_workspace_lib_retains_bin_diagnostics() {
                     let val: u32 = library::fetch_u32();
                 }
             "#,
-        ).build();
+        )
+        .build();
 
     let root_path = p.root();
     let mut rls = p.spawn_rls();
@@ -259,7 +277,8 @@ fn cmd_changing_workspace_lib_retains_bin_diagnostics() {
             "rootPath": root_path,
             "capabilities": {}
         })),
-    ).unwrap();
+    )
+    .unwrap();
 
     let to_publish_messages = |stdout: &RlsStdout| {
         stdout
@@ -309,7 +328,8 @@ fn cmd_changing_workspace_lib_retains_bin_diagnostics() {
                     "version": 0
                 }
             })),
-    ).unwrap();
+    )
+    .unwrap();
 
     let stdout = rls.wait_until_done_indexing_n(2, RLS_TIMEOUT);
 
@@ -367,7 +387,8 @@ fn cmd_changing_workspace_lib_retains_bin_diagnostics() {
                     "version": 1
                 }
             })),
-    ).unwrap();
+    )
+    .unwrap();
 
     let stdout = rls.wait_until_done_indexing_n(3, RLS_TIMEOUT);
     let lib_diagnostic = rfind_diagnostics_with_uri(&stdout, "library/src/lib.rs");
@@ -393,7 +414,8 @@ fn cmd_test_complete_self_crate_name() {
                 [workspace]
                 members = ["library"]
             "#,
-        ).file(
+        )
+        .file(
             "library/Cargo.toml",
             r#"
                 [package]
@@ -401,18 +423,21 @@ fn cmd_test_complete_self_crate_name() {
                 version = "0.1.0"
                 authors = ["Example <rls@example.com>"]
             "#,
-        ).file(
+        )
+        .file(
             "library/src/lib.rs",
             r#"
                 pub fn function() -> usize { 5 }
             "#,
-        ).file(
+        )
+        .file(
             "library/tests/test.rs",
             r#"
                    extern crate library;
                    use library::~
             "#,
-        ).build();
+        )
+        .build();
 
     let root_path = p.root();
     let mut rls = p.spawn_rls();
@@ -424,7 +449,8 @@ fn cmd_test_complete_self_crate_name() {
             "rootPath": root_path,
             "capabilities": {}
         })),
-    ).unwrap();
+    )
+    .unwrap();
 
     let stdout = rls.wait_until_done_indexing(RLS_TIMEOUT);
 
@@ -461,7 +487,8 @@ fn cmd_test_complete_self_crate_name() {
                 "version": 1
             }
         })),
-    ).unwrap();
+    )
+    .unwrap();
 
     let stdout = rls.wait_until(
         |stdout| {


### PR DESCRIPTION
This change attempts to have cmd test timeouts indicate more confidently that something went wrong, rather than just the test runner was running slowly.

Along with recording stdout from rls we now also record the instant of the last stdout write. This allows us to measure timeout duration from call time **or** last stdout write time (whichever is smaller).

This helps eliminates the niggling possibility that the timeout was just a little too small, and rls was writing stuff but just hadn't got to the point we expected yet, as rls would have definitely written nothing for an entire timeout duration without other interaction.

So a timeout error looks like this: 
```
thread 'cmd_test_complete_self_crate_name' panicked at 'Timed out waiting 30s for predicate, last rls-stdout write 30.0s ago', tests/support/mod.rs:163:13
note: Run with `RUST_BACKTRACE=1` for a backtrace.
---rls-stdout---
Content-Length: 607

{"jsonrpc":"2.0","id":0,"result":{"capabilities":{"textDocumentSync":2,"hoverProvider":true,"completionProvider":{"resolveProvider":true,"triggerCharacters":[".",":"]},"definitionProvider":true,"implementationProvider":true,"referencesProvider":true,"documentHighlightProvider":true,"documentSymbolProvider":true,"workspaceSymbolProvider":true,"codeActionProvider":true,"codeLensProvider":{"resolveProvider":false},"documentFormattingProvider":true,"documentRangeFormattingProvider":false,"renameProvider":true,"executeCommandProvider":{"commands":["rls.applySuggestion-18987","rls.deglobImports-18987"]}}}}Content-Length: 92

{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_1","title":"Building"}}Content-Length: 112

{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_1","message":"library","title":"Building"}}Content-Length: 122

{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_1","message":"library cfg(test)","title":"Building"}}Content-Length: 119

{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_1","message":"test cfg(test)","title":"Building"}}Content-Length: 104

{"jsonrpc":"2.0","method":"window/progress","params":{"done":true,"id":"progress_1","title":"Building"}}Content-Length: 92

{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_0","title":"Indexing"}}Content-Length: 364

{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"diagnostics":[{"code":"","message":"expected identifier, found `~`\n\nexpected identifier","range":{"end":{"character":33,"line":2},"start":{"character":32,"line":2}},"severity":1,"source":"rustc"}],"uri":"file:///home/alex/project/rls/target/rlsit/t2/ws_with_test_dir/library/tests/test.rs"}}Content-Length: 104

{"jsonrpc":"2.0","method":"window/progress","params":{"done":true,"id":"progress_0","title":"Indexing"}}Content-Length: 103

{"jsonrpc":"2.0","id":0,"result":[{"label":"function","kind":3,"detail":"pub fn function() -> usize"}]}
---------------
```

The error now says ***Timed out waiting 30s for predicate, last rls-stdout write 30.0s ago***. Unlike before we can immediately doubt that the runner was simply too slow and instead try to find the real causes.