### PR TITLE
Bump dependencies that are compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,7 @@ dependencies = [
  "rls-data 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-rustc 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-vfs 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-vfs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_tools_util 0.1.0 (git+https://github.com/rust-lang-nursery/rust-clippy?rev=5afdf8b78507ddf015d192858aef56e72c17de16)",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "rls-vfs"
-version = "0.4.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1918,7 +1918,7 @@ dependencies = [
 "checksum rls-data 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a209ce46bb52813cbe0786a7baadc0c1a3f5543ef93f179eda3b841ed72cf2e"
 "checksum rls-rustc 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9dba7390427aefa953608429701e3665192ca810ba8ae09301e001b7c7bed0"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
-"checksum rls-vfs 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ecbc8541b4c341d6271eae10f869dd9d36db871afe184f5b6f9bffbd6ed0373f"
+"checksum rls-vfs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcc93379d5ce372822a5928d19687e143f9e66ecda8ab8b0c721462ea3ba6f47"
 "checksum rustc-ap-arena 274.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "866fda692855b38f9d6562f0e952c75c6ebe4032d7dd63c608a88e7c4d3f8087"
 "checksum rustc-ap-rustc_cratesio_shim 274.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6c2343e11a97b4eb3bee29cd5f9314ea409a87baee5d3fec8d1516d1633412e"
 "checksum rustc-ap-rustc_data_structures 274.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b88f905f7ab99bf14220a3a87eff60ec143af8136fd0ca8573641c78be532ec8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ rls-blacklist = "0.1.2"
 rls-data = { version = "0.18.1", features = ["serialize-serde", "serialize-rustc"] }
 rls-rustc = "0.5.0"
 rls-span = { version = "0.4", features = ["serialize-serde"] }
-rls-vfs = "0.4.6"
+rls-vfs = "0.6"
 rustc_tools_util = { git = "https://github.com/rust-lang-nursery/rust-clippy", rev = "5afdf8b78507ddf015d192858aef56e72c17de16" }
 rustfmt-nightly = "0.99.6"
 rustc-serialize = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-url = "1.1.0"
-walkdir = "2.1"
+url = "1"
+walkdir = "2"
 regex = "1"
 ordslice = "0.3"
 crossbeam-channel = "0.2.3"


### PR DESCRIPTION
Those dependencies required no code changes for update. The changes
are:

 - rls-vfs: 0.4.6 -> 0.6.0
 - url: 1.1.0 -> 1.7.1
 - walkdir: 2.1 -> 2.2.5

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>