### PR TITLE
Propagate cargo errors as manifest diagnostics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ env:
   global:
   - RUSTFLAGS=--cfg=enable_tooltip_tests
   - RUST_BACKTRACE=1
+  - RLS_TEST_WAIT_FOR_AGES=1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
     PROJECT_NAME: rls
     RUSTFLAGS: --cfg=enable_tooltip_tests
     RUST_BACKTRACE: 1
+    RLS_TEST_WAIT_FOR_AGES: 1
   matrix:
     - TARGET: i686-pc-windows-msvc
       CHANNEL: nightly

--- a/src/actions/post_build.rs
+++ b/src/actions/post_build.rs
@@ -99,7 +99,7 @@ impl PostBuildHandler {
                     warn!("Not reporting: {} {:?}", error, stdout);
                 } else {
                     let stdout_msg = if stdout.is_empty() {
-                        "".to_string()
+                        stdout
                     } else {
                         format!("({})", stdout)
                     };

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -15,7 +15,7 @@ pub use self::cargo::make_cargo_config;
 use self::environment::EnvironmentLock;
 use self::plan::{Plan as BuildPlan, WorkStatus};
 
-use ::cargo::util::important_paths;
+use ::cargo::util::{CargoError, important_paths};
 use crate::actions::post_build::PostBuildHandler;
 use crate::actions::progress::{ProgressNotifier, ProgressUpdate};
 use crate::config::Config;
@@ -110,6 +110,12 @@ pub enum BuildResult {
     /// 0: error cause
     /// 1: command which caused the error
     Err(String, Option<String>),
+    /// Cargo failed.
+    CargoError {
+        error: CargoError,
+        stdout: String,
+        manifest_path: Option<PathBuf>,
+    },
 }
 
 /// Priority for a build request.

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -310,15 +310,13 @@ pub struct Project {
 #[must_use]
 #[derive(PartialEq, Clone)]
 pub struct ProjectBuilder {
-    name: String,
     root: Project,
     files: Vec<FileBuilder>,
 }
 
 impl ProjectBuilder {
-    pub fn new(name: &str, root: PathBuf) -> ProjectBuilder {
+    pub fn new(root: PathBuf) -> ProjectBuilder {
         ProjectBuilder {
-            name: name.to_string(),
             root: Project { root },
             files: vec![],
         }
@@ -372,7 +370,7 @@ impl Project {
 
 // Generates a project layout
 pub fn project(name: &str) -> ProjectBuilder {
-    ProjectBuilder::new(name, paths::root().join(name))
+    ProjectBuilder::new(paths::root().join(name))
 }
 
 // Path to cargo executables


### PR DESCRIPTION
Instead of handling some cargo errors with the message _"Error compiling dependent crate"_ we'll now propagate the cargo error and create a root manifest diagnostic with full causal details of it.

* Having cargo error details helps users figure out why the build is failing, as highlighted in #1069
* Using a diagnostic allows us more space to write the full error, as well as avoiding spam issues with _showMessage_. Cargo error diagnostics fit in with the other diagnostics.

## In action
![](https://user-images.githubusercontent.com/2331607/46507758-0e61a380-c832-11e8-8ee9-467f210ce2cb.gif)

## Limitations
* We create a single diagnostic covering the entire of the root manifest. So an issue with a certain dependency isn't very accurately targeted currently as the whole manifest is flagged. More accurate locations are not currently included in cargo errors, though we may be able to infer them.
* We use the root manifest even if the error is really to do with a workspace child manifest. Again we may later be able to infer this.
* Unlike other diagnostics the manifest must be saved before a new cargo run. As I understand it this is because we can't pass the Vfs into cargo.

Resolves #1069 as the diagnostic will be updated & reported every build instead of ignored.
Relates to #1078 as cargo error information is now, in most cases, included in the messaging & diagnostics.
Relates to #785
