### PR TITLE
Ci testing: Retry completions on empty response

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -191,6 +191,19 @@ impl RlsHandle {
         )
     }
 
+    /// Blocks until a json message has `json["id"] == id`.
+    ///
+    /// Returns the json message.
+    pub fn wait_until_json_id(&self, id: u64, timeout: Duration) -> serde_json::Value {
+        self.wait_until(
+            |stdout| stdout.to_json_messages().any(|json| json["id"] == id),
+            timeout,
+        )
+        .to_json_messages()
+        .rfind(|json| json["id"] == id)
+        .unwrap()
+    }
+
     pub fn stdout(&self) -> RlsStdout {
         let stdout = self.stdout.lock().unwrap();
         RlsStdout {


### PR DESCRIPTION
We're still not fully reliable in CI, in particular the "cmd_" tests. This change adds completion request retrying if we get back empty results to work around a race for rls to be ready to return the completions. It also adds a pattern of waiting on response-id rather than expectation, which should reduce the chances of timeout in favour of fast-failing.

### Ci failure
```
---rls-stdout---
failures:
---- cmd_test_complete_self_crate_name stdout ----
thread 'cmd_test_complete_self_crate_name' panicked at 'Timed out waiting 300s for predicate, last rls-stdout write 300.0s ago', tests\support\mod.rs:163:13
stack backtrace:
   0: std::sys::windows::backtrace::set_frames
   ...rest of stack trace...
---rls-stdout---
Content-Length: 605
{"jsonrpc":"2.0","id":0,"result":{"capabilities":{"textDocumentSync":2,"hoverProvider":true,"completionProvider":{"resolveProvider":true,"triggerCharacters":[".",":"]},"definitionProvider":true,"implementationProvider":true,"referencesProvider":true,"documentHighlightProvider":true,"documentSymbolProvider":true,"workspaceSymbolProvider":true,"codeActionProvider":true,"codeLensProvider":{"resolveProvider":false},"documentFormattingProvider":true,"documentRangeFormattingProvider":false,"renameProvider":true,"executeCommandProvider":{"commands":["rls.applySuggestion-3420","rls.deglobImports-3420"]}}}}Content-Length: 92
{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_1","title":"Building"}}Content-Length: 122
{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_1","message":"library cfg(test)","title":"Building"}}Content-Length: 112
{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_1","message":"library","title":"Building"}}Content-Length: 119
{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_1","message":"test cfg(test)","title":"Building"}}Content-Length: 104
{"jsonrpc":"2.0","method":"window/progress","params":{"done":true,"id":"progress_1","title":"Building"}}Content-Length: 92
{"jsonrpc":"2.0","method":"window/progress","params":{"id":"progress_0","title":"Indexing"}}Content-Length: 364
{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"diagnostics":[{"code":"","message":"expected identifier, found `~`\n\nexpected identifier","range":{"end":{"character":33,"line":2},"start":{"character":32,"line":2}},"severity":1,"source":"rustc"}],"uri":"file:///C:/projects/rls-x6grn/target/rlsit/t5/ws_with_test_dir/library/tests/test.rs"}}Content-Length: 104
{"jsonrpc":"2.0","method":"window/progress","params":{"done":true,"id":"progress_0","title":"Indexing"}}Content-Length: 36
{"jsonrpc":"2.0","id":0,"result":[]}
---------------
```
From the std out we can see **`{"jsonrpc":"2.0","id":0,"result":[]}`** at the end which is not what the test expects. As this happens only sometimes in CI, we can assume there is a race condition & rls is not always ready to respond to a completion request immediately after sending _indexing-done_.

This change assumes rls would eventually return the correct completion on retry so:
* Resends completion requests up to 2 times
* No longer times out on expected result, instead on response id meaning even repeated response failure of this kind will fail fast.