### PR TITLE
Fix std::sync hover doc expectation

### DIFF
--- a/test_data/hover/save_data/test_tooltip_mod_use_external.rs.0014_012.json
+++ b/test_data/hover/save_data/test_tooltip_mod_use_external.rs.0014_012.json
@@ -5,12 +5,11 @@
     "col": 12
   },
   "data": {
-    "Ok": [
-      {
+    "Ok": [{
         "language": "rust",
         "value": "libstd/sync/mod.rs"
       },
-      "Useful synchronization primitives.\n\nThis module contains useful safe and unsafe synchronization primitives.\nMost of the primitives in this module do not provide any sort of locking\nand/or blocking at all, but rather provide the necessary tools to build\nother types of concurrent primitives."
+      "Useful synchronization primitives.\n\n## The need for synchronization\n\nConceptually, a Rust program is a series of operations which will\nbe executed on a computer. The timeline of events happening in the\nprogram is consistent with the order of the operations in the code."
     ]
   }
 }

--- a/test_data/hover/save_data/test_tooltip_mod_use_external.rs.0015_012.json
+++ b/test_data/hover/save_data/test_tooltip_mod_use_external.rs.0015_012.json
@@ -5,12 +5,11 @@
     "col": 12
   },
   "data": {
-    "Ok": [
-      {
+    "Ok": [{
         "language": "rust",
         "value": "libstd/sync/mod.rs"
       },
-      "Useful synchronization primitives.\n\nThis module contains useful safe and unsafe synchronization primitives.\nMost of the primitives in this module do not provide any sort of locking\nand/or blocking at all, but rather provide the necessary tools to build\nother types of concurrent primitives."
+      "Useful synchronization primitives.\n\n## The need for synchronization\n\nConceptually, a Rust program is a series of operations which will\nbe executed on a computer. The timeline of events happening in the\nprogram is consistent with the order of the operations in the code."
     ]
   }
 }


### PR DESCRIPTION
Fixes hover failing `std::sync` tests after doc change. I also added _starts_with_ testing support, rather than full equality testing which will make the tests a little less fragile.