### PR TITLE
Detect manifest diagnostic position for toml::de::Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,7 @@ dependencies = [
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ walkdir = "2.1"
 regex = "1"
 ordslice = "0.3"
 crossbeam-channel = "0.2.3"
+toml = "0.4"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -835,3 +835,60 @@ fn cmd_dependency_typo_and_fix() {
 
     rls.shutdown(rls_timeout());
 }
+
+/// Tests correct positioning of a toml parse error, use of `==` instead of `=`.
+#[test]
+fn cmd_invalid_toml_manifest() {
+    let project = project("invalid_toml")
+        .file(
+            "Cargo.toml",
+            r#"[package]
+            name = "probably_valid"
+            version == "0.1.0"
+            authors = ["alexheretic@gmail.com"]
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() {
+                    println!("Hello world!");
+                }
+            "#,
+        )
+        .build();
+    let root_path = project.root();
+    let mut rls = project.spawn_rls();
+
+    rls.request(
+        0,
+        "initialize",
+        Some(json!({
+            "rootPath": root_path,
+            "capabilities": {}
+        })),
+    )
+    .unwrap();
+
+    let publish = rls
+        .wait_until_done_indexing(rls_timeout())
+        .to_json_messages()
+        .rfind(|m| m["method"] == "textDocument/publishDiagnostics")
+        .expect("No publishDiagnostics");
+
+    let diags = &publish["params"]["diagnostics"];
+    assert_eq!(diags.as_array().unwrap().len(), 1);
+    assert_eq!(diags[0]["severity"], 1);
+    assert!(
+        diags[0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("failed to parse manifest")
+    );
+    assert_eq!(
+        diags[0]["range"],
+        json!({ "start": { "line": 2, "character": 21 }, "end": { "line": 2, "character": 22 }})
+    );
+
+    rls.shutdown(rls_timeout());
+}


### PR DESCRIPTION
This is a follow up to #1079 introducing diagnostic positioning for toml parse errors.

## In action
![](https://user-images.githubusercontent.com/2331607/46600293-a20ccb80-cae1-11e8-859d-3db8f33f8ffa.png)

This is possible as these errors already include a `toml::de::Error::line_col` method.

## Issues
As in #1079 we're still assuming root manifest, so if the toml error is from a child manifest in the workspace this error will be misleading. However, perhaps no more misleading than one covering the entire of the root manifest.