### PR TITLE
Use rustfmt-like sort in deglob

### DIFF
--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -527,7 +527,7 @@ fn create_tooltip(
         tooltip.push(MarkedString::from_markdown(doc_url));
     }
     if let Some(context) = context {
-        tooltip.push(MarkedString::from_language_code(rust.clone(), context));
+        tooltip.push(MarkedString::from_language_code(rust, context));
     }
     if let Some(docs) = docs {
         tooltip.push(MarkedString::from_markdown(docs));

--- a/src/actions/progress.rs
+++ b/src/actions/progress.rs
@@ -131,7 +131,7 @@ impl<O: Output> DiagnosticsNotifier for BuildDiagnosticsNotifier<O> {
         self.out
             .notify(Notification::<ShowMessage>::new(ShowMessageParams {
                 typ: MessageType::Error,
-                message: message.to_owned(),
+                message,
             }));
     }
     fn notify_end_diagnostics(&self) {

--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -359,7 +359,7 @@ pub(super) fn current_sysroot() -> Option<String> {
         Some(format!("{}/toolchains/{}", home, toolchain))
     } else {
         let rustc_exe = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_owned());
-        env::var("SYSROOT").map(|s| s.to_owned()).ok().or_else(|| {
+        env::var("SYSROOT").ok().or_else(|| {
             Command::new(rustc_exe)
                 .arg("--print")
                 .arg("sysroot")

--- a/src/config.rs
+++ b/src/config.rs
@@ -250,7 +250,7 @@ impl Config {
         let shell = Shell::from_write(Box::new(sink()));
         let cwd = env::current_dir().expect("failed to get cwd");
 
-        let config = CargoConfig::new(shell, cwd.to_path_buf(), homedir(project_dir).unwrap());
+        let config = CargoConfig::new(shell, cwd, homedir(project_dir).unwrap());
 
         let ws = Workspace::new(&manifest_path, &config)?;
 
@@ -265,7 +265,7 @@ impl Config {
             _ => {}
         }
         if self.target_dir.as_ref().is_none() {
-            let target_dir = ws.target_dir().clone().into_path_unlocked();
+            let target_dir = ws.target_dir().into_path_unlocked();
             let target_dir = target_dir.join("rls");
             self.target_dir.infer(Some(target_dir));
             trace!(


### PR DESCRIPTION
It is annoying that RLS deglobs imports in different order from rustfmt. This PR changes deglob's ordering to rustfmt-like one.